### PR TITLE
Integrate CPack and Linux Desktop Entry (222-linux-installer)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,3 +122,15 @@ include(CTest)
 if (BUILD_TESTING)
     add_subdirectory(tests)
 endif()
+
+if(UNIX AND NOT APPLE)
+    install(TARGETS ${MAIN_TARGET_NAME} RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+
+    install(PROGRAMS gitease-launcher.sh DESTINATION ${CMAKE_INSTALL_BINDIR})
+
+    install(FILES gitease.desktop DESTINATION share/applications)
+
+    install(FILES Res/Images/Logo.png DESTINATION share/icons/hicolor/256x256/apps RENAME gitease.png)
+endif()
+
+include(packaging.cmake)

--- a/gitease-launcher.sh
+++ b/gitease-launcher.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+QT_PATH=$(find /opt/Qt -name "lib" -type d | grep "gcc_64" | sort -V | tail -n 1)
+# or QT_PATH="/opt/Qt/6.10.1/gcc_64/lib" or QT_PATH="~/Qt/6.10.0/gcc_64/lib" or ...
+export LD_LIBRARY_PATH="$QT_PATH:$LD_LIBRARY_PATH"
+exec GitEase "$@"
+
+# At the end shoud execute this command: chmod +x gitease-launcher.sh

--- a/gitease.desktop
+++ b/gitease.desktop
@@ -1,0 +1,8 @@
+[Desktop Entry]
+Type=Application
+Name=GitEase
+Comment=A powerful Git GUI client
+Exec=gitease-launcher.sh
+Icon=gitease
+Terminal=false
+Categories=Development;RevisionControl;

--- a/packaging.cmake
+++ b/packaging.cmake
@@ -1,0 +1,21 @@
+set(CPACK_PACKAGE_NAME "GitEase")
+set(CPACK_PACKAGE_VENDOR "GitEase Team")
+set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "A powerful Git GUI client")
+set(CPACK_PACKAGE_VERSION ${PROJECT_VERSION_SHORT})
+set(CPACK_PACKAGE_CONTACT "yasinfaraji100@gmail.com")
+
+if(UNIX AND NOT APPLE)
+    set(CPACK_GENERATOR "DEB;RPM;TGZ")
+
+    set(CPACK_DEBIAN_PACKAGE_MAINTAINER "GitEase Maintainer")
+    set(CPACK_DEBIAN_PACKAGE_SECTION "devel")
+    set(CPACK_DEBIAN_PACKAGE_PRIORITY "optional")
+    set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS ON) 
+
+    set(CPACK_RPM_PACKAGE_LICENSE "MIT") 
+    set(CPACK_RPM_PACKAGE_GROUP "Development/Tools")
+endif()
+
+include(CPack)
+
+# After (make) project, then should run (cpack) to generate .deb and .rpm and .tar.gz


### PR DESCRIPTION
**Overview**
This PR integrates CPack into the CMake build system to automate the generation of Linux installers (.deb, .rpm, .tar.gz). It also addresses the dependency issues with local Qt 6 installations by introducing a launcher script and a proper Desktop Entry for seamless Linux integration.

**How to Test**

1. Run `cmake ..` and `make` in the build directory.
2. Execute `cpack` to generate the installers.
3. Install the generated .deb package:
`sudo apt install ./GitEase-0.0.1-Linux.deb`
or
`sudo dpkg -i ./GitEase-0.0.1-Linux.deb`
4. Launch GitEase from the system applications menu
5. Verify the app opens correctly with the icon and correct Qt environment.

<img width="341" height="192" alt="1_files" src="https://github.com/user-attachments/assets/a0d1c132-8e60-4b67-8f3c-c4ae818eb3f1" />
<img width="396" height="246" alt="2_icons" src="https://github.com/user-attachments/assets/10736aed-5d63-47cc-b92e-7395d8fbb19d" />
