### PR TITLE
228 displaying diffview as chunks

### DIFF
--- a/Qml/Pages/CommittingPage.qml
+++ b/Qml/Pages/CommittingPage.qml
@@ -1228,6 +1228,9 @@ Item {
             DiffView {
                 id: diffView
                 anchors.fill: parent
+                chunkMode: true
+                contextLines: 0
+                expandLines: 10
                 onRequestStage: function (start, end, type) {
                     let res = root.statusController.stageSelectedLines(root.selectedFilePath, start, end, type)
                     if (res.success) {
@@ -1254,9 +1257,16 @@ Item {
     function updateDiff(isStaged) {
         let oldY = diffView.scrollPosition;
 
-        let res = root.statusController.getDiffView(root.selectedFilePath, isStaged)
-        if (res.success) {
-            diffView.diffData = res.data.lines
+        if(diffView.chunkMode){
+            let res = root.statusController.getChunkedDiffView(root.selectedFilePath, isStaged)
+            if (res.success) {
+                diffView.chunkData = res.data.chunks
+            }
+        }else{
+            let res = root.statusController.getDiffView(root.selectedFilePath, isStaged)
+            if (res.success) {
+                diffView.diffData = res.data.lines
+            }
         }
 
         diffView.readOnly = isStaged

--- a/Qml/Style/Icons.qml
+++ b/Qml/Style/Icons.qml
@@ -65,4 +65,7 @@ QtObject{
     property string calendarCheck:     "\uf274" // calendar-check
     property string clockRotateLeft:   "\uf1da" // clock-rotate-left (history)
     property string list:              "\uf03a" // list
+
+    property string arrowUpToLine:     "\uf341"
+    property string arrowDownToLine:   "\uf33d"
 }

--- a/Qml/View/Components/Diff/DiffView.qml
+++ b/Qml/View/Components/Diff/DiffView.qml
@@ -127,16 +127,31 @@ DetachablePanel {
                     Row {
                         anchors.centerIn: parent
                         spacing: 4
-                        Text {
+                        Label {
                             text: model.direction === "up" ? Style.icons.caretUp : Style.icons.caretDown
                             font.family: Style.fontTypes.font6Pro
-                            font.pixelSize: 13
-                            color: hiddenMarker.containsMouse ? Style.colors.accent : Style.colors.secondaryText
+                            font.pixelSize: 12
+                            color: hiddenMarker.containsMouse ? Style.colors.secondaryForeground
+                                                              : Qt.darker(Style.colors.secondaryForeground, 1.4)
+                            padding: 4
+                            background: Rectangle {
+                                color: hiddenMarker.containsMouse ? Style.colors.accent
+                                                                 : Qt.darker(Style.colors.linePanelBackgroound, 1.05)
+                                radius: 4
+                            }
                         }
-                        Text {
+                        Label {
                             text: model.hiddenCount - model.visibleCount
-                            font.pixelSize: 10
-                            color: hiddenMarker.containsMouse ? Style.colors.accent : Style.colors.secondaryText
+                            font.family: Style.fontTypes.roboto
+                            font.pixelSize: 9
+                            color: hiddenMarker.containsMouse ? Style.colors.secondaryForeground
+                                                              : Qt.darker(Style.colors.secondaryForeground, 1.4)
+                            padding: 3
+                            background: Rectangle {
+                                color: hiddenMarker.containsMouse ? Style.colors.accent
+                                                                 : Qt.darker(Style.colors.linePanelBackgroound, 1.05)
+                                radius: 3
+                            }
                         }
                     }
                 }

--- a/Qml/View/Components/Diff/DiffView.qml
+++ b/Qml/View/Components/Diff/DiffView.qml
@@ -259,6 +259,9 @@ DetachablePanel {
 
     // Called by Delegate when user presses Backspace at start
     function mergeLineUp(index) {
+        if (chunkMode)
+            return
+
         if (index === 0) return;
 
         var currentRow = fileModel.get(index)

--- a/Qml/View/Components/Diff/DiffView.qml
+++ b/Qml/View/Components/Diff/DiffView.qml
@@ -141,7 +141,7 @@ DetachablePanel {
                             }
                         }
                         Label {
-                            text: model.hiddenCount - model.visibleCount
+                            text: model.remaining
                             font.family: Style.fontTypes.roboto
                             font.pixelSize: 9
                             color: hiddenMarker.containsMouse ? Style.colors.secondaryForeground
@@ -316,6 +316,9 @@ DetachablePanel {
                     updateMaxContentWidth(right)
                 }
             } else if (chunk.chunkType === "hidden") {
+                chunk.visibleTop = 0
+                chunk.visibleBottom = 0
+
                 let prevChunk = (c > 0) ? chunkData[c-1] : null
                 let nextChunk = (c < chunkData.length-1) ? chunkData[c+1] : null
 
@@ -324,7 +327,7 @@ DetachablePanel {
                         rowType: "hidden",
                         direction: "down",
                         hiddenCount: chunk.hiddenCount,
-                        visibleCount: 0,
+                        remaining: chunk.hiddenCount,
                         chunkIndex: c
                     })
                 }
@@ -334,138 +337,145 @@ DetachablePanel {
                         rowType: "hidden",
                         direction: "up",
                         hiddenCount: chunk.hiddenCount,
-                        visibleCount: 0,
+                        remaining: chunk.hiddenCount,
                         chunkIndex: c
                     })
                 }
             }
         }
-    }
+        if (root.contextLines > 0) {
+            let processedChunks = []
+            for (let c = 0; c < chunkData.length; c++) {
+                let chunk = chunkData[c]
+                if (chunk.chunkType !== "hidden")
+                    continue
 
-    function expandHiddenBlock(modelIndex, direction) {
-        let row = chunkModel.get(modelIndex)
-        if (!row || row.rowType !== "hidden") 
-            return
-
-        let chunk = chunkData[row.chunkIndex]
-        if (!chunk || chunk.chunkType !== "hidden" || !chunk.hiddenLines) 
-            return
-
-        let remaining = row.hiddenCount - row.visibleCount
-        let toShow = Math.min(expandLines, remaining)
-        if (toShow <= 0) return
-
-        let hiddenLines = chunk.hiddenLines
-        let newLines = []
-        let oldVisible = row.visibleCount
-        let oldBarIndex = modelIndex
-        let chunkIdx = row.chunkIndex
-        let totalHidden = row.hiddenCount
-
-        // 1. Prepare the new context lines
-        if (direction === "down") {
-            for (let i = 0; i < toShow; i++) {
-                let lineObj = hiddenLines[oldVisible + i]
-                if (!lineObj) break
-                newLines.push({
-                    rowType: "context",
-                    diffType: GitDiff.Context,
-                    leftText: lineObj.content,
-                    rightText: lineObj.content,
-                    oldLineNum: lineObj.oldLine,
-                    newLineNum: lineObj.newLine
-                })
-            }
-        } else {  // "up"
-            let endIdx = hiddenLines.length - 1 - oldVisible
-            for (let i = 0; i < toShow; i++) {
-                let idx = endIdx - i
-                if (idx < 0) break
-                let lineObj = hiddenLines[idx]
-                newLines.push({
-                    rowType: "context",
-                    diffType: GitDiff.Context,
-                    leftText: lineObj.content,
-                    rightText: lineObj.content,
-                    oldLineNum: lineObj.oldLine,
-                    newLineNum: lineObj.newLine
-                })
-            }
-            newLines.sort((a, b) => a.oldLineNum - b.oldLineNum)
-        }
-
-        // 2. Remove the bar temporarily
-        chunkModel.remove(oldBarIndex)
-
-        // 3. Insert the new lines at the bar's old position
-        for (let i = 0; i < newLines.length; i++) {
-            chunkModel.insert(oldBarIndex + i, newLines[i])
-        }
-
-        // 4. Re-insert the bar at the correct new position
-        let newVisible = oldVisible + toShow
-        let barProperties = {
-            rowType: "hidden",
-            direction: direction,
-            hiddenCount: totalHidden,
-            visibleCount: newVisible,
-            chunkIndex: chunkIdx,
-            diffType: GitDiff.Context,
-            leftText: "", rightText: "",
-            oldLineNum: -1, newLineNum: -1
-        }
-
-        if (direction === "down") {
-            // Bar goes after the new lines
-            chunkModel.insert(oldBarIndex + toShow, barProperties)
-        } else {
-            // Bar goes before the new lines (stay at oldBarIndex)
-            chunkModel.insert(oldBarIndex, barProperties)
-        }
-
-        // 5. If fully expanded, remove this bar and its sibling
-        if (newVisible >= totalHidden) {
-            let barToRemove = direction === "down" ? oldBarIndex + toShow : oldBarIndex
-            chunkModel.remove(barToRemove)
-            for (let i = 0; i < chunkModel.count; i++) {
-                let r = chunkModel.get(i)
-                if (r.rowType === "hidden" && r.chunkIndex === chunkIdx) {
-                    chunkModel.remove(i)
-                    break
+                let downIdx = -1, upIdx = -1
+                for (let i = 0; i < chunkModel.count; i++) {
+                    let r = chunkModel.get(i)
+                    if (r.rowType === "hidden" && r.chunkIndex === c) {
+                        if (r.direction === "down") downIdx = i
+                        else if (r.direction === "up") upIdx = i
+                    }
+                }
+                if (downIdx !== -1) {
+                    root.expandHiddenBlock(downIdx, "down", root.contextLines)
+                    if (upIdx !== -1) {
+                        upIdx = -1
+                        for (let j = 0; j < chunkModel.count; j++) {
+                            let r = chunkModel.get(j)
+                            if (r.rowType === "hidden" && r.chunkIndex === c && r.direction === "up")
+                                upIdx = j
+                        }
+                    }
+                }
+                if (upIdx !== -1) {
+                    root.expandHiddenBlock(upIdx, "up", root.contextLines)
                 }
             }
         }
-
-        // 6. Update widths
-        for (let line of newLines) {
-            updateMaxContentWidth(line.leftText)
-        }
     }
 
-    function removeBarsForGap(anyBarIndex, chunkIdx) {
-        // Remove the given bar first
-        chunkModel.remove(anyBarIndex)
-        // Then remove the other bar with the same chunkIndex
+    function expandHiddenBlock(modelIndex, direction, customCount) {
+        let bar = chunkModel.get(modelIndex)
+        if (!bar || bar.rowType !== "hidden")
+            return
+
+        let chunk = chunkData[bar.chunkIndex]
+        if (!chunk || chunk.chunkType !== "hidden" || !chunk.hiddenLines)
+            return
+
+        let totalHidden = chunk.hiddenCount
+        let visibleTop = chunk.visibleTop || 0
+        let visibleBottom = chunk.visibleBottom || 0
+        let remaining = totalHidden - visibleTop - visibleBottom
+        if (remaining <= 0)
+            return
+
+        let toShow = Math.min(customCount !== undefined ? customCount : root.expandLines, remaining)
+        if (toShow <= 0)
+            return
+
+        let hiddenLines = chunk.hiddenLines
+        let newLines = []
+        let oldBarIndex = modelIndex
+        let chunkIdx = bar.chunkIndex
+
+        if (direction === "down") {
+            for (let i = 0; i < toShow; i++) {
+                let lineObj = hiddenLines[visibleTop + i]
+                if (!lineObj) break
+                newLines.push(makeContextLine(lineObj))
+            }
+
+            chunkModel.remove(oldBarIndex)
+            for (let i = 0; i < newLines.length; i++)
+                chunkModel.insert(oldBarIndex + i, newLines[i])
+
+            chunk.visibleTop = visibleTop + toShow
+
+            let newRemaining = totalHidden - chunk.visibleTop - chunk.visibleBottom
+            chunkModel.insert(oldBarIndex + toShow, {
+                rowType: "hidden",
+                direction: "down",
+                hiddenCount: totalHidden,
+                remaining: newRemaining,
+                chunkIndex: chunkIdx
+            })
+
+        } else { // "up"
+            let endIdx = hiddenLines.length - 1 - visibleBottom
+            for (let i = 0; i < toShow; i++) {
+                let idx = endIdx - i
+                if (idx < 0) break
+                newLines.push(makeContextLine(hiddenLines[idx]))
+            }
+            newLines.sort((a, b) => a.oldLineNum - b.oldLineNum)
+
+            chunkModel.remove(oldBarIndex)
+            for (let i = 0; i < newLines.length; i++)
+                chunkModel.insert(oldBarIndex + i, newLines[i])
+
+            chunk.visibleBottom = visibleBottom + toShow
+
+            let newRemaining = totalHidden - chunk.visibleTop - chunk.visibleBottom
+            chunkModel.insert(oldBarIndex, {
+                rowType: "hidden",
+                direction: "up",
+                hiddenCount: totalHidden,
+                remaining: newRemaining,
+                chunkIndex: chunkIdx
+            })
+        }
+
+        let finalRemaining = totalHidden - chunk.visibleTop - chunk.visibleBottom
         for (let i = 0; i < chunkModel.count; i++) {
             let r = chunkModel.get(i)
             if (r.rowType === "hidden" && r.chunkIndex === chunkIdx) {
-                chunkModel.remove(i)
-                break
+                chunkModel.setProperty(i, "remaining", finalRemaining)
             }
         }
+
+        if (finalRemaining <= 0) {
+            for (let i = chunkModel.count - 1; i >= 0; i--) {
+                let r = chunkModel.get(i)
+                if (r.rowType === "hidden" && r.chunkIndex === chunkIdx)
+                    chunkModel.remove(i)
+            }
+        }
+
+        for (let line of newLines)
+            updateMaxContentWidth(line.leftText)
     }
 
-    function appendHiddenBar(direction, chunk, chunkIdx) {
-        chunkModel.append({
-            rowType: "hidden",
-            direction: direction,
-            hiddenCount: chunk.hiddenCount || 0,
-            visibleCount: 0,
-            chunkIndex: chunkIdx,
-            firstVisibleIndex: direction === "up" ? -1 : 0,   // used only for up
+    function makeContextLine(lineObj) {
+        return {
+            rowType: "context",
             diffType: GitDiff.Context,
-            leftText: "", rightText: "",
-            oldLineNum: -1, newLineNum: -1
-        })
+            leftText: lineObj.content,
+            rightText: lineObj.content,
+            oldLineNum: lineObj.oldLine,
+            newLineNum: lineObj.newLine
+        }
     }
 }

--- a/Qml/View/Components/Diff/DiffView.qml
+++ b/Qml/View/Components/Diff/DiffView.qml
@@ -14,7 +14,13 @@ DetachablePanel {
 
     /* Property Declarations
      * ****************************************************************************************/
-    property var diffData: []
+    property var diffData: []   // used when chunkMode = false
+    property var chunkData: []  // used when chunkMode = true
+
+    /* Chunking configuration */
+    property bool chunkMode     : false
+    property int  contextLines  : 0         // how many unchanged lines to show around each hunk
+    property int  expandLines   : 10        // lines to reveal when expanding a hidden block
 
     property bool readOnly: false
 
@@ -36,7 +42,14 @@ DetachablePanel {
         id: fileModel
     }
 
+    ListModel {
+        id: chunkModel
+    }
+
     onDiffDataChanged: {
+        if (chunkMode)
+            return
+
         fileModel.clear()
 
         for(var i = 0; i < diffData.length; i++) {
@@ -51,13 +64,19 @@ DetachablePanel {
             if (diff.type === GitDiff.Deleted)
                 right = "";
 
-            appendRow(diff.type, left, right, diff.oldLine, diff.newLine);
+            appendRow(fileModel, diff.type, left, right, diff.oldLine, diff.newLine);
 
             updateMaxContentWidth(left);
             updateMaxContentWidth(right);
         }
     }
 
+    onChunkDataChanged: {
+        if (!chunkMode)
+            return
+
+        buildChunkModel()
+    }
 
     TextMetrics {
         id: widthCalculator
@@ -68,13 +87,15 @@ DetachablePanel {
     EmptyStateView {
         title: "No file changes to show"
         details: "Select a file to view the Diff"
-        visible: !root.diffData || root.diffData.length === 0
+        visible: chunkMode ? (!chunkData || chunkData.length === 0)
+                           : (!root.diffData || root.diffData.length === 0)
     }
 
     Rectangle {
         anchors.fill: parent
         color: Style.colors.editorBackgroound
-        visible: root.diffData && root.diffData.length > 0
+        visible: chunkMode ? (chunkData && chunkData.length > 0)
+                           : (root.diffData && root.diffData.length > 0)
 
         ListView {
             id: diffListView
@@ -83,35 +104,63 @@ DetachablePanel {
 
             anchors.fill: parent
             clip: true
-            model: fileModel
+            model: chunkMode ? chunkModel : fileModel
 
             cacheBuffer: 5000
             reuseItems: true
             anchors.bottomMargin: hScrollBar.visible ? hScrollBar.height : 0
             ScrollBar.vertical: ScrollBar { active: true }
 
-            delegate: SideBySideDiff {
+            delegate: Item{
+                id: delegateItem
                 width: diffListView.width
-                horizontalOffset: diffListView.horizontalScrollOffset
-                readOnly: root.readOnly
-                diffType: model.type
-                leftContent: model.leftText
-                rightContent: model.rightText
-                leftLineNum: model.oldLineNum
-                rightLineNum: model.newLineNum
-                fileModel: diffListView.model
-                onRequestSplit: (pos, txt) => root.splitLine(index, pos, txt)
-                onRequestMergeUp: root.mergeLineUp(index)
-                onRequestFocusNext: diffListView.currentIndex = index + 1
-                onRequestFocusPrev: diffListView.currentIndex = index - 1
+                height: model.rowType === "hidden" ? 18 : diffLineItem.height
 
-                isCurrentItem: ListView.isCurrentItem
+                MouseArea{
+                    id: hiddenMarker
+                    anchors.fill: parent
+                    visible: model.rowType === "hidden"
+                    hoverEnabled: true
+                    cursorShape: Qt.PointingHandCursor
+                    onClicked: root.expandHiddenBlock(index, model.direction)
 
-                onRequestStage: function (start, end, type) {
-                    root.requestStage(start, end, type)
+                    Row {
+                        anchors.centerIn: parent
+                        spacing: 4
+                        Text {
+                            text: model.direction === "up" ? Style.icons.caretUp : Style.icons.caretDown
+                            font.family: Style.fontTypes.font6Pro
+                            font.pixelSize: 13
+                            color: hiddenMarker.containsMouse ? Style.colors.accent : Style.colors.secondaryText
+                        }
+                        Text {
+                            text: model.hiddenCount - model.visibleCount
+                            font.pixelSize: 10
+                            color: hiddenMarker.containsMouse ? Style.colors.accent : Style.colors.secondaryText
+                        }
+                    }
                 }
-                onRequestRevert: function (start, end, type) {
-                    root.requestRevert(start, end, type)
+
+                SideBySideDiff {
+                    id: diffLineItem
+                    anchors.fill: parent
+                    visible: model.rowType !== "hidden"
+                    horizontalOffset: diffListView.horizontalScrollOffset
+                    readOnly: root.readOnly || (root.chunkMode && model.rowType === "context")
+                    diffModel: diffListView.model
+                    diffType: (model.diffType !== undefined) ? model.diffType : GitDiff.Context
+                    leftContent:  model.leftText  || ""
+                    rightContent: model.rightText || ""
+                    leftLineNum:  model.oldLineNum !== undefined ? model.oldLineNum : -1
+                    rightLineNum: model.newLineNum !== undefined ? model.newLineNum : -1
+                    isCurrentItem: ListView.isCurrentItem
+
+                    onRequestSplit:  (pos, txt) => root.splitLine(index, pos, txt)
+                    onRequestMergeUp: root.mergeLineUp(index)
+                    onRequestFocusNext: diffListView.currentIndex = index + 1
+                    onRequestFocusPrev: diffListView.currentIndex = index - 1
+                    onRequestStage: (start, end, type) => root.requestStage(start, end, type)
+                    onRequestRevert: (start, end, type) => root.requestRevert(start, end, type)
                 }
             }
         }
@@ -135,18 +184,22 @@ DetachablePanel {
 
     /* Functions
      * ****************************************************************************************/
-    function appendRow(type, lTxt, rTxt, lNum, rNum) {
-        fileModel.append({
-                             "type": type,
-                             "leftText": lTxt,
-                             "rightText": rTxt,
-                             "oldLineNum": lNum,
-                             "newLineNum": rNum
-                         })
+    function appendRow(model, type, lTxt, rTxt, lNum, rNum) {
+        model.append({
+                     "type": type,
+                     "leftText": lTxt,
+                     "rightText": rTxt,
+                     "oldLineNum": lNum,
+                     "newLineNum": rNum
+                 })
     }
 
     // Called by Delegate when user presses Enter
     function splitLine(index, cursorPosition, textAfterCursor) {
+
+        if (chunkMode)
+            return
+
         // Update the current row to contain only text BEFORE cursor
         var currentRow = fileModel.get(index)
         var originalText = currentRow.rightText
@@ -219,4 +272,185 @@ DetachablePanel {
         }
     }
 
+    function buildChunkModel() {
+        chunkModel.clear()
+
+        if (!chunkData || chunkData.length === 0)
+            return
+
+        for (let c = 0; c < chunkData.length; c++) {
+            let chunk = chunkData[c]
+
+            if (chunk.chunkType === "changed") {
+                let lines = chunk.lines
+                for (let l = 0; l < lines.length; l++) {
+                    let line    = lines[l]
+                    let left    = (line.type === GitDiff.Added)     ? "" : line.content
+                    let right   = (line.type === GitDiff.Deleted)   ? "" :
+                                  (line.type === GitDiff.Modified   ? line.newContent : line.content)
+
+                    chunkModel.append({
+                        rowType     : "diff",
+                        diffType    : line.type,
+                        leftText    : left,
+                        rightText   : right,
+                        oldLineNum  : line.oldLine !== undefined ? line.oldLine : -1,
+                        newLineNum  : line.newLine !== undefined ? line.newLine : -1
+                    })
+                    updateMaxContentWidth(left)
+                    updateMaxContentWidth(right)
+                }
+            } else if (chunk.chunkType === "hidden") {
+                let prevChunk = (c > 0) ? chunkData[c-1] : null
+                let nextChunk = (c < chunkData.length-1) ? chunkData[c+1] : null
+
+                if (prevChunk && prevChunk.chunkType === "changed") {
+                    chunkModel.append({
+                        rowType: "hidden",
+                        direction: "down",
+                        hiddenCount: chunk.hiddenCount,
+                        visibleCount: 0,
+                        chunkIndex: c
+                    })
+                }
+
+                if (nextChunk && nextChunk.chunkType === "changed") {
+                    chunkModel.append({
+                        rowType: "hidden",
+                        direction: "up",
+                        hiddenCount: chunk.hiddenCount,
+                        visibleCount: 0,
+                        chunkIndex: c
+                    })
+                }
+            }
+        }
+    }
+
+    function expandHiddenBlock(modelIndex, direction) {
+        let row = chunkModel.get(modelIndex)
+        if (!row || row.rowType !== "hidden") 
+            return
+
+        let chunk = chunkData[row.chunkIndex]
+        if (!chunk || chunk.chunkType !== "hidden" || !chunk.hiddenLines) 
+            return
+
+        let remaining = row.hiddenCount - row.visibleCount
+        let toShow = Math.min(expandLines, remaining)
+        if (toShow <= 0) return
+
+        let hiddenLines = chunk.hiddenLines
+        let newLines = []
+        let oldVisible = row.visibleCount
+        let oldBarIndex = modelIndex
+        let chunkIdx = row.chunkIndex
+        let totalHidden = row.hiddenCount
+
+        // 1. Prepare the new context lines
+        if (direction === "down") {
+            for (let i = 0; i < toShow; i++) {
+                let lineObj = hiddenLines[oldVisible + i]
+                if (!lineObj) break
+                newLines.push({
+                    rowType: "context",
+                    diffType: GitDiff.Context,
+                    leftText: lineObj.content,
+                    rightText: lineObj.content,
+                    oldLineNum: lineObj.oldLine,
+                    newLineNum: lineObj.newLine
+                })
+            }
+        } else {  // "up"
+            let endIdx = hiddenLines.length - 1 - oldVisible
+            for (let i = 0; i < toShow; i++) {
+                let idx = endIdx - i
+                if (idx < 0) break
+                let lineObj = hiddenLines[idx]
+                newLines.push({
+                    rowType: "context",
+                    diffType: GitDiff.Context,
+                    leftText: lineObj.content,
+                    rightText: lineObj.content,
+                    oldLineNum: lineObj.oldLine,
+                    newLineNum: lineObj.newLine
+                })
+            }
+            newLines.sort((a, b) => a.oldLineNum - b.oldLineNum)
+        }
+
+        // 2. Remove the bar temporarily
+        chunkModel.remove(oldBarIndex)
+
+        // 3. Insert the new lines at the bar's old position
+        for (let i = 0; i < newLines.length; i++) {
+            chunkModel.insert(oldBarIndex + i, newLines[i])
+        }
+
+        // 4. Re-insert the bar at the correct new position
+        let newVisible = oldVisible + toShow
+        let barProperties = {
+            rowType: "hidden",
+            direction: direction,
+            hiddenCount: totalHidden,
+            visibleCount: newVisible,
+            chunkIndex: chunkIdx,
+            diffType: GitDiff.Context,
+            leftText: "", rightText: "",
+            oldLineNum: -1, newLineNum: -1
+        }
+
+        if (direction === "down") {
+            // Bar goes after the new lines
+            chunkModel.insert(oldBarIndex + toShow, barProperties)
+        } else {
+            // Bar goes before the new lines (stay at oldBarIndex)
+            chunkModel.insert(oldBarIndex, barProperties)
+        }
+
+        // 5. If fully expanded, remove this bar and its sibling
+        if (newVisible >= totalHidden) {
+            let barToRemove = direction === "down" ? oldBarIndex + toShow : oldBarIndex
+            chunkModel.remove(barToRemove)
+            for (let i = 0; i < chunkModel.count; i++) {
+                let r = chunkModel.get(i)
+                if (r.rowType === "hidden" && r.chunkIndex === chunkIdx) {
+                    chunkModel.remove(i)
+                    break
+                }
+            }
+        }
+
+        // 6. Update widths
+        for (let line of newLines) {
+            updateMaxContentWidth(line.leftText)
+        }
+    }
+
+    function removeBarsForGap(anyBarIndex, chunkIdx) {
+        // Remove the given bar first
+        chunkModel.remove(anyBarIndex)
+        // Then remove the other bar with the same chunkIndex
+        for (let i = 0; i < chunkModel.count; i++) {
+            let r = chunkModel.get(i)
+            if (r.rowType === "hidden" && r.chunkIndex === chunkIdx) {
+                chunkModel.remove(i)
+                break
+            }
+        }
+    }
+
+    function appendHiddenBar(direction, chunk, chunkIdx) {
+        chunkModel.append({
+            rowType: "hidden",
+            direction: direction,
+            hiddenCount: chunk.hiddenCount || 0,
+            visibleCount: 0,
+            chunkIndex: chunkIdx,
+            firstVisibleIndex: direction === "up" ? -1 : 0,   // used only for up
+            diffType: GitDiff.Context,
+            leftText: "", rightText: "",
+            oldLineNum: -1, newLineNum: -1
+        })
+    }
 }

--- a/Qml/View/Components/Diff/DiffView.qml
+++ b/Qml/View/Components/Diff/DiffView.qml
@@ -114,29 +114,41 @@ DetachablePanel {
             delegate: Item{
                 id: delegateItem
                 width: diffListView.width
-                height: model.rowType === "hidden" ? 18 : diffLineItem.height
+                height: model.rowType === "hidden" ? 24 : diffLineItem.height
 
-                MouseArea{
-                    id: hiddenMarker
+                Item {
                     anchors.fill: parent
                     visible: model.rowType === "hidden"
-                    hoverEnabled: true
-                    cursorShape: Qt.PointingHandCursor
-                    onClicked: root.expandHiddenBlock(index, model.direction)
+
+                    MouseArea{
+                        id: hiddenMarker
+                        anchors.fill: parent
+                        hoverEnabled: true
+                        cursorShape: Qt.PointingHandCursor
+                        onClicked: root.expandHiddenBlock(index, model.direction)
+                    }
+
+                    Rectangle{
+                        anchors.verticalCenter: parent.verticalCenter
+                        width: parent.width
+                        height: 1
+                        color: hiddenMarker.containsMouse ? Style.colors.accent
+                                                          : Style.colors.primaryBorder
+                    }
 
                     Row {
                         anchors.centerIn: parent
-                        spacing: 4
+                        spacing: 6
                         Label {
                             text: model.direction === "up" ? Style.icons.arrowUpToLine : Style.icons.arrowDownToLine
                             font.family: Style.fontTypes.font6Pro
                             font.pixelSize: 12
                             color: hiddenMarker.containsMouse ? Style.colors.secondaryForeground
-                                                              : Qt.darker(Style.colors.secondaryForeground, 1.4)
+                                                              : Style.colors.secondaryText
                             padding: 4
                             background: Rectangle {
                                 color: hiddenMarker.containsMouse ? Style.colors.accent
-                                                                 : Qt.darker(Style.colors.linePanelBackgroound, 1.05)
+                                                                  : Qt.darker(Style.colors.linePanelBackgroound, 1.05)
                                 radius: 4
                             }
                         }
@@ -145,11 +157,11 @@ DetachablePanel {
                             font.family: Style.fontTypes.roboto
                             font.pixelSize: 9
                             color: hiddenMarker.containsMouse ? Style.colors.secondaryForeground
-                                                              : Qt.darker(Style.colors.secondaryForeground, 1.4)
+                                                              : Style.colors.secondaryText
                             padding: 3
                             background: Rectangle {
                                 color: hiddenMarker.containsMouse ? Style.colors.accent
-                                                                 : Qt.darker(Style.colors.linePanelBackgroound, 1.05)
+                                                                  : Qt.darker(Style.colors.linePanelBackgroound, 1.05)
                                 radius: 3
                             }
                         }

--- a/Qml/View/Components/Diff/DiffView.qml
+++ b/Qml/View/Components/Diff/DiffView.qml
@@ -128,7 +128,7 @@ DetachablePanel {
                         anchors.centerIn: parent
                         spacing: 4
                         Label {
-                            text: model.direction === "up" ? Style.icons.caretUp : Style.icons.caretDown
+                            text: model.direction === "up" ? Style.icons.arrowUpToLine : Style.icons.arrowDownToLine
                             font.family: Style.fontTypes.font6Pro
                             font.pixelSize: 12
                             color: hiddenMarker.containsMouse ? Style.colors.secondaryForeground

--- a/Qml/View/Components/Diff/DiffView.qml
+++ b/Qml/View/Components/Diff/DiffView.qml
@@ -106,8 +106,8 @@ DetachablePanel {
             clip: true
             model: chunkMode ? chunkModel : fileModel
 
-            cacheBuffer: 5000
-            reuseItems: true
+            cacheBuffer: 0
+            reuseItems: false
             anchors.bottomMargin: hScrollBar.visible ? hScrollBar.height : 0
             ScrollBar.vertical: ScrollBar { active: true }
 

--- a/Qml/View/Components/Repository/SideBySideDiff.qml
+++ b/Qml/View/Components/Repository/SideBySideDiff.qml
@@ -1,3 +1,4 @@
+
 import QtQuick 2.15
 import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.15
@@ -23,6 +24,8 @@ Item {
     property bool isCurrentItem: false
     property var fileModel
 
+    property var diffModel
+
     property bool readOnly: false
 
     property real horizontalOffset: 0
@@ -37,7 +40,8 @@ Item {
         if (index === 0)
             return true;
 
-        let prevItem = fileModel.get(index - 1);
+        let model = diffModel || fileModel;
+        let prevItem = model ? model.get(index - 1) : null;
         return prevItem ? prevItem.type === GitDiff.Context : false;
     }
 
@@ -313,19 +317,20 @@ Item {
         }
     }
 
-
     function getRange() {
         let startIdx = index;
         let endIdx = index;
+        let model = diffModel || fileModel;
 
-        for (let i = index; i < fileModel.count; i++) {
-            let item = fileModel.get(i);
-            if (!item || item.type === GitDiff.Context) break;
+        for (let i = index; i < model.count; i++) {
+            let item = model.get(i);
+            if (!item || item.type === GitDiff.Context ||
+                (item.rowType && item.rowType !== "diff")) break;
             endIdx = i;
         }
 
-        let firstItem = fileModel.get(startIdx);
-        let lastItem = fileModel.get(endIdx);
+        let firstItem = model.get(startIdx);
+        let lastItem = model.get(endIdx);
 
         if (!firstItem || !lastItem) return { start: 0, end: 0, type: 0 };
 

--- a/Qml/View/Components/Repository/SideBySideDiff.qml
+++ b/Qml/View/Components/Repository/SideBySideDiff.qml
@@ -41,8 +41,14 @@ Item {
             return true;
 
         let model = diffModel || fileModel;
-        let prevItem = model ? model.get(index - 1) : null;
-        return prevItem ? prevItem.type === GitDiff.Context : false;
+        if (!model)
+            return false;
+
+        let prevItem = model.get(index - 1);
+        if (!prevItem)
+            return false;
+
+        return prevItem.rowType !== "diff";
     }
 
 

--- a/Src/Git/GitStatus.cpp
+++ b/Src/Git/GitStatus.cpp
@@ -811,6 +811,90 @@ GitResult GitStatus::getStagedDiff(const QString &filePath)
     return GitResult(true, QVariant::fromValue(result));
 }
 
+GitResult GitStatus::getChunkedDiffView(const QString &filePath, bool staged)
+{
+    GitResult diffRes = staged ? getStagedDiff(filePath) : getDiff(filePath);
+    if (!diffRes.success())
+        return diffRes;
+
+    QList<GitDiff> diffList = diffRes.data().value<QList<GitDiff>>();
+
+    QVariantList allLines;
+    for (const GitDiff &d : diffList) {
+        allLines.append(gitDiffToMap(d));
+    }
+
+    QVariantList chunks;
+
+    int i = 0;
+    const int N = allLines.size();
+
+    while (i < N) {
+        QVariantMap line = allLines[i].toMap();
+
+        if (isContextLine(line)) {
+            int ctxStart = i;
+            while (i < N && isContextLine(allLines[i].toMap()))
+                i++;
+
+            int ctxEnd = i - 1;
+
+            QVariantMap hidden;
+            hidden["chunkType"]   = "hidden";
+            hidden["hiddenCount"] = ctxEnd - ctxStart + 1;
+
+            QVariantMap first   = allLines[ctxStart].toMap();
+            hidden["oldStart"]  = first["oldLine"];
+            hidden["newStart"]  = first["newLine"];
+
+            QVariantList hiddenLines;
+            for (int j = ctxStart; j <= ctxEnd; ++j)
+                hiddenLines.append(allLines[j]);
+            hidden["hiddenLines"] = hiddenLines;
+
+            chunks.append(hidden);
+        } else {
+            int hunkStart = i;
+            while (i < N && !isContextLine(allLines[i].toMap())) i++;
+            int hunkEnd = i - 1;
+
+            QVariantMap changed;
+            changed["chunkType"] = "changed";
+            changed["oldStart"]  = allLines[hunkStart].toMap()["oldLine"];
+            changed["oldEnd"]    = allLines[hunkEnd].toMap()["oldLine"];
+            changed["newStart"]  = allLines[hunkStart].toMap()["newLine"];
+            changed["newEnd"]    = allLines[hunkEnd].toMap()["newLine"];
+
+            QVariantList lines;
+            for (int j = hunkStart; j <= hunkEnd; ++j)
+                lines.append(allLines[j]);
+            changed["lines"] = lines;
+
+            chunks.append(changed);
+        }
+    }
+
+    QVariantMap resultData;
+    resultData["chunks"] = chunks;
+    return GitResult(true, resultData);
+}
+
+QVariantMap GitStatus::gitDiffToMap(const GitDiff &d)
+{
+    QVariantMap m;
+    m["type"]       = static_cast<int>(d.type());
+    m["oldLine"]    = d.oldLine();
+    m["newLine"]    = d.newLine();
+    m["content"]    = d.content();
+    m["newContent"] = d.newContent();
+    return m;
+}
+
+bool GitStatus::isContextLine(const QVariantMap &line) const
+{
+    return line.value("type").toInt() == static_cast<int>(GitDiff::Context);
+}
+
 GitResult GitStatus::stageSelectedLines(const QString &filePath, int startLine, int endLine, int mode)
 {
     if (!m_currentRepo || !m_currentRepo->repo)

--- a/Src/Git/GitStatus.h
+++ b/Src/Git/GitStatus.h
@@ -13,6 +13,7 @@
 #include "GitFileStatus.h"
 #include "GitResult.h"
 #include "IGitController.h"
+#include "GitDiff.h"
 
 // Smart pointer deleters for libgit2 types
 struct IndexDeleter { void operator()(git_index* p) const { git_index_free(p); } };
@@ -168,6 +169,10 @@ public:
     Q_INVOKABLE GitResult revertAll();
 
     Q_INVOKABLE QString getHeadHash();
+
+    /// Returns a QVariantList of chunk objects ready for QML
+    Q_INVOKABLE GitResult getChunkedDiffView(const QString &filePath, bool staged);
+
 private:
     /**
      * @brief Get unstaged diff view (index to workdir).
@@ -270,4 +275,7 @@ private:
     * @return GitResult success status.
     */
     GitResult writeIndexFromBuffer(git_repository *repo, const QString &filePath, const QByteArray &contentUtf8, uint32_t modeIfKnown);
+
+    QVariantMap gitDiffToMap(const GitDiff &d);
+    bool isContextLine(const QVariantMap &line) const;
 };


### PR DESCRIPTION
Display diff as expandable chunks (#228)

Replace the flat line-by-line diff with a chunked view that shows only changed hunks. Unchanged context is hidden behind clickable separator bars. The user can expand context lines in configurable steps. Both sides of a gap share visibility state, so expanding one side updates the other, and both bars are removed when fully expanded.

Key changes:
• Added chunkMode, contextLines, expandLines properties to DiffView
• Added GitStatus::getChunkedDiffView() in C++ to build chunk models from the full diff
• Added hidden‑row delegate with up/down expand arrows styled like stage/revert buttons
• Shared counters (visibleTop/visibleBottom) prevent overlapping lines from the two sides of a gap
• Pre‑expansion of context lines according to contextLines
• Fixed layout compacting of file list after stage/unstage (diff list recycling)
• Stage/revert buttons now appear correctly in chunked mode
• Backward compatible – chunkMode: false keeps the old flat diff