### PR TITLE
Add support for displaying uncommitted changes in commit graph (215-show-working-tree-on-graph-view)

### DIFF
--- a/Qml/Pages/GraphViewPage.qml
+++ b/Qml/Pages/GraphViewPage.qml
@@ -27,6 +27,7 @@ Item {
     property StashController        stashController: null
     property string                 selectedCommit: ""
     property string                 selectedFilePath: ""
+    property string                 headHash: ""
     property ConflictController conflictController: null
     property MergeController mergeController: null
     property RebaseController rebaseController: null
@@ -488,7 +489,11 @@ Item {
                            reloadButton.hovered ? Style.colors.cardBackground : Style.colors.secondaryBackground
                 }
 
-                onClicked: commitGraph.reloadAll()
+                onClicked: {
+                    commitGraph.reloadAll()
+                    root.headHash = commitController.getHeadHash()
+                }
+
             }
         }
     }
@@ -522,7 +527,46 @@ Item {
                 conflictController: root.conflictController
 
                 onCommitClicked: function(commitId) {
-                    root.selectedCommit = commitId
+                    let node = commitGraph.commits.find(c => c.hash === commitId);
+
+                    root.selectedCommit = commitId;
+
+                    if (node && node.isUncommitted) {
+                        let res = statusController.status()
+
+                        if (!res.success || !res.data) {
+                            console.log("status failed:", res);
+                            fileChangesDock.files = [];
+                            return;
+                        }
+
+                        fileChangesDock.files = res.data;
+
+                        return;
+                    }
+
+                    let res = commitController.getCommitFileChanges(commitId);
+
+                    if (!res.success) {
+                        console.log("commit diff failed:", res);
+                        fileChangesDock.files = [];
+                        return;
+                    }
+
+                    let files = [];
+
+                    if (res.data) {
+                        if (res.data.staged)
+                            files = files.concat(res.data.staged);
+
+                        if (res.data.unstaged)
+                            files = files.concat(res.data.unstaged);
+
+                        if (Array.isArray(res.data))
+                            files = res.data;
+                    }
+
+                    fileChangesDock.files = files;
                 }
             }
         }
@@ -551,20 +595,42 @@ Item {
                         repositoryController : root.repositoryController
                         statusController: root.statusController
 
-                        onFileSelected: function(filePath){
+                        onFileSelected: function(filePath) {
                             root.selectedFilePath = filePath
 
-                            let selectedCommitObj = commitGraph.selectedCommit
-                            let parentHash = ""
-                            if (selectedCommitObj && selectedCommitObj.isStash && selectedCommitObj.stashParentId) {
-                                parentHash = selectedCommitObj.stashParentId
-                            } else {
-                                parentHash = root.commitController.getParentHash(root.selectedCommit)
+                            let commitId = root.selectedCommit
+                            let node = commitGraph.commits.find(c => c.hash === commitId)
+
+                            let res = null
+
+                            if (commitId === "__uncommitted__" || (node && node.isUncommitted)) { // UNCOMMITTED COMMITS
+                                let headHash = statusController.getHeadHash()
+
+                                if (!headHash) {
+                                    console.log("HEAD is null -> cannot diff uncommitted")
+                                    return
+                                }
+
+                                res = statusController.getWorkingDirectoryDiff(headHash, filePath)
+                            }
+                            else { // NORMAL COMMITS
+                                let parentHash = ""
+
+                                if (node && node.isStash && node.stashParentId) {
+                                    parentHash = node.stashParentId
+                                } else {
+                                    parentHash = commitController.getParentHash(commitId)
+                                }
+
+                                if (!parentHash || !commitId) {
+                                    console.log("Invalid diff inputs:", parentHash, commitId)
+                                    return
+                                }
+
+                                res = statusController.getDiff(parentHash, commitId, filePath)
                             }
 
-                            let res = root.statusController.getDiff(parentHash, root.selectedCommit, root.selectedFilePath)
-
-                            if (res.success) {
+                            if (res && res.success) {
                                 diffView.diffData = res.data
                             }
                         }

--- a/Qml/View/Components/Docks/CommitGraphDock.qml
+++ b/Qml/View/Components/Docks/CommitGraphDock.qml
@@ -1584,22 +1584,23 @@ Item {
                         property bool isStash: modelData.isStash === true
 
                         color: {
-                            if (commitData.isUncommitted) {
-                                if (isSelected) {
-                                    return "#6088B2DF";
-                                } else {
-                                    return "#2f2f2f";
-                                }
-                            }
                             if (isSelected) {
                                 return "#6088B2DF";
-                            } else if (isHovered) {
-                                return Style.colors.hoverTitle;
-                            } else if (isHead) {
-                                return "#40FFA500";
-                            } else {
-                                return Style.colors.primaryBackground;
                             }
+                            if (commitData.isUncommitted) {
+                                if (isHovered) {
+                                    return Qt.darker(Style.colors.hoverTitle, 1.03);
+                                }
+                                return Style.colors.secondaryBackground || Style.colors.primaryBackground;
+                            }
+                            if (isHovered) {
+                                return Style.colors.hoverTitle;
+                            }
+                            if (isHead) {
+                                return "#40FFA500";
+                            }
+
+                            return Style.colors.primaryBackground;
                         }
 
                         radius: (isSelected || isHovered) ? 4 : 0

--- a/Qml/View/Components/Docks/CommitGraphDock.qml
+++ b/Qml/View/Components/Docks/CommitGraphDock.qml
@@ -1786,6 +1786,9 @@ Item {
                                 if (mouse.button !== Qt.LeftButton)
                                     return;
 
+                                if (commitData.isUncommitted)
+                                    return;
+
                                 if (commitData.isStash)
                                     return;
 

--- a/Qml/View/Components/Docks/CommitGraphDock.qml
+++ b/Qml/View/Components/Docks/CommitGraphDock.qml
@@ -1585,7 +1585,11 @@ Item {
 
                         color: {
                             if (commitData.isUncommitted) {
-                                return "#2f2f2f";
+                                if (isSelected) {
+                                    return "#6088B2DF";
+                                } else {
+                                    return "#2f2f2f";
+                                }
                             }
                             if (isSelected) {
                                 return "#6088B2DF";

--- a/Qml/View/Components/Docks/CommitGraphDock.qml
+++ b/Qml/View/Components/Docks/CommitGraphDock.qml
@@ -1765,6 +1765,9 @@ Item {
                                root.commitClicked(commitData.hash);
 
                                 if (mouse.button === Qt.RightButton) {
+                                    if (commitData.isUncommitted)
+                                        return;
+
                                     if(!root.isCommitSelected(commitData.hash))
                                         root.setSingleSelection(commitData, index)
 

--- a/Qml/View/Components/Docks/CommitGraphDock.qml
+++ b/Qml/View/Components/Docks/CommitGraphDock.qml
@@ -2166,7 +2166,7 @@ Item {
 
             author: "",
             authorEmail: "",
-            authorDate: new Date(),
+            authorDate: "",
 
             parentHashes: root.headHash ? [root.headHash] : [],
             commitType: "uncommitted",

--- a/Qml/View/Components/Docks/CommitGraphDock.qml
+++ b/Qml/View/Components/Docks/CommitGraphDock.qml
@@ -165,6 +165,8 @@ Item {
     }
 
     function commitColor(commitObj) {
+        if (commitObj && commitObj.isUncommitted)
+            return "#888888";
         if (!commitObj || !commitObj.colorKey)
             return GraphUtils.getCategoryColor("default")
         return GraphUtils.getCategoryColor(commitObj.colorKey)
@@ -1191,10 +1193,17 @@ Item {
                                             ctx.globalAlpha = 0.9;
                                             ctx.lineWidth = 2.5;
 
+                                            if (commit2.isUncommitted) {
+                                                ctx.setLineDash([4, 4]);
+                                            } else {
+                                                ctx.setLineDash([]);
+                                            }
+
                                             ctx.beginPath();
                                             ctx.moveTo(centerX, centerY);
                                             ctx.lineTo(parentX, parentY);
                                             ctx.stroke();
+                                            ctx.setLineDash([]);
                                             ctx.restore();
                                         }
                                     } else {
@@ -1575,6 +1584,9 @@ Item {
                         property bool isStash: modelData.isStash === true
 
                         color: {
+                            if (commitData.isUncommitted) {
+                                return "#2f2f2f";
+                            }
                             if (isSelected) {
                                 return "#6088B2DF";
                             } else if (isHovered) {
@@ -1670,7 +1682,7 @@ Item {
                                         verticalAlignment: Text.AlignVCenter
                                         font.pixelSize: 10
                                         font.family: Style.fontTypes.roboto
-                                        font.weight: commitItem.isHead ? 900 : 400
+                                        font.weight: commitData.isUncommitted ? 700 : (commitItem.isHead ? 900 : 400)
                                         font.letterSpacing: 0.2
                                         Layout.fillWidth: true
                                         Layout.leftMargin: 6
@@ -1756,6 +1768,11 @@ Item {
                                     contextMenu.open();
 
                                 } else {
+                                    if (commitData.isUncommitted) {
+                                        root.selectedCommit = commitData;
+                                        root.commitClicked("__uncommitted__");
+                                        return;
+                                    }
                                     root.applySelection(commitData, index, mouse.modifiers)
                                 }
                             }
@@ -2044,7 +2061,10 @@ Item {
                     isStash: true,
                     stashIndex: stash.index,
                     stashLabel: stashLabel,
-                    stashParentId: stash.parentId || ""
+                    stashParentId: stash.parentId || "",
+
+                    files: commit.files ?? null,
+                    isUncommitted: commit.isUncommitted ?? false
                 }
                 stashNodeList.push(stashObj)
             }
@@ -2094,7 +2114,10 @@ Item {
                 isStash: false,
                 stashIndex: -1,
                 stashLabel: "",
-                stashParentId: ""
+                stashParentId: "",
+
+                files: commit.files ?? null,
+                isUncommitted: commit.isUncommitted ?? false
             }
 
             compiled.push(obj)
@@ -2107,6 +2130,59 @@ Item {
         }
 
         return compiled
+    }
+
+    function createUncommittedNode() {
+        if (!statusController)
+            return null;
+
+        let res = statusController.status();
+        if (!res.success || !res.data)
+            return null;
+
+        let staged = [];
+        let unstaged = [];
+
+        res.data.forEach((file) => {
+            if (file.isStaged)
+            {
+                staged.push(file);
+            }
+            else if (file.isUnstaged || file.isUntracked)
+            {
+                unstaged.push(file);
+            }
+        });
+
+        let total = staged.length + unstaged.length;
+        if (total === 0)
+            return null;
+
+        return {
+            hash: "__uncommitted__",
+            shortHash: "",
+            message: "Uncommitted Changes",
+            summary: "Uncommitted Changes (" + total + " files)",
+
+            author: "",
+            authorEmail: "",
+            authorDate: new Date(),
+
+            parentHashes: root.headHash ? [root.headHash] : [],
+            commitType: "uncommitted",
+
+            branchNames: [],
+            tagNames: [],
+            colorKey: "uncommitted",
+
+            isUncommitted: true,
+            isStash: false,
+
+            files: {
+                staged: staged,
+                unstaged: unstaged
+            }
+        };
     }
 
     function selectedIndex() {
@@ -2305,6 +2381,9 @@ Item {
         }
 
         var commits = compileGraphCommits(page, allBranches, stashes);
+        var uncommitted = createUncommittedNode();
+        if (uncommitted)
+            commits.unshift(uncommitted);
         commitsOffset = page ? page.length : 0
         hasMoreCommits = (page && page.length === pageSize)
 

--- a/Qml/View/Components/Docks/CommitGraphDock.qml
+++ b/Qml/View/Components/Docks/CommitGraphDock.qml
@@ -2161,8 +2161,8 @@ Item {
         return {
             hash: "__uncommitted__",
             shortHash: "",
-            message: "Uncommitted Changes",
-            summary: "Uncommitted Changes (" + total + " files)",
+            message: "Working tree Changes",
+            summary: "Working tree Changes (" + total + " files)",
 
             author: "",
             authorEmail: "",

--- a/Src/Git/GitStatus.cpp
+++ b/Src/Git/GitStatus.cpp
@@ -108,37 +108,78 @@ GitResult GitStatus::stageAll(bool includeUntrackedFiles)
 
 GitResult GitStatus::status()
 {
-    // Get repository handle - SIMPLIFIED
     if (!m_currentRepo || !m_currentRepo->repo)
         return GitResult(false, QVariant(), "No repository available. Please open a repository first.");
 
-
-    QVariantMap statusData;
     QList<GitFileStatus> fileInfos;
 
-    // Configure status options
     git_status_options opts = GIT_STATUS_OPTIONS_INIT;
-    opts.show = GIT_STATUS_SHOW_INDEX_AND_WORKDIR;      //Index vs HEAD
+    opts.show = GIT_STATUS_SHOW_INDEX_AND_WORKDIR;
     opts.flags = GIT_STATUS_OPT_INCLUDE_UNTRACKED;
 
     git_status_list *status_list = nullptr;
-    int gitResult = git_status_list_new(&status_list,  m_currentRepo->repo, &opts);
+    git_diff *diff = nullptr;
 
-    if (gitResult == 0) {
-        size_t count = git_status_list_entrycount(status_list);
+    if (git_status_list_new(&status_list, m_currentRepo->repo, &opts) != 0 || !status_list)
+        return GitResult(true, QVariant::fromValue(fileInfos));
 
-        // Process each status entry
-        for (size_t i = 0; i < count; i++) {
-            const git_status_entry *entry = git_status_byindex(status_list, i);
-            if (!entry) continue;
+    git_diff_options diffOpts = GIT_DIFF_OPTIONS_INIT;
+    diffOpts.flags |= GIT_DIFF_INCLUDE_UNTRACKED;
 
-            GitFileStatus fileInfo = GitFileStatus(entry);
-            fileInfos.append(fileInfo);
+    git_diff_index_to_workdir(&diff, m_currentRepo->repo, nullptr, &diffOpts);
+
+    size_t numDeltas = diff ? git_diff_num_deltas(diff) : 0;
+
+    for (size_t i = 0; i < git_status_list_entrycount(status_list); i++) {
+
+        const git_status_entry *entry = git_status_byindex(status_list, i);
+        if (!entry) continue;
+
+        int add = 0, del = 0;
+        const git_diff_delta *matched = nullptr;
+
+        if (diff) {
+            for (size_t j = 0; j < numDeltas; j++) {
+
+                const git_diff_delta *delta = git_diff_get_delta(diff, j);
+                if (!delta) continue;
+
+                QString dPath = QString::fromUtf8(delta->new_file.path);
+
+                QString ePath;
+                if (entry->head_to_index && entry->head_to_index->new_file.path)
+                    ePath = QString::fromUtf8(entry->head_to_index->new_file.path);
+                else if (entry->index_to_workdir && entry->index_to_workdir->new_file.path)
+                    ePath = QString::fromUtf8(entry->index_to_workdir->new_file.path);
+
+                if (dPath != ePath)
+                    continue;
+
+                matched = delta;
+
+                git_patch *patch = nullptr;
+                size_t a = 0, d = 0;
+
+                if (git_patch_from_diff(&patch, diff, j) == GIT_OK && patch) {
+                    git_patch_line_stats(nullptr, &a, &d, patch);
+                    git_patch_free(patch);
+                }
+
+                add = static_cast<int>(a);
+                del = static_cast<int>(d);
+                break;
+            }
         }
 
-        // Clean up status list
-        git_status_list_free(status_list);
+        fileInfos.append(
+            matched
+                ? GitFileStatus(matched, add, del)
+                : GitFileStatus(entry)
+            );
     }
+
+    git_status_list_free(status_list);
+    if (diff) git_diff_free(diff);
 
     emitGitCommand("git status --short");
 
@@ -410,6 +451,96 @@ GitResult GitStatus::getDiff(const QString &oldCommitHash, const QString &newCom
 
     // Return the result with the diff lines
     return GitResult(true, QVariant::fromValue(result), "Commit diff retrieved successfully.");
+}
+
+GitResult GitStatus::getWorkingDirectoryDiff(const QString &headCommitHash, const QString &filePath)
+{
+    QList<GitDiff> result;
+
+    if (!m_currentRepo || !m_currentRepo->repo)
+        return GitResult(false, QVariant(), "No repository available. Please open a repository first.");
+
+    git_object *headObj = nullptr;
+    git_tree *headTree = nullptr;
+    git_diff *diff = nullptr;
+
+    int rc = git_revparse_single(&headObj, m_currentRepo->repo, headCommitHash.toUtf8().constData());
+    if (rc != GIT_OK)
+        return GitResult(false, QVariant(), "Failed to retrieve HEAD commit.");
+
+    rc = git_commit_tree(&headTree, reinterpret_cast<git_commit*>(headObj));
+    if (rc != GIT_OK) {
+        git_object_free(headObj);
+        return GitResult(false, QVariant(), "Failed to retrieve HEAD tree.");
+    }
+
+    git_diff_options opts = GIT_DIFF_OPTIONS_INIT;
+    opts.flags |= GIT_DIFF_INCLUDE_UNTRACKED |
+                  GIT_DIFF_RECURSE_UNTRACKED_DIRS |
+                  GIT_DIFF_PATIENCE |
+                  GIT_DIFF_INDENT_HEURISTIC;
+
+    QByteArray pathBytes = filePath.toUtf8();
+    char* path = const_cast<char*>(pathBytes.constData());
+    opts.pathspec.strings = &path;
+    opts.pathspec.count = 1;
+
+    rc = git_diff_tree_to_workdir_with_index(
+        &diff,
+        m_currentRepo->repo,
+        headTree,
+        &opts
+        );
+
+    if (rc != GIT_OK) {
+        git_tree_free(headTree);
+        git_object_free(headObj);
+        return GitResult(false, QVariant(), "Failed to create working directory diff.");
+    }
+
+    std::vector<GitDiff> rawLines;
+
+    git_diff_print(diff, GIT_DIFF_FORMAT_PATCH,
+                   [](const git_diff_delta*, const git_diff_hunk*, const git_diff_line *line, void *payload) -> int {
+
+                       auto *vec = static_cast<std::vector<GitDiff>*>(payload);
+
+                       if (line->origin == GIT_DIFF_LINE_CONTEXT ||
+                           line->origin == GIT_DIFF_LINE_ADDITION ||
+                           line->origin == GIT_DIFF_LINE_DELETION) {
+
+                           QString content = QString::fromUtf8(line->content, line->content_len);
+                           content.remove('\n').remove('\r');
+
+                           GitDiff::DiffType type;
+
+                           if (line->origin == GIT_DIFF_LINE_ADDITION)
+                               type = GitDiff::Added;
+                           else if (line->origin == GIT_DIFF_LINE_DELETION)
+                               type = GitDiff::Deleted;
+                           else
+                               type = GitDiff::Context;
+
+                           vec->push_back(GitDiff(type, line->old_lineno, line->new_lineno, content));
+                       }
+
+                       return 0;
+                   },
+                   &rawLines
+                   );
+
+    for (const auto &line : rawLines)
+        result.append(line);
+
+    git_diff_free(diff);
+    git_tree_free(headTree);
+    git_object_free(headObj);
+
+    emitGitCommand(QString("git diff %1 -- %2")
+                       .arg(quoteCommandArg(headCommitHash),
+                            quoteCommandArg(filePath)));
+
+    return GitResult(true, QVariant::fromValue(result), "Working directory diff retrieved successfully.");
 }
 
 GitResult GitStatus::getCommitFileChanges(const QString &commitHash)

--- a/Src/Git/GitStatus.cpp
+++ b/Src/Git/GitStatus.cpp
@@ -173,7 +173,7 @@ GitResult GitStatus::status()
 
         fileInfos.append(
             matched
-                ? GitFileStatus(matched, add, del)
+                ? GitFileStatus(entry, add, del, static_cast<GitFileStatus::DeltaStatus>(matched->status))
                 : GitFileStatus(entry)
             );
     }

--- a/Src/Git/GitStatus.h
+++ b/Src/Git/GitStatus.h
@@ -100,6 +100,14 @@ public:
                       const QString &filePath);
 
     /**
+    * @brief Retrieves a side-by-side diff between HEAD and working directory for a file.
+    * @param headCommitHash The hash of the HEAD commit.
+    * @param filePath The relative path of the file.
+    */
+    Q_INVOKABLE GitResult getWorkingDirectoryDiff(const QString &headCommitHash,
+                                                  const QString &filePath);
+
+    /**
     * @brief Retrieves the list of files changed in a specific commit with their stats.
     *
     * This function compares the given commit with its parent (if any) and extracts

--- a/Src/Git/Models/GitFileStatus.cpp
+++ b/Src/Git/Models/GitFileStatus.cpp
@@ -54,6 +54,34 @@ GitFileStatus::GitFileStatus(const git_diff_delta *delta, int additions, int del
     m_deltaStatus = static_cast<DeltaStatus>(delta->status);
 }
 
+GitFileStatus::GitFileStatus(const git_status_entry *entry,
+                             int additions,
+                             int deletions,
+                             DeltaStatus deltaStatus)
+{
+    if (!entry) return;
+
+    if (entry->head_to_index && entry->head_to_index->new_file.path)
+        m_path = QString::fromUtf8(entry->head_to_index->new_file.path);
+    else if (entry->index_to_workdir && entry->index_to_workdir->new_file.path)
+        m_path = QString::fromUtf8(entry->index_to_workdir->new_file.path);
+
+    m_status = static_cast<Status>(entry->status);
+
+    m_isStaged = entry->status & GIT_STATUS_INDEX_NEW ||
+                 entry->status & GIT_STATUS_INDEX_MODIFIED ||
+                 entry->status & GIT_STATUS_INDEX_DELETED;
+
+    m_isUnstaged = entry->status & GIT_STATUS_WT_MODIFIED ||
+                   entry->status & GIT_STATUS_WT_DELETED;
+
+    m_isUntracked = entry->status & GIT_STATUS_WT_NEW;
+
+    m_additionsCount = additions;
+    m_deletionsCount = deletions;
+    m_deltaStatus = deltaStatus;
+}
+
 QString GitFileStatus::path() const
 {
     return m_path;

--- a/Src/Git/Models/GitFileStatus.h
+++ b/Src/Git/Models/GitFileStatus.h
@@ -55,6 +55,9 @@ public:
 
     GitFileStatus(const git_diff_delta *delta, int additions, int deletions);
 
+    GitFileStatus(const git_status_entry *entry, int additions, int deletions,
+                  DeltaStatus deltaStatus);
+
 
     QString path() const;
 


### PR DESCRIPTION
This PR adds support for visualizing uncommitted changes within the commit graph.

- Introduces a virtual "Uncommitted Changes" node
- Enables diff view for working directory changes
- Separates commit-based diff from working directory diff logic

This improves visibility of current workspace changes directly in the graph view.