### PR TITLE
284 refactor graph view page

### DIFF
--- a/Qml/Core/Scripts/CommitGraphDataLoader.js
+++ b/Qml/Core/Scripts/CommitGraphDataLoader.js
@@ -1,0 +1,167 @@
+.pragma library
+
+// ====================================================================
+// CommitGraphDataLoader – pure data compilation helpers.
+// ====================================================================
+
+/**
+ * Compiles graph‑ready commits from raw controller data.
+ * @param {Array} rawCommits  – page from commitController.getCommits()
+ * @param {Array} rawBranches – branchController.getBranches()
+ * @param {Array} rawStashes  – stashController.list().data
+ * @param {Array} allTags     – tagController.list().data  (optional)
+ * @param {Object} appSettings – appModel.appSettings.generalSettings (optional)
+ * @returns {Array} compiled commit objects with colorKey, branchNames, etc.
+ */
+function compileGraphCommits(rawCommits, rawBranches, rawStashes, allTags, appSettings) {
+    if (!rawCommits)
+        return [];
+
+    var hashToTags = {};
+    if (allTags) {
+        for (var i = 0; i < allTags.length; i++) {
+            var tg = allTags[i];
+            if (tg.commitId) {
+                if (!hashToTags[tg.commitId])
+                    hashToTags[tg.commitId] = [];
+
+                hashToTags[tg.commitId].push(tg.name);
+            }
+        }
+    }
+
+    var tipHashToBranches = {};
+    if (rawBranches) {
+        for (var i = 0; i < rawBranches.length; i++) {
+            var b = rawBranches[i];
+            if (!b || !b.targetHash)
+                continue;
+
+            if (!tipHashToBranches[b.targetHash])
+                tipHashToBranches[b.targetHash] = [];
+
+            tipHashToBranches[b.targetHash].push(b.name);
+        }
+    }
+
+    var showStashes = appSettings ? !!appSettings.showStashNodes : false;
+    var stashNodeList = [];
+    if (showStashes && rawStashes && rawStashes.length) {
+        var seenStash = {};
+        for (var s = 0; s < rawStashes.length; s++) {
+            var stash = rawStashes[s];
+            if (!stash || !stash.id || seenStash[stash.id])
+                continue;
+
+            seenStash[stash.id] = true;
+
+            var label = "stash@{" + stash.index + "}";
+            stashNodeList.push({
+                hash            : stash.id,
+                shortHash       : stash.id.substring(0, 7),
+                message         : stash.message || label,
+                summary         : stash.message || label,
+                author          : stash.author || "",
+                authorEmail     : "",
+                authorDate      : stash.dateTime || "",
+                parentHashes    : stash.parentId ? [stash.parentId] : [],
+                commitType      : "stash",
+                branchNames     : [label],
+                tagNames        : [],
+                colorKey        : "",
+                isStash         : true,
+                stashIndex      : stash.index,
+                stashLabel      : label,
+                stashParentId   : stash.parentId || "",
+                files           : null,
+                isUncommitted   : false
+            });
+        }
+    }
+
+    var compiled = [];
+    var stashInserted = {};
+
+    for (var c = 0; c < rawCommits.length; c++) {
+        var commit = rawCommits[c];
+
+        for (var sj = 0; sj < stashNodeList.length; sj++) {
+            var sn = stashNodeList[sj];
+            if (!stashInserted[sn.hash] && sn.stashParentId === commit.hash) {
+                compiled.push(sn);
+                stashInserted[sn.hash] = true;
+            }
+        }
+
+        compiled.push({
+            hash            : commit.hash,
+            shortHash       : commit.shortHash,
+            message         : commit.message,
+            summary         : commit.summary,
+            author          : commit.author,
+            authorEmail     : commit.authorEmail,
+            authorDate      : commit.authorDate,
+            parentHashes    : commit.parentHashes || [],
+            commitType      : (commit.parentHashes && commit.parentHashes.length > 1) ? "merge" : "normal",
+            branchNames     : tipHashToBranches[commit.hash] || [],
+            tagNames        : hashToTags[commit.hash] || [],
+            colorKey        : "",
+            isStash         : false,
+            stashIndex      : -1,
+            stashLabel      : "",
+            stashParentId   : "",
+            files           : commit.files || null,
+            isUncommitted   : commit.isUncommitted || false
+        });
+    }
+
+    for (var sk = 0; sk < stashNodeList.length; sk++) {
+        if (!stashInserted[stashNodeList[sk].hash])
+            compiled.push(stashNodeList[sk]);
+    }
+
+    return compiled;
+}
+
+/**
+ * Creates an uncommitted pseudo‑commit from status data.
+ * @param {Array} statusData – result of statusController.status().data
+ * @param {string} headHash  – current HEAD hash
+ * @returns {Object|null} uncommitted node
+ */
+function createUncommittedNode(statusData, headHash) {
+    if (!statusData)
+        return null;
+
+    var staged      = [];
+    var unstaged    = [];
+    statusData.forEach(function(file) {
+        if (file.isStaged)
+            staged.push(file);
+
+        else if (file.isUnstaged || file.isUntracked)
+            unstaged.push(file);
+    });
+
+    var total = staged.length + unstaged.length;
+    if (total === 0)
+        return null;
+
+    return {
+        hash: "__uncommitted__",
+        shortHash       : "",
+        message         : "Working tree Changes",
+        summary         : "Working tree Changes (" + total + " files)",
+        author          : "",
+        authorEmail     : "",
+        authorDate      : "",
+        parentHashes    : headHash ? [headHash] : [],
+        commitType      : "uncommitted",
+        branchNames     : [],
+        tagNames        : [],
+        colorKey        : "uncommitted",
+        isUncommitted   : true,
+        isStash         : false,
+        files           : { staged: staged, unstaged: unstaged }
+    };
+}

--- a/Qml/Core/Scripts/CommitGraphFilter.js
+++ b/Qml/Core/Scripts/CommitGraphFilter.js
@@ -1,0 +1,125 @@
+.pragma library
+
+// ====================================================================
+// CommitGraphFilter – pure filter / data‑loading helpers.
+// ====================================================================
+
+/**
+ * Filters the full commit list according to text, dates, and modes.
+ * @param {Array}  allCommits        – full unfiltered list
+ * @param {string} filterText        – search text
+ * @param {string} filterStartDate   – YYYY‑MM‑DD
+ * @param {string} filterEndDate     – YYYY‑MM‑DD
+ * @param {Array}  filterMode        – active modes (e.g. ["Messages"])
+ * @param {Array}  selectedHashes    – currently selected hashes
+ * @returns {Object} { filtered: Array, stillSelected: Array }
+ */
+function applyFilter(allCommits, filterText, filterStartDate, filterEndDate, filterMode, selectedHashes) {
+    var base    = allCommits || [];
+    var needle  = (filterText || "").trim().toLowerCase();
+    var startMs = parseDateYYYYMMDD(filterStartDate);
+    var endMs   = parseDateYYYYMMDD(filterEndDate);
+
+    if (!isNaN(endMs))
+        endMs = endMs + (24 * 60 * 60 * 1000) - 1;
+
+    var filtered = [];
+    for (var i = 0; i < base.length; i++) {
+        var c = base[i];
+        if (!c) continue;
+
+        if (!isNaN(startMs) || !isNaN(endMs)) {
+            var commitMs = new Date(c.authorDate).getTime();
+            if (!isNaN(startMs) && !(commitMs >= startMs))
+                continue;
+
+            if (!isNaN(endMs) && !(commitMs <= endMs))
+                continue;
+        }
+
+        if (needle && !applicationFilter(c, needle, filterMode))
+            continue;
+
+        filtered.push(c);
+    }
+
+    var stillSelected = [];
+    if (selectedHashes && selectedHashes.length) {
+        for (var si = 0; si < selectedHashes.length; si++) {
+            var h = selectedHashes[si];
+            if (filtered.some(function(x) { return x.hash === h; }))
+                stillSelected.push(h);
+        }
+    }
+
+    return { filtered: filtered, stillSelected: stillSelected };
+}
+
+/**
+ * Simple date parser (identical to original).
+ */
+function parseDateYYYYMMDD(str) {
+    if (!str)
+        return NaN;
+
+    str = ("" + str).trim();
+
+    if (str.length < 8)
+        return NaN;
+
+    var parts = str.split(/[-\/]/);
+
+    if (parts.length !== 3)
+        return NaN;
+
+    var y = parseInt(parts[0], 10)
+    var m = parseInt(parts[1], 10)
+    var d = parseInt(parts[2], 10)
+
+    if (isNaN(y) || isNaN(m) || isNaN(d))
+        return NaN;
+
+    return new Date(y, m-1, d, 0,0,0,0).getTime();
+}
+
+function hasAnyFilter(filterText, filterStartDate, filterEndDate) {
+    return (filterText      && filterText.trim().length > 0)        ||
+           (filterStartDate && filterStartDate.trim().length > 0)   ||
+           (filterEndDate   && filterEndDate.trim().length > 0);
+}
+
+function applicationFilter(commit, needle, modes) {
+    if (!needle)
+        return true;
+
+    var activeMode = (modes && modes.length > 0) ? modes : ["Messages"];
+    for (var i = 0; i < activeMode.length; i++) {
+        var mode = activeMode[i];
+        var haystack = "";
+        switch (mode) {
+            case "Messages":
+                haystack = (commit.summary||"") + " " + (commit.message||"")
+                break;
+
+            case "Subjects":
+                haystack = commit.summary || ""
+                break;
+
+            case "Authors":
+                haystack = commit.author || ""
+                break;
+            case "Emails":
+                haystack = commit.authorEmail || ""
+                break;
+
+            case "SHA-1":
+                haystack = commit.hash || ""
+                break;
+        }
+
+        if (haystack.toLowerCase().indexOf(needle) !== -1)
+            return true;
+    }
+
+    return false;
+}

--- a/Qml/Core/Scripts/CommitGraphMenuBuilder.js
+++ b/Qml/Core/Scripts/CommitGraphMenuBuilder.js
@@ -1,0 +1,108 @@
+.pragma library
+
+// ====================================================================
+// CommitGraphMenuBuilder – builds the context‑menu data model
+// for a commit.
+// ====================================================================
+
+function buildMenu(state) {
+    var model = [];
+
+    // Checkout section
+    if (state.branchNames.length > 0) {
+        var checkoutSubMenu = state.branchNames.map(function(bName) {
+            return {
+                text: bName,
+                icon: "gitBranch",
+                action: "checkoutBranch",
+                payload: { branch: bName }
+            };
+        });
+
+        checkoutSubMenu.push({
+            text: "Checkout " + state.shortHash + " (Detached)",
+            icon: "hash",
+            action: "checkoutCommit",
+            payload: { hash: state.fullHash }
+        });
+
+        model.push({
+            text: "Checkout",
+            icon: "gitBranch",
+            enabled: !state.isHead,
+            subItems: checkoutSubMenu
+        });
+    }
+
+    else {
+        model.push({
+            text: "Checkout Commit " + state.shortHash,
+            icon: "hash",
+            enabled: !state.isHead,
+            action: "checkoutCommit",
+            payload: { hash: state.fullHash }
+        });
+    }
+
+    // New Branch / Tag
+    model.push({
+        text: "New Branch from here",
+        icon: "branchPlus",
+        action: "newBranch",
+        payload: { hash: state.fullHash }
+    });
+
+    model.push({
+        text: "Create Tag here",
+        icon: "tag",
+        action: "newTag",
+        payload: { hash: state.fullHash }
+    });
+
+    // Merge
+    if (state.hasMergeableBranches) {
+        model.push({
+                separator: true
+        });
+
+        state.mergeableBranches.forEach(function(bName) {
+            model.push({
+                text: "Merge '" + bName + "' into '" + state.currentBranch + "'",
+                icon: "arowLeftRight",
+                action: "mergeBranch",
+                payload: { source: bName, target: state.currentBranch }
+            });
+        });
+    }
+
+    // Rebase
+    if (state.canRebase) {
+        model.push({
+            text: "Rebase onto " + state.shortHash,
+            icon: "clockRotateLeft",
+            action: "rebase",
+            payload: { hash: state.fullHash }
+        });
+    }
+
+    // Cherry‑Pick
+    if (state.numSelected > 1) {
+        model.push({
+            text: "Cherry-Pick Selected (" + state.numSelected + ")",
+            icon: "copy",
+            enabled: state.cherryPickEnabled,
+            action: "cherryPickSelected"
+        });
+    }
+    else {
+        model.push({
+            text: "Cherry-Pick " + state.shortHash,
+            icon: "copy",
+            enabled: state.canCherryPick,
+            action: "cherryPickSingle",
+            payload: { hash: state.fullHash }
+        });
+    }
+
+    return model;
+}

--- a/Qml/Core/Scripts/CommitGraphNavigation.js
+++ b/Qml/Core/Scripts/CommitGraphNavigation.js
@@ -12,7 +12,7 @@
  * @param {string} newNavRule      – (optional) new navigation rule to apply
  * @returns {{ selected: Object, index: number, scroll: boolean }}
  */
-function selectNext(commits, selectedCommit, selectedIndex, navigationRule, newNavRule) {
+function selectPrevious(commits, selectedCommit, selectedIndex, navigationRule, newNavRule) {
     if (newNavRule !== undefined)
         navigationRule = newNavRule;
 
@@ -60,7 +60,7 @@ function selectNext(commits, selectedCommit, selectedIndex, navigationRule, newN
 /**
  * Same signature, but moves upwards.
  */
-function selectPrevious(commits, selectedCommit, selectedIndex, navigationRule, newNavRule) {
+function selectNext(commits, selectedCommit, selectedIndex, navigationRule, newNavRule) {
     if (newNavRule !== undefined)
         navigationRule = newNavRule;
 

--- a/Qml/Core/Scripts/CommitGraphNavigation.js
+++ b/Qml/Core/Scripts/CommitGraphNavigation.js
@@ -1,0 +1,186 @@
+.pragma library
+
+// ====================================================================
+// CommitGraphNavigation – stateless navigation & selection helpers.
+// ====================================================================
+
+/**
+ * @param {Array}  commits         – current commit array
+ * @param {Object} selectedCommit  – the currently selected commit (or null)
+ * @param {number} selectedIndex   – index of selectedCommit in commits (-1 if none)
+ * @param {string} navigationRule  – "Author Email", "Author", "Parent 1", "Branch", "Message"
+ * @param {string} newNavRule      – (optional) new navigation rule to apply
+ * @returns {{ selected: Object, index: number, scroll: boolean }}
+ */
+function selectNext(commits, selectedCommit, selectedIndex, navigationRule, newNavRule) {
+    if (newNavRule !== undefined)
+        navigationRule = newNavRule;
+
+    if (!commits.length)
+        return null;
+
+    var idx = selectedIndex;
+    if (idx < 0)
+        return { selected: commits[0], index: 0, scroll: true };
+
+    if (!selectedCommit)
+        return null;
+
+    if (navigationRule === "Parent 1") {
+        if (!selectedCommit.parentHashes || !selectedCommit.parentHashes.length) return null;
+        var parentHash = selectedCommit.parentHashes[0];
+        for (var i = idx + 1; i < commits.length; i++) {
+            if (commits[i] && commits[i].hash === parentHash) {
+                return { selected: commits[i], index: i, scroll: true };
+            }
+        }
+        return null;
+    }
+
+    if (navigationRule === "Branch") {
+        var laneKey = selectedCommit.colorKey;
+        if (!laneKey) return null;
+        for (var i = idx + 1; i < commits.length; i++) {
+            if (commits[i] && commits[i].colorKey === laneKey) {
+                return { selected: commits[i], index: i, scroll: true };
+            }
+        }
+        return null;
+    }
+
+    var matchValue = getNavigationRuleValue(selectedCommit, navigationRule);
+    for (var i = idx + 1; i < commits.length; i++) {
+        if (commits[i] && getNavigationRuleValue(commits[i], navigationRule) === matchValue) {
+            return { selected: commits[i], index: i, scroll: true };
+        }
+    }
+    return null;
+}
+
+/**
+ * Same signature, but moves upwards.
+ */
+function selectPrevious(commits, selectedCommit, selectedIndex, navigationRule, newNavRule) {
+    if (newNavRule !== undefined)
+        navigationRule = newNavRule;
+
+    if (!commits.length)
+        return null;
+
+    var idx = selectedIndex;
+    if (idx < 0) return { selected: commits[0], index: 0, scroll: true };
+
+    if (!selectedCommit)
+        return null;
+
+    if (navigationRule === "Parent 1") {
+        for (var i = idx - 1; i >= 0; i--) {
+            var commit = commits[i];
+            if (commit && commit.parentHashes && commit.parentHashes.length &&
+                commit.parentHashes[0] === selectedCommit.hash) {
+                return { selected: commit, index: i, scroll: true };
+            }
+        }
+        return null;
+    }
+
+    if (navigationRule === "Branch") {
+        var laneKey = selectedCommit.colorKey;
+        if (!laneKey) return null;
+        for (var i = idx - 1; i >= 0; i--) {
+            if (commits[i] && commits[i].colorKey === laneKey) {
+                return { selected: commits[i], index: i, scroll: true };
+            }
+        }
+        return null;
+    }
+
+    var matchValue = getNavigationRuleValue(selectedCommit, navigationRule);
+    for (var i = idx - 1; i >= 0; i--) {
+        if (commits[i] && getNavigationRuleValue(commits[i], navigationRule) === matchValue) {
+            return { selected: commits[i], index: i, scroll: true };
+        }
+    }
+    return null;
+}
+
+/**
+ * Returns new selection state after a mouse click.
+ *
+ * @param {Object} commitData     – clicked commit
+ * @param {number} index          – its index
+ * @param {number} modifiers      – Qt keyboard modifiers
+ * @param {Array}  currentHashes  – currently selected hashes
+ * @param {number} lastIndex      – last selected index (for shift‑click)
+ * @param {Array}  commits        – full commit array
+ * @returns {{ hashes: Array, lastIndex: number }} new selection
+ */
+function applySelection(commitData, index, modifiers, currentHashes, lastIndex, commits) {
+    if (!commitData || !commitData.hash)
+        return null;
+
+    if ((modifiers & Qt.ControlModifier)) {
+        var list    = currentHashes ? currentHashes.slice() : [];
+        var idx     = list.indexOf(commitData.hash);
+
+        if (idx >= 0)
+            list.splice(idx, 1);
+
+        else
+            list.push(commitData.hash);
+
+        return { hashes: list, lastIndex: index };
+    }
+
+    if ((modifiers & Qt.ShiftModifier) && lastIndex >= 0) {
+        var start   = Math.min(lastIndex, index);
+        var end     = Math.max(lastIndex, index);
+        var hashes  = [];
+
+        for (var i = start; i <= end; i++) {
+            var c = commits[i];
+            if (c && c.hash) hashes.push(c.hash);
+        }
+        return { hashes: hashes, lastIndex: index };
+    }
+
+    return { hashes: [commitData.hash], lastIndex: index };
+}
+
+/**
+ * @returns {number} index of selectedCommit in commits, or -1
+ */
+function selectedIndex(commits, selectedCommit) {
+    if (!selectedCommit)
+        return -1;
+
+    for (var i = 0; i < commits.length; i++) {
+        if (commits[i] && commits[i].hash === selectedCommit.hash)
+            return i;
+    }
+    return -1;
+}
+
+function getNavigationRuleValue(commit, rule) {
+    if (!commit)
+        return null;
+
+    switch (rule) {
+        case "Author":
+            return (commit.author || "").toString();
+
+        case "Author Email":
+            return (commit.authorEmail || "").toString();
+
+        case "Parent 1":
+            return (commit.parentHashes && commit.parentHashes.length) ? commit.parentHashes[0] : null;
+
+        case "Branch":
+            return commit.colorKey;
+
+        case "Message":
+
+        default:
+            return (commit.summary || "").toString();
+    }
+}

--- a/Qml/Core/Scripts/GraphViewPresenter.js
+++ b/Qml/Core/Scripts/GraphViewPresenter.js
@@ -1,52 +1,48 @@
 /*! ***********************************************************************************************
  * GraphViewPresenter
- * Handles commit/file interaction logic for GraphViewPage.
- * Must be initialized with dependencies before use.
  * ************************************************************************************************/
 .pragma library
 
-var selectedCommit = "";
-var selectedFilePath = "";
+/* Property Declarations
+ * ****************************************************************************************/
+var selectedCommit      = "";
+var selectedFilePath    = "";
 
-var commitGraph = null;
-var fileChangesDock = null;
-var diffView = null;
-var statusController = null;
-var commitController = null;
+var commitGraph         = null;
+var fileChangesDock     = null;
+var diffView            = null;
+var statusController    = null;
+var commitController    = null;
 
+/* Functions
+ * ****************************************************************************************/
 function init(deps) {
-    commitGraph = deps.commitGraph;
-    fileChangesDock = deps.fileChangesDock;
-    diffView = deps.diffView;
-    statusController = deps.statusController;
-    commitController = deps.commitController;
+    commitGraph         = deps.commitGraph;
+    fileChangesDock     = deps.fileChangesDock;
+    diffView            = deps.diffView;
+    statusController    = deps.statusController;
+    commitController    = deps.commitController;
 }
 
 function clearSelection() {
-    selectedCommit = "";
-    selectedFilePath = "";
-    if (diffView)
-        diffView.diffData = null;
+    selectedCommit      = "";
+    selectedFilePath    = "";
+    diffView.diffData   = null;
 }
 
 function handleCommitClicked(commitId) {
     selectedCommit = commitId;
-    if (fileChangesDock)
-        fileChangesDock.commitHash = commitId;
+
+    fileChangesDock.commitHash = commitId;
 
     if (commitId !== "__uncommitted__")
         return;
 
-    // uncommitted node
-    if (!statusController)
-        return;
-
-    var node = commitGraph ? commitGraph.commits.find(function(c) { return c.hash === commitId; }) : null;
+    var node = commitGraph.commits.find(function(c) { return c.hash === commitId; });
     if (node && node.isUncommitted) {
         var res = statusController.status();
         if (!res.success || !res.data) {
-            console.log("status failed:", res);
-            if (fileChangesDock) fileChangesDock.files = [];
+            fileChangesDock.files = [];
             return;
         }
         fileChangesDock.files = res.data;
@@ -56,17 +52,15 @@ function handleCommitClicked(commitId) {
 function handleFileSelected(filePath) {
     selectedFilePath = filePath;
     var commitId = selectedCommit;
-    if (!commitId || !commitGraph || !diffView)
+    if (!commitId)
         return;
 
     var node = commitGraph.commits ? commitGraph.commits.find(function(c) { return c.hash === commitId; }) : null;
 
     // uncommitted diff
     if (commitId === "__uncommitted__" || (node && node.isUncommitted)) {
-        if (!statusController) return;
         var headHash = statusController.getHeadHash();
         if (!headHash) {
-            console.log("HEAD is null -> cannot diff uncommitted");
             return;
         }
         var res = statusController.getWorkingDirectoryDiff(headHash, filePath);
@@ -83,7 +77,7 @@ function handleFileSelected(filePath) {
         parentHash = node.stashParentId;
     }
     // 2) try commitController.getParentHash
-    else if (commitController) {
+    else {
         parentHash = commitController.getParentHash(commitId);
     }
     // 3) fallback to first parent from node data
@@ -92,14 +86,11 @@ function handleFileSelected(filePath) {
     }
 
     if (!parentHash) {
-        console.log("Cannot determine parent for commit", commitId);
         return;
     }
 
     var diffRes = statusController.getDiff(parentHash, commitId, filePath);
     if (diffRes && diffRes.success) {
         diffView.diffData = diffRes.data;
-    } else if (diffRes) {
-        console.log("getDiff failed:", diffRes.errorMessage);
     }
 }

--- a/Qml/Core/Scripts/GraphViewPresenter.js
+++ b/Qml/Core/Scripts/GraphViewPresenter.js
@@ -1,0 +1,105 @@
+/*! ***********************************************************************************************
+ * GraphViewPresenter
+ * Handles commit/file interaction logic for GraphViewPage.
+ * Must be initialized with dependencies before use.
+ * ************************************************************************************************/
+.pragma library
+
+var selectedCommit = "";
+var selectedFilePath = "";
+
+var commitGraph = null;
+var fileChangesDock = null;
+var diffView = null;
+var statusController = null;
+var commitController = null;
+
+function init(deps) {
+    commitGraph = deps.commitGraph;
+    fileChangesDock = deps.fileChangesDock;
+    diffView = deps.diffView;
+    statusController = deps.statusController;
+    commitController = deps.commitController;
+}
+
+function clearSelection() {
+    selectedCommit = "";
+    selectedFilePath = "";
+    if (diffView)
+        diffView.diffData = null;
+}
+
+function handleCommitClicked(commitId) {
+    selectedCommit = commitId;
+    if (fileChangesDock)
+        fileChangesDock.commitHash = commitId;
+
+    if (commitId !== "__uncommitted__")
+        return;
+
+    // uncommitted node
+    if (!statusController)
+        return;
+
+    var node = commitGraph ? commitGraph.commits.find(function(c) { return c.hash === commitId; }) : null;
+    if (node && node.isUncommitted) {
+        var res = statusController.status();
+        if (!res.success || !res.data) {
+            console.log("status failed:", res);
+            if (fileChangesDock) fileChangesDock.files = [];
+            return;
+        }
+        fileChangesDock.files = res.data;
+    }
+}
+
+function handleFileSelected(filePath) {
+    selectedFilePath = filePath;
+    var commitId = selectedCommit;
+    if (!commitId || !commitGraph || !diffView)
+        return;
+
+    var node = commitGraph.commits ? commitGraph.commits.find(function(c) { return c.hash === commitId; }) : null;
+
+    // uncommitted diff
+    if (commitId === "__uncommitted__" || (node && node.isUncommitted)) {
+        if (!statusController) return;
+        var headHash = statusController.getHeadHash();
+        if (!headHash) {
+            console.log("HEAD is null -> cannot diff uncommitted");
+            return;
+        }
+        var res = statusController.getWorkingDirectoryDiff(headHash, filePath);
+        if (res && res.success)
+            diffView.diffData = res.data;
+        return;
+    }
+
+    // normal / stash commits
+    var parentHash = "";
+
+    // 1) stash: use stashParentId
+    if (node && node.isStash && node.stashParentId) {
+        parentHash = node.stashParentId;
+    }
+    // 2) try commitController.getParentHash
+    else if (commitController) {
+        parentHash = commitController.getParentHash(commitId);
+    }
+    // 3) fallback to first parent from node data
+    if (!parentHash && node && node.parentHashes && node.parentHashes.length > 0) {
+        parentHash = node.parentHashes[0];
+    }
+
+    if (!parentHash) {
+        console.log("Cannot determine parent for commit", commitId);
+        return;
+    }
+
+    var diffRes = statusController.getDiff(parentHash, commitId, filePath);
+    if (diffRes && diffRes.success) {
+        diffView.diffData = diffRes.data;
+    } else if (diffRes) {
+        console.log("getDiff failed:", diffRes.errorMessage);
+    }
+}

--- a/Qml/Core/Scripts/GraphViewPresenter.js
+++ b/Qml/Core/Scripts/GraphViewPresenter.js
@@ -16,6 +16,11 @@ var commitController    = null;
 
 /* Functions
  * ****************************************************************************************/
+
+/**
+ * @brief Initializes the presenter with required dependencies.
+ * @param {Object} deps - Dictionary containing references to UI components and controllers.
+ */
 function init(deps) {
     commitGraph         = deps.commitGraph;
     fileChangesDock     = deps.fileChangesDock;
@@ -24,12 +29,19 @@ function init(deps) {
     commitController    = deps.commitController;
 }
 
+/**
+ * @brief Clears the currently selected commit and file, and resets the diff view.
+ */
 function clearSelection() {
     selectedCommit      = "";
     selectedFilePath    = "";
     diffView.diffData   = null;
 }
 
+/**
+ * @brief Handles the event when a commit is clicked in the graph.
+ * @param {string} commitId - The hash of the selected commit, or "__uncommitted__".
+ */
 function handleCommitClicked(commitId) {
     selectedCommit = commitId;
 
@@ -49,6 +61,11 @@ function handleCommitClicked(commitId) {
     }
 }
 
+/**
+ * @brief Handles the event when a file is selected in the file changes dock.
+ *        Fetches the appropriate diff and updates the DiffView.
+ * @param {string} filePath - The path of the selected file.
+ */
 function handleFileSelected(filePath) {
     selectedFilePath = filePath;
     var commitId = selectedCommit;

--- a/Qml/Pages/GraphViewPage.qml
+++ b/Qml/Pages/GraphViewPage.qml
@@ -133,6 +133,25 @@ Item {
     /* Functions
      * ****************************************************************************************/
     function initPresenter() {
+        if (!notificationController) {
+            console.error("ConflictPopup: missing required controllers")
+            close()
+            return
+        }
+
+        if (!statusController || !commitController) {
+                notificationController.error("Cannot initialize Graph View: required controllers are missing.",
+                                             "Initialization Error", 4000)
+            return
+        }
+
+        if (!commitGraph || !fileChangesDock || !diffView) {
+                notificationController.error("GraphViewPage: missing required UI components",
+                                             "Initialization Error", 4000)
+            return
+        }
+
+        // 3. Initialize Presenter safely
         Presenter.init({
             commitGraph     : commitGraph,
             fileChangesDock : fileChangesDock,

--- a/Qml/Pages/GraphViewPage.qml
+++ b/Qml/Pages/GraphViewPage.qml
@@ -33,13 +33,7 @@ Item {
     property RebaseController       rebaseController        : null
     property CherryPickController   cherryPickController    : null
 
-
-
-    /* Object Properties
-     * ****************************************************************************************/
-    anchors.fill: parent
-
-    property alias graphRef: commitGraph
+    property alias                  graphRef                : commitGraph
 
     // Header exposed to MainWindow
     property Component headerContent: Component {
@@ -68,6 +62,8 @@ Item {
         }
     }
 
+    /* Signals and Connections
+     * ****************************************************************************************/
     Component.onCompleted: {
         Qt.callLater(initPresenter)
     }
@@ -79,6 +75,10 @@ Item {
             diffView.diffData = null
         }
     }
+
+    /* Object Properties
+     * ****************************************************************************************/
+    anchors.fill: parent
 
     /* Children
      * ****************************************************************************************/
@@ -134,8 +134,7 @@ Item {
      * ****************************************************************************************/
     function initPresenter() {
         if (!notificationController) {
-            console.error("ConflictPopup: missing required controllers")
-            close()
+            console.error("GraphViewPage: missing Notification Controller")
             return
         }
 
@@ -151,7 +150,6 @@ Item {
             return
         }
 
-        // 3. Initialize Presenter safely
         Presenter.init({
             commitGraph     : commitGraph,
             fileChangesDock : fileChangesDock,

--- a/Qml/Pages/GraphViewPage.qml
+++ b/Qml/Pages/GraphViewPage.qml
@@ -6,6 +6,8 @@ import GitEase_Style
 import GitEase_Style_Impl
 import GitEase
 
+import "qrc:/GitEase/Qml/Core/Scripts/GraphViewPresenter.js" as Presenter
+
 /*! ***********************************************************************************************
  * GraphViewPage
  * Graph View Page shown Commit Graph Dock, File Changes and Diff View
@@ -14,487 +16,43 @@ import GitEase
 Item {
     id: root
 
-    /* Property Declarations
-     * ****************************************************************************************/
-    property var                    page: null
-    property AppModel               appModel: null
-    property BranchController       branchController: null
-    property CommitController       commitController: null
-    property StatusController       statusController: null
-    property RepositoryController   repositoryController: null
-    property NotificationController notificationController: null
-    property UiSessionPopups        uiSessionPopups: null
-    property StashController        stashController: null
-    property string                 selectedCommit: ""
-    property string                 selectedFilePath: ""
-    property string                 headHash: ""
-    property ConflictController conflictController: null
-    property MergeController mergeController: null
-    property RebaseController rebaseController: null
-    property CherryPickController cherryPickController: null
+    /* Property Declarations */
+    property var                    page                    : null
+    property AppModel               appModel                : null
 
-    /* Object Properties
-     * ****************************************************************************************/
+    property BranchController       branchController        : null
+    property CommitController       commitController        : null
+    property StatusController       statusController        : null
+    property RepositoryController   repositoryController    : null
+    property NotificationController notificationController  : null
+    property UiSessionPopups        uiSessionPopups         : null
+    property StashController        stashController         : null
+    property ConflictController     conflictController      : null
+    property MergeController        mergeController         : null
+    property RebaseController       rebaseController        : null
+    property CherryPickController   cherryPickController    : null
+
+    property alias graphRef: commitGraph
+
     anchors.fill: parent
 
-    /* Children
-     * ****************************************************************************************/
+    // Header exposed to MainWindow
+    property Component headerContent: Component {
+        GraphViewHeader {
+            id: graphViewHeader
+            commitGraph: root.graphRef
+        }
+    }
 
-    onSelectedCommitChanged: {
-        fileChangesDock.commitHash = root.selectedCommit
+    Component.onCompleted: {
+        Qt.callLater(initPresenter)
     }
 
     Connections {
         target: repositoryController
-
         function onRepositorySelected() {
-            root.selectedCommit = ""
-            root.selectedFilePath = ""
+            Presenter.clearSelection()
             diffView.diffData = null
-        }
-    }
-
-    // Exposed to MainWindow's header area (see MainWindow.qml)
-    property Component headerContent: Component {
-        RowLayout {
-            id: headerRow
-            anchors.fill: parent
-            anchors.leftMargin: parent.width < Style.appHeight ? 8 : 20
-            anchors.rightMargin: parent.width < Style.appHeight ? 4 : 5
-            spacing: parent.width < Style.appHeight ? 6 : 10
-
-            readonly property bool compact: parent.width < 650
-
-            property var navigationRules: ["Author Email", "Author", "Parent 1", "Branch"]
-            property string navigationRule: "Author Email"
-            property string filterStartDate: ""   // YYYY-MM-DD
-            property string filterEndDate: ""     // YYYY-MM-DD
-            property string filterText: ""
-
-            function applyFilter() {
-                if (!commitGraph)
-                    return
-                
-                var selectedModes = []
-                for (var i = 0; i < filterOptionsModel.count; i++) {
-                    var item = filterOptionsModel.get(i)
-                    if (item.checked) {
-                        selectedModes.push(item.text)
-                    }
-                }
-                
-                commitGraph.applyFilter(filterText, filterStartDate, filterEndDate, selectedModes)
-            }
-
-            property var activeDateField: null
-            property bool activeIsStart: true
-
-            function openDatePicker(field, isStart) {
-                activeDateField = field
-                activeIsStart = isStart
-
-                // If we already have a selected date, open the calendar focused on it.
-                var dateStr = isStart ? filterStartDate : filterEndDate
-                calendar.setDate(dateStr)
-
-                var pos = field.mapToItem(parent, 0, field.height + 6)
-                calendar.errorMessage = ""
-                datePopup.x = Math.max(0, Math.min(pos.x, parent.width - datePopup.width))
-                datePopup.y = pos.y
-
-                datePopup.open()
-            }
-
-            Popup {
-                id: datePopup
-                modal: true
-                focus: true
-                padding: 4
-                closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutside
-
-                Overlay.modal: Rectangle {
-                    color: "transparent"
-                }
-
-                Overlay.modeless: Rectangle {
-                    color: "transparent"
-                }
-
-                background: Rectangle {
-                    radius: 8
-                    color: Style.colors.primaryBackground
-                    border.width: 1
-                    border.color: Style.colors.primaryBorder
-                }
-
-                implicitWidth: calendar.implicitWidth + padding * 2
-                implicitHeight: calendar.implicitHeight + padding * 2
-
-                contentItem: Column {
-                    spacing: 4
-
-                    Calendar {
-                        id: calendar
-
-                        function commitDate(date) {
-                            if (!headerRow.activeDateField)
-                                return
-
-                            var formatted = calendar.dateToString(date)
-                            calendar.errorMessage = ""
-
-                            if (headerRow.activeIsStart) {
-                                if (headerRow.filterEndDate && formatted > headerRow.filterEndDate) {
-                                    calendar.errorMessage = "Start date cannot be greater than end date"
-                                    return
-                                }
-
-                                headerRow.filterStartDate = formatted
-                            } else {
-                                if (headerRow.filterStartDate && formatted < headerRow.filterStartDate) {
-                                    calendar.errorMessage = "End date cannot be less than start date"
-                                    return
-                                }
-
-                                headerRow.filterEndDate = formatted
-                            }
-
-                            headerRow.applyFilter()
-                            datePopup.close()
-                        }
-
-                        onDateSelected: commitDate(calendar.selectedDate)
-
-                        onClearRequested: {
-                            if (headerRow.activeIsStart)
-                                headerRow.filterStartDate = ""
-                            else
-                                headerRow.filterEndDate = ""
-
-                            headerRow.applyFilter()
-                            datePopup.close()
-                        }
-                    }
-                }
-            }
-
-            TextField {
-                id: textFilterField
-                placeholderTextColor: Style.colors.descriptionText
-                backgroundColor: textFilterField.hovered ? Style.colors.cardBackground : Style.colors.secondaryBackground
-                Layout.fillWidth: true
-                minHeight: 25
-                placeholderText: {
-                    var selectedItems = filterOptionsPopup.selectedItems
-                    var selected = (selectedItems && selectedItems.length > 0)
-                            ? selectedItems.map(function(it) { return it.text }).join(", ")
-                            : ""
-                    return selected.length > 0 ? ("Write Filter By " + selected) : "Write Filter By"
-                }
-                text: parent.filterText
-                font.family: Style.fontTypes.roboto
-                font.weight: 400
-                font.pixelSize: 9
-                borderRadius: 5
-                borderWidth: 0
-                focusBorderWidth: 1
-                onTextChanged: {
-                    parent.filterText = text
-                    parent.applyFilter()
-                }
-            }
-
-            ToolButton {
-                id: filterButton
-                Layout.preferredWidth: 25
-                Layout.preferredHeight: 25
-                hoverEnabled: true
-
-                text: Style.icons.filter
-                font.family: (filterOptionsPopup.visible || filterButton.hovered)
-                             ? Style.fontTypes.font6ProSolid
-                             : Style.fontTypes.font6Pro
-                font.pixelSize: 14
-
-                contentItem: Text {
-                    anchors.centerIn: parent
-                    text: filterButton.text
-                    font: filterButton.font
-                    color: filterButton.enabled ? Style.colors.foreground : Style.colors.mutedText
-                    horizontalAlignment: Text.AlignHCenter
-                    verticalAlignment: Text.AlignVCenter
-                }
-
-                background: Rectangle {
-                    radius: 5
-                    color: !filterButton.enabled ? Style.colors.primaryBackground :
-                           filterButton.down ? Style.colors.surfaceMuted :
-                           filterButton.hovered ? Style.colors.cardBackground : Style.colors.secondaryBackground
-                }
-
-                onClicked: filterOptionsPopup.open()
-            }
-
-            ItemSelectorPopup {
-                id: filterOptionsPopup
-
-                // Position under the filter icon
-                x: filterButton.x
-                y: filterButton.y + filterButton.height + 6
-
-                model: filterOptionsModel
-
-                onOpened: {
-                    x = Math.max(0, Math.min(x, parent.width - width))
-                }
-
-                onSelectionChanged: function(items) {
-                    headerRow.applyFilter()
-                }
-            }
-
-            ListModel {
-                id: filterOptionsModel
-                ListElement { text: "Messages"; checked: false }
-                ListElement { text: "Subjects"; checked: false }
-                ListElement { text: "Authors"; checked: false }
-                ListElement { text: "Emails"; checked: false }
-                ListElement { text: "SHA-1"; checked: false }
-            }
-
-            Label {
-                Layout.leftMargin: headerRow.compact ? 8 : 40
-                color: Style.colors.descriptionText
-                text: "From:"
-                font.family: Style.fontTypes.roboto
-                font.weight: 400
-                font.pixelSize: 12
-            }
-
-            Item {
-                Layout.preferredWidth: headerRow.compact ? 22 : 90
-                Layout.preferredHeight: 25
-
-                TextField {
-                    id: startDateField
-                    placeholderTextColor: Style.colors.descriptionText
-                    backgroundColor: startDateFieldMouseArea.containsMouse ? Style.colors.cardBackground : Style.colors.secondaryBackground
-                    anchors.fill: parent
-                    minHeight: 25
-                    rightPadding: (startDateCaret.width + 5)
-                    placeholderText: headerRow.compact ? "" : "2025-08-30"
-                    text: headerRow.compact ? "" : headerRow.filterStartDate
-                    font.family: Style.fontTypes.roboto
-                    font.weight: 400
-                    font.pixelSize: 10
-                    borderRadius: 5
-                    borderWidth: 0
-                    focusBorderWidth: 1
-                    readOnly: true
-                    enabled: text.trim().length > 0
-                }
-
-                RoniaTextIcon {
-                    id: startDateCaret
-                    anchors.right: parent.right
-                    anchors.rightMargin: 6
-                    anchors.verticalCenter: parent.verticalCenter
-                    width: 12
-                    height: 12
-                    text: Style.icons.caretDown
-                    font.pixelSize: 15
-                    color: Style.colors.descriptionText
-                }
-
-                MouseArea {
-                    id: startDateFieldMouseArea
-                    anchors.fill: parent
-                    acceptedButtons: Qt.LeftButton
-                    hoverEnabled: true
-                    onClicked: headerRow.openDatePicker(startDateField, true)
-                }
-            }
-
-            Label {
-                color: Style.colors.descriptionText
-                text: "To:"
-                font.family: Style.fontTypes.roboto
-                font.weight: 400
-                font.pixelSize: 12
-            }
-
-            Item {
-                Layout.preferredWidth: headerRow.compact ? 22 : 90
-                Layout.preferredHeight: 25
-
-                TextField {
-                    id: endDateField
-                    placeholderTextColor: Style.colors.descriptionText
-                    backgroundColor: endDateFieldMouseArea.containsMouse ? Style.colors.cardBackground : Style.colors.secondaryBackground
-                    anchors.fill: parent
-                    minHeight: 25
-                    rightPadding: (endDateCaret.width + 5)
-                    placeholderText: headerRow.compact ? "" : "2025-09-30"
-                    text: headerRow.compact ? "" : headerRow.filterEndDate
-                    font.family: Style.fontTypes.roboto
-                    font.weight: 400
-                    font.pixelSize: 10
-                    borderRadius: 5
-                    borderWidth: 0
-                    focusBorderWidth: 1
-                    readOnly: true
-                    enabled: text.trim().length > 0
-                }
-
-                RoniaTextIcon {
-                    id: endDateCaret
-                    anchors.right: parent.right
-                    anchors.rightMargin: 6
-                    anchors.verticalCenter: parent.verticalCenter
-                    width: 12
-                    height: 12
-                    text: Style.icons.caretDown
-                    font.pixelSize: 15
-                    color: Style.colors.descriptionText
-                }
-
-                MouseArea {
-                    id: endDateFieldMouseArea
-                    anchors.fill: parent
-                    acceptedButtons: Qt.LeftButton
-                    hoverEnabled: true
-                    onClicked: headerRow.openDatePicker(endDateField, false)
-                }
-            }
-
-            ComboBox {
-                id: columnCombo
-                model: parent.navigationRules
-
-                Layout.leftMargin: headerRow.compact ? 6 : 20
-                minHeight: 26
-                visible: !headerRow.compact
-                borderWidth: 0
-                focusBorderWidth: 1
-                font.family: Style.fontTypes.roboto
-                font.weight: 400
-                font.pixelSize: 10
-
-                Material.background: Style.colors.primaryBackground
-                Material.foreground: Style.colors.secondaryText
-
-                background: Rectangle {
-                    radius: 5
-                    color: columnCombo.hovered ? Style.colors.cardBackground : Style.colors.secondaryBackground
-                }
-
-                Layout.preferredWidth: 90
-                currentIndex: parent.navigationRules.indexOf(parent.navigationRule)
-                onActivated: function(index) {
-                    parent.navigationRule = parent.navigationRules[index]
-                    parent.applyFilter()
-                }
-            }
-
-            ToolButton {
-                id: downButton
-                Layout.preferredWidth: 26
-                Layout.preferredHeight: 26
-
-                visible: !headerRow.compact
-                enabled: !!commitGraph
-                hoverEnabled: true
-
-                text: Style.icons.caretDown
-                font.family: Style.fontTypes.font6ProSolid
-                font.pixelSize: 15
-
-                contentItem: Text {
-                    anchors.centerIn: parent
-                    text: downButton.text
-                    font: downButton.font
-                    color: downButton.enabled ? Style.colors.foreground : Style.colors.mutedText
-                    horizontalAlignment: Text.AlignHCenter
-                    verticalAlignment: Text.AlignVCenter
-                }
-
-                background: Rectangle {
-                    radius: 5
-                    color: !downButton.enabled ? Style.colors.primaryBackground :
-                           downButton.down ? Style.colors.surfaceMuted :
-                           downButton.hovered ? Style.colors.cardBackground : Style.colors.secondaryBackground
-                }
-
-                onClicked: commitGraph.selectNext(navigationRule)
-            }
-
-            ToolButton {
-                id: upButton
-                Layout.preferredWidth: 26
-                Layout.preferredHeight: 26
-
-                visible: !headerRow.compact
-                enabled: !!commitGraph
-                hoverEnabled: true
-
-                text: Style.icons.caretUp
-                font.family: Style.fontTypes.font6ProSolid
-                font.pixelSize: 15
-
-                contentItem: Text {
-                    anchors.centerIn: parent
-                    text: upButton.text
-                    font: upButton.font
-                    color: upButton.enabled ? Style.colors.foreground : Style.colors.mutedText
-                    horizontalAlignment: Text.AlignHCenter
-                    verticalAlignment: Text.AlignVCenter
-                }
-
-                background: Rectangle {
-                    radius: 5
-                    color: !upButton.enabled ? Style.colors.primaryBackground :
-                           upButton.down ? Style.colors.surfaceMuted :
-                           upButton.hovered ? Style.colors.cardBackground : Style.colors.secondaryBackground
-                }
-
-                onClicked: commitGraph.selectPrevious(navigationRule)
-            }
-
-            ToolButton {
-                id: reloadButton
-                Layout.preferredWidth: 26
-                Layout.preferredHeight: 26
-                Layout.leftMargin: 10
-
-                enabled: !!commitGraph
-                hoverEnabled: true
-
-                text: Style.icons.refresh
-                font.family: Style.fontTypes.font6Pro
-                font.pixelSize: 14
-
-                contentItem: Text {
-                    anchors.centerIn: parent
-                    text: reloadButton.text
-                    font: reloadButton.font
-                    color: reloadButton.enabled ? Style.colors.foreground : Style.colors.mutedText
-                    horizontalAlignment: Text.AlignHCenter
-                    verticalAlignment: Text.AlignVCenter
-                }
-
-                background: Rectangle {
-                    radius: 5
-                    color: !reloadButton.enabled ? Style.colors.primaryBackground :
-                           reloadButton.down ? Style.colors.surfaceMuted :
-                           reloadButton.hovered ? Style.colors.cardBackground : Style.colors.secondaryBackground
-                }
-
-                onClicked: {
-                    commitGraph.reloadAll()
-                    root.headHash = commitController.getHeadHash()
-                }
-
-            }
         }
     }
 
@@ -508,40 +66,22 @@ Item {
 
             CommitGraphDock {
                 id: commitGraph
-                repositoryController: root.repositoryController
-                appModel: root.appModel
-                branchController: root.branchController
-                mergeController: root.mergeController
-                rebaseController: root.rebaseController
-                cherryPickController: root.cherryPickController
-                addBranchPopup: uiSessionPopups.addBranchPopup
-                addTagPopup: uiSessionPopups.addTagPopup
-                commitController: root.commitController
-                statusController: root.statusController
-                notificationController: root.notificationController
-                stashController: root.stashController
-                conflictController: root.conflictController
 
-                onCommitClicked: function(commitId) {
-                    root.selectedCommit = commitId;
+                repositoryController    : root.repositoryController
+                appModel                : root.appModel
+                branchController        : root.branchController
+                mergeController         : root.mergeController
+                rebaseController        : root.rebaseController
+                cherryPickController    : root.cherryPickController
+                addBranchPopup          : uiSessionPopups.addBranchPopup
+                addTagPopup             : uiSessionPopups.addTagPopup
+                commitController        : root.commitController
+                statusController        : root.statusController
+                notificationController  : root.notificationController
+                stashController         : root.stashController
+                conflictController      : root.conflictController
 
-                    if(commitId !== "__uncommitted__")
-                        return
-
-                    let node = commitGraph.commits.find(c => c.hash === commitId);
-
-                    if (node && node.isUncommitted) {
-                        let res = statusController.status()
-
-                        if (!res.success || !res.data) {
-                            console.log("status failed:", res);
-                            fileChangesDock.files = [];
-                            return;
-                        }
-
-                        fileChangesDock.files = res.data;
-                    }
-                }
+                onCommitClicked: function(commitId) { Presenter.handleCommitClicked(commitId) }
             }
         }
 
@@ -551,48 +91,10 @@ Item {
             FileChangesDock {
                 id: fileChangesDock
 
-                repositoryController : root.repositoryController
+                repositoryController: root.repositoryController
                 statusController: root.statusController
 
-                onFileSelected: function(filePath) {
-                    root.selectedFilePath = filePath
-
-                    let commitId = root.selectedCommit
-                    let node = commitGraph.commits.find(c => c.hash === commitId)
-
-                    let res = null
-
-                    if (commitId === "__uncommitted__" || (node && node.isUncommitted)) { // UNCOMMITTED COMMITS
-                        let headHash = statusController.getHeadHash()
-
-                        if (!headHash) {
-                            console.log("HEAD is null -> cannot diff uncommitted")
-                            return
-                        }
-
-                        res = statusController.getWorkingDirectoryDiff(headHash, filePath)
-                    }
-                    else { // NORMAL COMMITS
-                        let parentHash = ""
-
-                        if (node && node.isStash && node.stashParentId) {
-                            parentHash = node.stashParentId
-                        } else {
-                            parentHash = commitController.getParentHash(commitId)
-                        }
-
-                        if (!parentHash || !commitId) {
-                            console.log("Invalid diff inputs:", parentHash, commitId)
-                            return
-                        }
-
-                        res = statusController.getDiff(parentHash, commitId, filePath)
-                    }
-
-                    if (res && res.success) {
-                        diffView.diffData = res.data
-                    }
-                }
+                onFileSelected: function(filePath) { Presenter.handleFileSelected(filePath) }
             }
 
             DiffView {
@@ -600,5 +102,15 @@ Item {
                 readOnly: true
             }
         }
+    }
+
+    function initPresenter() {
+        Presenter.init({
+            commitGraph     : commitGraph,
+            fileChangesDock : fileChangesDock,
+            diffView        : diffView,
+            statusController: statusController,
+            commitController: commitController
+        })
     }
 }

--- a/Qml/Pages/GraphViewPage.qml
+++ b/Qml/Pages/GraphViewPage.qml
@@ -138,15 +138,27 @@ Item {
             return
         }
 
-        if (!statusController || !commitController) {
-                notificationController.error("Cannot initialize Graph View: required controllers are missing.",
-                                             "Initialization Error", 4000)
-            return
-        }
+        var missing = []
 
-        if (!commitGraph || !fileChangesDock || !diffView) {
-                notificationController.error("GraphViewPage: missing required UI components",
-                                             "Initialization Error", 4000)
+        if (!appModel)               missing.push("AppModel")
+        if (!branchController)       missing.push("BranchController")
+        if (!commitController)       missing.push("CommitController")
+        if (!statusController)       missing.push("StatusController")
+        if (!repositoryController)   missing.push("RepositoryController")
+        if (!notificationController) missing.push("NotificationController")
+        if (!stashController)        missing.push("StashController")
+        if (!mergeController)        missing.push("MergeController")
+        if (!rebaseController)       missing.push("RebaseController")
+        if (!cherryPickController)   missing.push("CherryPickController")
+        if (!conflictController)     missing.push("ConflictController")
+        if (!addBranchPopup)         missing.push("AddBranchPopup")
+        if (!addTagPopup)            missing.push("AddTagPopup")
+
+        if (missing.length > 0) {
+            notificationController.error(
+                    "Commit Graph cannot work correctly – missing: " + missing.join(", "),
+                    "Initialization Error", 5000
+            )
             return
         }
 

--- a/Qml/Pages/GraphViewPage.qml
+++ b/Qml/Pages/GraphViewPage.qml
@@ -16,7 +16,8 @@ import "qrc:/GitEase/Qml/Core/Scripts/GraphViewPresenter.js" as Presenter
 Item {
     id: root
 
-    /* Property Declarations */
+    /* Property Declarations
+     * ****************************************************************************************/
     property var                    page                    : null
     property AppModel               appModel                : null
 
@@ -32,15 +33,38 @@ Item {
     property RebaseController       rebaseController        : null
     property CherryPickController   cherryPickController    : null
 
-    property alias graphRef: commitGraph
 
+
+    /* Object Properties
+     * ****************************************************************************************/
     anchors.fill: parent
+
+    property alias graphRef: commitGraph
 
     // Header exposed to MainWindow
     property Component headerContent: Component {
         GraphViewHeader {
             id: graphViewHeader
-            commitGraph: root.graphRef
+
+            isGraphReady: root.graphRef !== null
+
+            onFilterRequested: function(text, startDate, endDate, modes) {
+                if (root.graphRef) {
+                    root.graphRef.applyFilter(text, startDate, endDate, modes);
+                }
+            }
+
+            onNextRequested: function(rule) {
+                root.graphRef.selectNext(rule);
+            }
+
+            onPreviousRequested: function(rule) {
+                root.graphRef.selectPrevious(rule);
+            }
+
+            onReloadRequested: function() {
+                root.graphRef.reloadAll();
+            }
         }
     }
 
@@ -56,6 +80,8 @@ Item {
         }
     }
 
+    /* Children
+     * ****************************************************************************************/
     ColumnLayout {
         anchors.fill: parent
         spacing: 0
@@ -104,6 +130,8 @@ Item {
         }
     }
 
+    /* Functions
+     * ****************************************************************************************/
     function initPresenter() {
         Presenter.init({
             commitGraph     : commitGraph,

--- a/Qml/Pages/GraphViewPage.qml
+++ b/Qml/Pages/GraphViewPage.qml
@@ -145,14 +145,11 @@ Item {
         if (!commitController)       missing.push("CommitController")
         if (!statusController)       missing.push("StatusController")
         if (!repositoryController)   missing.push("RepositoryController")
-        if (!notificationController) missing.push("NotificationController")
         if (!stashController)        missing.push("StashController")
         if (!mergeController)        missing.push("MergeController")
         if (!rebaseController)       missing.push("RebaseController")
         if (!cherryPickController)   missing.push("CherryPickController")
         if (!conflictController)     missing.push("ConflictController")
-        if (!addBranchPopup)         missing.push("AddBranchPopup")
-        if (!addTagPopup)            missing.push("AddTagPopup")
 
         if (missing.length > 0) {
             notificationController.error(

--- a/Qml/View/Components/Docks/CommitGraphDock.qml
+++ b/Qml/View/Components/Docks/CommitGraphDock.qml
@@ -865,77 +865,58 @@ DetachablePanel {
     function executeMergeBranch(source, target) {
         mergeMethodPopup.sourceBranch = source
         mergeMethodPopup.targetBranch = target
+
         mergeMethodPopup.accepted.connect(function(noFF) {
             var res = root.mergeController.mergeBranchIntoCurrent(source, noFF)
+
             if (root.mergeController.hasMergeConflicts()) {
                 mergeConflictPopup.open()
-                if (root.notificationController) root.notificationController.warning("Merge conflicts detected.", "Merge", 4000)
-            } else if (!res.success) {
-                if (root.notificationController) root.notificationController.error(res.errorMessage || "Merge failed", "Merge", 5000)
+
+                root.notificationController.warning("Merge conflicts detected.", "Merge", 4000)
+
+                root.reloadAll()
             } else {
-                if (root.notificationController) root.notificationController.success("Merge completed", "Merge", 3000)
+                handleGitControllerResult(res, "Merge completed", mergeConflictPopup, "Merge")
             }
+
             mergeMethodPopup.accepted.disconnect(arguments.callee)
-            root.reloadAll()
         })
+
         mergeMethodPopup.open()
     }
 
     function executeRebase(commitHash) {
-        var res = root.rebaseController.rebase(commitHash)
-        if (res && res.success) {
-            root.notificationController.success("Rebase completed", "Rebase", 3000)
-        }
+        var res = rebaseController.rebase(commitHash);
 
-        else if (res && res.data && (res.data.status === "conflict" || res.data.hasConflicts)) {
-            rebaseConflictPopup.open()
-            root.notificationController.warning("Rebase conflicts detected.", "Rebase", 4000)
-        }
-
-        else {
-            root.notificationController.error(res ? res.errorMessage : "Rebase failed", "Rebase", 5000)
-        }
-
-        root.reloadAll()
+        handleGitControllerResult(res, "Rebase completed", rebaseConflictPopup, "Rebase");
     }
 
     function executeCherryPickSelected() {
-        console.log("2")
-        var hashes = selectedCommitHashesInOrder()
-        var res = root.cherryPickController.cherryPickCommits(hashes)
-        if (res && res.success) {
-            root.notificationController.success("Cherry-pick completed", "Cherry-Pick", 3000)
-        }
+        var hashes  = selectedCommitHashesInOrder();
+        var res     = cherryPickController.cherryPickCommits(hashes);
 
-        else if (res && res.data && (res.data.status === "conflict" || res.data.hasConflicts)) {
-            cherryPickConflictPopup.open()
-            root.notificationController.warning("Cherry-pick conflicts detected.", "Cherry-Pick", 4000)
-        }
-
-        else {
-            root.notificationController.error(res ? res.errorMessage : "Cherry-pick failed", "Cherry-Pick", 5000)
-        }
-
-        root.reloadAll()
+        handleGitControllerResult(res, "Cherry-pick completed", cherryPickConflictPopup, "Cherry-Pick");
     }
 
     function executeCherryPickSingle(commitHash) {
-        console.log("1")
-        var res = root.cherryPickController.cherryPickCommit(commitHash)
+        var res = cherryPickController.cherryPickCommit(commitHash);
+
+        handleGitControllerResult(res, "Cherry-pick completed", cherryPickConflictPopup, "Cherry-Pick");
+    }
+
+    function handleGitControllerResult(res, successMsg, conflictPopup, commandName) {
         if (res && res.success) {
-            if (root.notificationController) root.notificationController.success("Cherry-pick completed", "Cherry-Pick", 3000)
+            notificationController.success(successMsg, commandName, 3000)
         }
-
         else if (res && res.data && (res.data.status === "conflict" || res.data.hasConflicts)) {
-            cherryPickConflictPopup.open()
-            root.notificationController.warning("Cherry-pick conflicts detected.", "Cherry-Pick", 4000)
+            conflictPopup.open();
+            notificationController.warning(commandName + " conflicts detected.", commandName, 4000);
         }
-
         else {
-            root.notificationController.error(res ? res.errorMessage : "Cherry-pick failed", "Cherry-Pick", 5000)
+            notificationController.error(res ? res.errorMessage : commandName + " failed", commandName, 5000);
         }
 
-        root.reloadAll()
+        root.reloadAll();
     }
 
     function handleItemDoubleClick(data, button, modifiers, idx) {

--- a/Qml/View/Components/Docks/CommitGraphDock.qml
+++ b/Qml/View/Components/Docks/CommitGraphDock.qml
@@ -2,43 +2,360 @@ import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
 
+import GitEase
 import GitEase_Style
 import GitEase_Style_Impl
-import GitEase
 
-import "qrc:/GitEase/Qml/Core/Scripts/GraphLayout.js" as GraphLayout
-import "qrc:/GitEase/Qml/Core/Scripts/GraphUtils.js" as GraphUtils
+import "qrc:/GitEase/Qml/Core/Scripts/GraphLayout.js"            as GraphLayout
+import "qrc:/GitEase/Qml/Core/Scripts/GraphUtils.js"             as GraphUtils
+import "qrc:/GitEase/Qml/Core/Scripts/CommitGraphDataLoader.js"  as DataLoader
+import "qrc:/GitEase/Qml/Core/Scripts/CommitGraphFilter.js"      as Filter
+import "qrc:/GitEase/Qml/Core/Scripts/CommitGraphNavigation.js"  as Navigation
+import "qrc:/GitEase/Qml/Core/Scripts/CommitGraphMenuBuilder.js" as MenuBuilder
 
 /*! ***********************************************************************************************
  * CommitGraphDock
- * show graph and commits
  * ************************************************************************************************/
+
 DetachablePanel {
-    id : root
+    id: root
 
-    property AppModel appModel: null
+    /* Property Declarations
+     * ****************************************************************************************/
+    property AppModel               appModel                : null
 
-    property BranchController branchController: null
+    property BranchController       branchController        : null
+    property MergeController        mergeController         : null
+    property RebaseController       rebaseController        : null
+    property CherryPickController   cherryPickController    : null
+    property ConflictController     conflictController      : null
+    property TagController          tagController           : null
+    property StatusController       statusController        : null
+    property CommitController       commitController        : null
+    property RepositoryController   repositoryController    : null
+    property NotificationController notificationController  : null
+    property StashController        stashController         : null
 
-    property MergeController mergeController: null
-    property RebaseController rebaseController: null
-    property CherryPickController cherryPickController: null
+    property AddBranchPopup         addBranchPopup          : null
+    property AddTagPopup            addTagPopup             : null
 
-    property ConflictController conflictController: null
 
-    property AddBranchPopup addBranchPopup: null
+    property var    allCommits      : []
+    property var    commits         : []
+    property var    allCommitsHash  : ({})
+    property string headHash        : ""
 
-    property AddTagPopup addTagPopup: null
+    property var selectedCommitHashes   : []
+    property var selectedCommit         : null
+    property int lastSelectedIndex      : -1
 
-    property StatusController statusController: null
+    property string navigationRule  : "Message"
+    property string filterText      : ""
+    property string filterStartDate : ""
+    property string filterEndDate   : ""
+    property var    filterMode      : []
 
-    property CommitController commitController: null
+    property int    pageSize        : 200
+    property int    commitsOffset   : 0
+    property bool   isLoadingMore   : false
+    property bool   hasMoreCommits  : true
 
-    property RepositoryController repositoryController: null
-    
-    property NotificationController notificationController: null
+    property var commitPositions    : ({})
+    property int commitItemHeight   : 24
+    property int commitItemSpacing  : 4
+    property int columnSpacing      : 30
 
-    property StashController stashController: null
+    property int commitsColGraphWidth       : parent.width * 0.08
+    property int commitsColBranchTagWidth   : parent.width * 0.17
+    property int commitsColMessageWidth     : parent.width * 0.6
+    property int commitsColAuthorWidth      : parent.width * 0.08
+    property int commitsColDateWidth        : parent.width * 0.17
+
+    readonly property int minColGraphWidth      : 60
+    readonly property int minColBranchTagWidth  : 80
+    readonly property int minColMessageWidth    : 100
+    readonly property int minColAuthorWidth     : 60
+    readonly property int minColDateWidth       : 80
+
+    readonly property bool hasAnyFilter         : Filter.hasAnyFilter(root.filterText, root.filterStartDate, root.filterEndDate)
+
+    /* Signals
+     * ****************************************************************************************/
+    signal commitClicked(string commitId)
+
+    /* Object Properties
+     * ****************************************************************************************/
+    title: qsTr("Commit Graph")
+
+    /* Children
+     * ****************************************************************************************/
+    Rectangle {
+        anchors.fill: parent
+        color: Style.colors.primaryBackground
+
+        EmptyStateView {
+            title: "no commit to show"
+            details: root.emptyStateDetailsText()
+            visible: !root.commits || root.commits.length === 0
+        }
+
+        ColumnLayout {
+            anchors.fill: parent
+            spacing: 0
+
+            Rectangle {
+                Layout.fillWidth: true
+                Layout.preferredHeight: (commits && commits.length > 0) ? 30 : 0
+                visible: commits && commits.length > 0
+                color: Style.colors.primaryBackground
+
+                RowLayout {
+                    anchors.fill: parent
+                    spacing: 0
+
+                    ResizableColumnHeader {
+                        Layout.preferredWidth: root.commitsColGraphWidth
+                        label: "Graph"
+                        onResized: function(delta) {
+                            var newWidth = Math.max(root.minColGraphWidth, root.commitsColGraphWidth + delta)
+                            var actualDelta = newWidth - root.commitsColGraphWidth
+                            var nextWidth = root.commitsColBranchTagWidth - actualDelta
+                            if (nextWidth < root.minColBranchTagWidth) {
+                                nextWidth = root.minColBranchTagWidth
+                                newWidth = root.commitsColGraphWidth + (root.commitsColBranchTagWidth - root.minColBranchTagWidth)
+                            }
+                            root.commitsColGraphWidth = newWidth
+                            root.commitsColBranchTagWidth = nextWidth
+                        }
+                    }
+
+                    ResizableColumnHeader {
+                        Layout.preferredWidth: root.commitsColBranchTagWidth
+                        label: "Branch/Tag"
+                        onResized: function(delta) {
+                            var newWidth = Math.max(root.minColBranchTagWidth, root.commitsColBranchTagWidth + delta)
+                            var actualDelta = newWidth - root.commitsColBranchTagWidth
+                            var nextWidth = root.commitsColMessageWidth - actualDelta
+                            if (nextWidth < root.minColMessageWidth) {
+                                nextWidth = root.minColMessageWidth
+                                newWidth = root.commitsColBranchTagWidth + (root.commitsColMessageWidth - root.minColMessageWidth)
+                            }
+                            root.commitsColBranchTagWidth = newWidth
+                            root.commitsColMessageWidth = nextWidth
+                        }
+                    }
+
+                    ResizableColumnHeader {
+                        Layout.preferredWidth: root.commitsColMessageWidth
+                        label: "Message"
+                        onResized: function(delta) {
+                            var newWidth = Math.max(root.minColMessageWidth, root.commitsColMessageWidth + delta)
+                            var actualDelta = newWidth - root.commitsColMessageWidth
+                            var nextWidth = root.commitsColAuthorWidth - actualDelta
+                            if (nextWidth < root.minColAuthorWidth) {
+                                nextWidth = root.minColAuthorWidth
+                                newWidth = root.commitsColMessageWidth + (root.commitsColAuthorWidth - root.minColAuthorWidth)
+                            }
+                            root.commitsColMessageWidth = newWidth
+                            root.commitsColAuthorWidth = nextWidth
+                        }
+                    }
+
+                    ResizableColumnHeader {
+                        Layout.preferredWidth: root.commitsColAuthorWidth
+                        label: "Author"
+                        onResized: function(delta) {
+                            var newWidth = Math.max(root.minColAuthorWidth, root.commitsColAuthorWidth + delta)
+                            var actualDelta = newWidth - root.commitsColAuthorWidth
+                            var nextWidth = root.commitsColDateWidth - actualDelta
+                            if (nextWidth < root.minColDateWidth) {
+                                nextWidth = root.minColDateWidth
+                                newWidth = root.commitsColAuthorWidth + (root.commitsColDateWidth - root.minColDateWidth)
+                            }
+                            root.commitsColAuthorWidth = newWidth
+                            root.commitsColDateWidth = nextWidth
+                        }
+                    }
+
+                    Rectangle {
+                        Layout.preferredWidth: root.commitsColDateWidth
+                        Layout.fillHeight: true
+                        color: Style.colors.primaryBackground
+                        Label {
+                            anchors.left: parent.left
+                            anchors.verticalCenter: parent.verticalCenter
+                            text: "Date"
+                            color: Style.colors.foreground
+                            font.pixelSize: 11
+                            font.bold: true
+                        }
+                    }
+                }
+            }
+
+            RowLayout {
+                Layout.fillWidth: true
+                Layout.fillHeight: true
+                spacing: 0
+
+                Flickable {
+                    id: graphFlickable
+                    Layout.preferredWidth: root.commitsColGraphWidth + root.commitsColBranchTagWidth
+                    Layout.fillHeight: true
+                    contentWidth: children[0].width
+                    contentHeight: children[0].height
+                    clip: true
+                    interactive: false
+                    contentY: commitsListView.contentY
+                    flickableDirection: Flickable.VerticalFlick
+
+                    MouseArea {
+                        anchors.fill: parent
+                        onWheel: function(wheel) {
+                            var newY = commitsListView.contentY - wheel.angleDelta.y
+                            var maxY = Math.max(0, commitsListView.contentHeight - commitsListView.height)
+                            commitsListView.contentY = Math.max(0, Math.min(newY, maxY))
+                        }
+                    }
+
+                    CommitGraphCanvas {
+                        id: graphCanvas
+                        width: root.commitsColGraphWidth + root.commitsColBranchTagWidth
+                        height: Math.max(commitsListView.contentHeight, graphFlickable.height)
+                        commits: root.commits
+                        commitPositions: root.commitPositions
+                        columnSpacing: root.columnSpacing
+                        commitItemHeight: root.commitItemHeight
+                        commitItemSpacing: root.commitItemSpacing
+                        selectedHashes: root.selectedCommitHashes
+                        headHash: root.headHash
+                        showAvatar: root.appModel?.appSettings?.generalSettings?.showAvatar ?? true
+                        graphColumnWidth: root.commitsColGraphWidth
+                        branchTagColumnWidth: root.commitsColBranchTagWidth
+                        allCommitsHash: root.allCommitsHash
+                        onInfiniteScroll: root.loadMoreCommits()
+                    }
+                }
+
+                ListView {
+                    id: commitsListView
+
+                    Layout.fillWidth    : true
+                    Layout.fillHeight   : true
+                    Layout.minimumWidth : 100
+
+                    model   : root.commits
+                    clip    : true
+
+                    delegate: CommitListDelegate {
+                        height: root.commitItemHeight + root.commitItemSpacing * 2
+
+                        messageWidth: root.commitsColMessageWidth
+                        authorWidth : root.commitsColAuthorWidth
+                        dateWidth   : root.commitsColDateWidth
+
+                        indicatorColor: {
+                            if (modelData && modelData.isUncommitted)
+                                return "#888888"
+
+                            if (!modelData || !modelData.colorKey)
+                                return GraphUtils.getCategoryColor("default")
+
+                            return GraphUtils.getCategoryColor(modelData.colorKey)
+                        }
+
+                        isSelected  : root.isCommitSelected(modelData.hash)
+                        isHead      : modelData ? modelData.hash === root.headHash  : false
+                        isStash     : modelData ? modelData.isStash === true        : false
+                        parentRoot  : root
+
+                        onItemClicked: function(button, modifiers, idx, mouseX, mouseY) {
+                            root.handleItemClick(modelData, button, modifiers, idx, mouseX, mouseY)
+                        }
+
+                        onItemDoubleClicked: function(button, modifiers, idx) {
+                            root.handleItemDoubleClick(modelData, button, modifiers, idx)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    ContextMenu {
+        id: contextMenu
+        width: 250
+    }
+
+    Connections {
+        target: Style
+        function onCurrentThemeChanged() {
+            graphCanvas.requestPaint()
+        }
+    }
+
+    Connections {
+        target: root.repositoryController
+        function onRepositorySelected() {
+            root.reloadAll()
+        }
+    }
+
+    Connections {
+        target: root.addBranchPopup
+
+        function onBranchCreatedSuccessfully() {
+            root.selectedCommit         = null
+            root.selectedCommitHashes   = []
+            root.lastSelectedIndex      = -1
+            root.reloadAll()
+        }
+    }
+
+    Connections {
+        target: root.addTagPopup
+        function onTagCreatedSuccessfully() {
+            root.selectedCommit = null
+            root.reloadAll()
+        }
+    }
+
+    Connections {
+        target: root.appModel?.appSettings?.generalSettings ?? null
+        function onShowAvatarChanged() {
+            graphCanvas.requestPaint()
+        }
+
+        function onShowStashNodesChanged() {
+            root.refreshStashNodes()
+        }
+    }
+
+    Connections {
+        target: root
+        function onGraphColumnWidthChanged() {
+            graphCanvas.requestPaint()
+        }
+
+        function onBranchTagColumnWidthChanged() {
+            graphCanvas.requestPaint()
+        }
+    }
+
+    onRepositoryControllerChanged: root.reloadAll()
+
+    onStashControllerChanged: {
+        if (root.allCommits.length)
+            root.refreshStashNodes()
+    }
+
+    onAllCommitsChanged: {
+        root.allCommitsHash = {}
+        for (var i = 0; i < root.allCommits.length; i++) {
+            var c = root.allCommits[i]
+            if (c && c.hash) root.allCommitsHash[c.hash] = c.hash
+        }
+    }
 
     ConflictPopup {
         id: mergeConflictPopup
@@ -47,12 +364,9 @@ DetachablePanel {
         conflictController: root.conflictController
         notificationController: root.notificationController
         statusController: root.statusController
-        onOperationCompleted: reloadAll()
     }
 
-    MergeMethodPopup {
-        id: mergeMethodPopup
-    }
+    MergeMethodPopup { id: mergeMethodPopup }
 
     ConflictPopup {
         id: rebaseConflictPopup
@@ -61,7 +375,6 @@ DetachablePanel {
         conflictController: root.conflictController
         notificationController: root.notificationController
         statusController: root.statusController
-        onOperationCompleted: reloadAll()
     }
 
     ConflictPopup {
@@ -71,73 +384,19 @@ DetachablePanel {
         conflictController: root.conflictController
         notificationController: root.notificationController
         statusController: root.statusController
-        onOperationCompleted: reloadAll()
     }
 
-    /* Property Declarations
-     * ****************************************************************************************/
-    // Full data set (unfiltered) vs displayed set (filtered)
-    property var allCommits: []
-    property var commits: []
-    property var selectedCommit: null
-    property var allCommitsHash: ({})
-    property string headHash: ""
-
-    property var selectedCommitHashes: []
-    property int lastSelectedIndex: -1
-
-    // navigation state
-    // navigationRule: one of ["Author Email", "Author", "Parent 1", "Branch"]
-    property string navigationRule: "Message"
-    // Dates are inclusive; accept empty string to disable bound. Format: YYYY-MM-DD
-    property string filterStartDate: ""
-    property string filterEndDate: ""
-    property string filterText: ""
-    property var filterMode: []  // Array of selected filter items: ["Messages", "Authors", etc.]
-
-    // Empty-state helper
-    readonly property bool hasAnyFilter: (root.filterText && root.filterText.trim().length > 0)
-                                          || (root.filterStartDate && root.filterStartDate.trim().length > 0)
-                                          || (root.filterEndDate && root.filterEndDate.trim().length > 0)
-
-    // Lazy loading (infinite scroll)
-    property int pageSize: 200
-    property int commitsOffset: 0
-    property bool isLoadingMore: false
-    property bool hasMoreCommits: true
-
-    property int graphColumnWidth: 0  // Will be calculated as half of dock width
-    property int commitItemHeight: 24  // Reduced spacing between commits
-    property int commitItemSpacing: 4
-    property int columnSpacing: 30  // Increased spacing between branch columns
-    property var commitPositions: ({})  // Cache for commit positions {hash: {x, y, column}}
-
-    // Property to receive list of CommitData objects
-    property int commitsColGraphWidth: parent.width * 0.08
-    property int commitsColBranchTagWidth: parent.width * 0.17
-    property int commitsColMessageWidth: parent.width * 0.6
-    property int commitsColAuthorWidth: parent.width * 0.08
-    property int commitsColDateWidth: parent.width * 0.17
-    
-    // Minimum widths for each column
-    readonly property int minColGraphWidth: 60
-    readonly property int minColBranchTagWidth: 80
-    readonly property int minColMessageWidth: 100
-    readonly property int minColAuthorWidth: 60
-    readonly property int minColDateWidth: 80
-
-    /* Object Properties
-     * ****************************************************************************************/
-    title: qsTr("Commit Graph")
-
-    /* Signals
-     * ****************************************************************************************/
-    signal commitClicked(string commitId)
+    CheckoutBranchSelectorPopup {
+        id: checkoutBranchSelector
+        property string commitHash: ""
+        onBranchSelected: function(branchName) {
+            root.handleCheckoutBranchOrCreate(branchName, checkoutBranchSelector.commitHash)
+        }
+    }
 
     /* Functions
      * ****************************************************************************************/
     function emptyStateDetailsText() {
-        // 1) No commits in repo at all
         if (!root.allCommits || root.allCommits.length === 0)
             return "This repository has no commits."
 
@@ -170,272 +429,121 @@ DetachablePanel {
         return "No commits match: " + parts.join(", ")
     }
 
-    function commitColor(commitObj) {
-        if (commitObj && commitObj.isUncommitted)
-            return "#888888";
-        if (!commitObj || !commitObj.colorKey)
-            return GraphUtils.getCategoryColor("default")
-        return GraphUtils.getCategoryColor(commitObj.colorKey)
+    function clearGraphCaches() {
+        GraphUtils.clearBranchColorCache()
+        GraphUtils.clearTagColorCache()
+        GraphUtils.clearCategoryColorCache()
     }
 
-    function edgeColor(edge, commitByHash) {
-        if (commitByHash && edge && edge.from) {
-            var fromCommit = commitByHash[edge.from]
-            if (fromCommit && fromCommit.colorKey)
-                return GraphUtils.getCategoryColor(fromCommit.colorKey)
-        }
-        return GraphUtils.getCategoryColor("edge:" + edge.from + ":" + edge.to)
-    }
-
-    function normalizeFilterString(str) {
-        return (str === null || str === undefined) ? "" : ("" + str)
-    }
-
-    function isCommitSelected(commitHash){
-        if(!commitHash || !root.selectedCommitHashes)
-            return false
-
-        return root.selectedCommitHashes.indexOf(commitHash) !== -1
-    }
-
-    function applySelection(commitData, index, modifiers){
-        if (!commitData || !commitData.hash)
-            return
-
-        if ((modifiers & Qt.ControlModifier) !== 0) {
-            toggleSelection(commitData, index)
-            return
-        }
-
-        if ((modifiers & Qt.ShiftModifier) !== 0 && root.lastSelectedIndex >= 0) {
-            selectRange(root.lastSelectedIndex, index)
-            return
-        }
-
-        setSingleSelection(commitData, index)
-    }
-
-    function setSingleSelection(commitData, index){
-        if(!commitData || !commitData.hash)
-            return
-
-        root.selectedCommitHashes = [commitData.hash]
-        root.lastSelectedIndex = index
-    }
-
-    function toggleSelection(commitData, index) {
-        if (!commitData || !commitData.hash)
-            return
-
-        var list = root.selectedCommitHashes ? root.selectedCommitHashes.slice(0) : []
-        var idx = list.indexOf(commitData.hash)
-        if (idx >= 0) {
-            list.splice(idx, 1)
-        } else {
-            list.push(commitData.hash)
-        }
-
-        root.selectedCommitHashes = list
-        root.lastSelectedIndex = index
-    }
-
-    function selectRange(anchorIndex, targetIndex) {
-        if (!root.commits || root.commits.length === 0)
-            return
-
-        var start = Math.min(anchorIndex, targetIndex)
-        var end = Math.max(anchorIndex, targetIndex)
-
-        var list = []
-        for (var i = start; i <= end; i++) {
-            var c = root.commits[i]
-            if (c && c.hash)
-                list.push(c.hash)
-        }
-
-        root.selectedCommitHashes = list
-    }
-
-    function selectedCommitHashesInOrder() {
-        var commits = selectedCommitsInOrder()
-        var hashes = []
-        for (var i = 0; i < commits.length; i++) {
-            hashes.push(commits[i].hash)
-        }
-        return hashes
-    }
-
-    function selectionHasStash() {
-        var commits = selectedCommitsInOrder()
-        for (var i = 0; i < commits.length; i++) {
-            if (commits[i].isStash)
-                return true
-        }
-        return false
-    }
-
-    function selectionHasHead() {
-        var commits = selectedCommitsInOrder()
-        for (var i = 0; i < commits.length; i++) {
-            if (commits[i].hash === root.headHash)
-                return true
-        }
-        return false
-    }
-
-    function selectedCommitsInOrder() {
-        var selected = []
-        if (!root.commits || !root.selectedCommitHashes)
-            return selected
-
-        for (var i = root.commits.length - 1; i >= 0; i--) {
-            var c = root.commits[i]
-
-            if (c && c.hash && isCommitSelected(c.hash)) {
-                selected.push(c)
-            }
-        }
-
-        return selected
-    }
-
-    function parseDateYYYYMMDD(str) {
-        // Returns milliseconds since epoch, or NaN if invalid.
-        // Accepts:
-        // - YYYY-MM-DD
-        // - YYYY/MM/DD (used by GraphViewPage placeholders)
-        if (str === null || str === undefined)
-            return NaN
-
-        str = ("" + str).trim()
-        if (str.length < 8)
-            return NaN
-
-        // Split on '-' or '/'
-        var parts = str.split(/[-\/]/)
-        if (parts.length !== 3)
-            return NaN
-
-        var y = parseInt(parts[0])
-        var m = parseInt(parts[1])
-        var d = parseInt(parts[2])
-        if (isNaN(y) || isNaN(m) || isNaN(d))
-            return NaN
-
-        // local time midnight
-        return new Date(y, m - 1, d, 0, 0, 0, 0).getTime()
-    }
-
-    /*!
-     * Application-level filter: checks if a commit matches based on selected filter modes
-     * Returns true if the commit matches the filter criteria
-     */
-    function applicationFilter(commit, needle, modes) {
-        if (!needle || needle.length === 0)
-            return true  // No text filter, matches all
-
-        // If no modes selected, default to "Messages"
-        var activeMode = (modes && modes.length > 0) ? modes : ["Messages"]
-        
-        // Check each active filter mode
-        for (var i = 0; i < activeMode.length; i++) {
-            var mode = activeMode[i]
-            var haystack = ""
-            
-            switch(mode) {
-                case "Messages":
-                    haystack = normalizeFilterString(commit.summary) + " " + normalizeFilterString(commit.message)
-                    break
-                case "Subjects":
-                    haystack = normalizeFilterString(commit.summary)
-                    break
-                case "Authors":
-                    haystack = normalizeFilterString(commit.author)
-                    break
-                case "Emails":
-                    haystack = normalizeFilterString(commit.authorEmail)
-                    break
-                case "SHA-1":
-                    haystack = normalizeFilterString(commit.hash)
-                    break
-                default:
-                    continue
-            }
-            
-            // If any mode matches, return true
-            if (haystack.toLowerCase().indexOf(needle) !== -1)
-                return true
-        }
-        
-        return false  // No mode matched
+    function layoutCommits(items) {
+        return GraphLayout.calculateDAGPositions(items, root.columnSpacing, root.commitItemHeight, root.commitItemSpacing)
     }
 
     function applyFilter(text, startDate, endDate, modes) {
         if (text !== undefined)
             root.filterText = text
+
         if (startDate !== undefined)
             root.filterStartDate = startDate
+
         if (endDate !== undefined)
             root.filterEndDate = endDate
+
         if (modes !== undefined)
             root.filterMode = modes
 
-        var base = root.allCommits || []
-        if (!base.length) {
-            loadData([])
+        var result = Filter.applyFilter(
+            root.allCommits,
+            root.filterText,
+            root.filterStartDate,
+            root.filterEndDate,
+            root.filterMode,
+            root.selectedCommitHashes
+        )
+
+        loadData(result.filtered)
+        root.selectedCommitHashes = result.stillSelected
+        if (!result.stillSelected.length) {
+            root.selectedCommit = null
+            root.lastSelectedIndex = -1
+        }
+
+        if (Filter.hasAnyFilter(root.filterText, root.filterStartDate, root.filterEndDate)) {
+            ensureMinimumResults()
+        }
+    }
+
+    function clearFilter() {
+        root.filterText         = ""
+        root.filterStartDate    = ""
+        root.filterEndDate      = ""
+        root.filterMode         = []
+        root.navigationRule     = "Message"
+        loadData(root.allCommits.slice(0))
+    }
+
+    function loadData(items) {
+        var positions = layoutCommits(items)
+        assignLaneColorKeys(items, positions)
+        root.commitPositions = positions
+        root.commits = items.slice(0)
+    }
+
+    function assignLaneColorKeys(items, positions) {
+        var colorKeyByHash = {}
+        for (var i = items.length - 1; i >= 0; i--) {
+            var c = items[i]
+            var pos = positions[c.hash]
+            if (!pos) continue
+
+            var inherited = ""
+            if (c.parentHashes && c.parentHashes.length) {
+                for (var p = 0; p < c.parentHashes.length; p++) {
+                    var parentHash = c.parentHashes[p]
+                    var parentPos = positions[parentHash]
+                    if (parentPos && parentPos.column === pos.column) {
+                        inherited = colorKeyByHash[parentHash] || ""
+                        break
+                    }
+                }
+            }
+
+            c.colorKey = inherited ? inherited : ("lane-seg:" + pos.column + ":" + c.hash)
+            colorKeyByHash[c.hash] = c.colorKey
+        }
+    }
+
+    function update() {
+        graphCanvas.requestPaint()
+    }
+
+    function reloadAll() {
+        if (!root.appModel || !root.appModel.currentRepository)
             return
-        }
 
-        var needle = normalizeFilterString(root.filterText).trim().toLowerCase()
+        clearGraphCaches()
+        commitsOffset   = 0
+        hasMoreCommits  = true
+        isLoadingMore   = false
 
-        var startMs = parseDateYYYYMMDD(root.filterStartDate)
-        var endMs = parseDateYYYYMMDD(root.filterEndDate)
+        var headRes = root.statusController ? root.statusController.getHeadHash() : null
+        root.headHash = (headRes && headRes.success) ? headRes.data : ""
 
-        if (!isNaN(endMs))
-            endMs = endMs + (24 * 60 * 60 * 1000) - 1
+        var commitRes = root.commitController.getCommits(pageSize, commitsOffset)
+        if (!commitRes.success || !commitRes.data) return
 
-        var filtered = []
-        for (var i = 0; i < base.length; i++) {
-            var c = base[i]
-            if (!c)
-                continue
+        var page = commitRes.data
+        var compiled = compilePage(page)
 
-            // Date range filter (authorDate)
-            if (!isNaN(startMs) || !isNaN(endMs)) {
-                var commitMs = new Date(c.authorDate).getTime()
-                if (!isNaN(startMs) && !(commitMs >= startMs))
-                    continue
-                if (!isNaN(endMs) && !(commitMs <= endMs))
-                    continue
-            }
+        var statusRes = root.statusController ? root.statusController.status() : null
+        var uncommitted = DataLoader.createUncommittedNode(statusRes && statusRes.success ? statusRes.data : null, root.headHash)
+        if (uncommitted) compiled.unshift(uncommitted)
 
-            // Text filter using applicationFilter
-            if (!applicationFilter(c, needle, root.filterMode))
-                continue
+        commitsOffset = page.length
+        hasMoreCommits = (page.length === pageSize)
 
-            filtered.push(c)
-        }
-
-        loadData(filtered)
-
-        // Auto-load more pages if filtered results are less than pageSize
-        ensureMinimumResults()
-
-        // If current selection is filtered out, clear it.
-        if (root.selectedCommitHashes && root.selectedCommitHashes.length > 0) {
-            var stillSelected = []
-            for (var si = 0; si < root.selectedCommitHashes.length; si++) {
-                var h = root.selectedCommitHashes[si]
-                var exists = filtered.find(function(x) { return x && x.hash === h })
-                if (exists)
-                    stillSelected.push(h)
-            }
-            root.selectedCommitHashes = stillSelected
-            if (!stillSelected.length) {
-                root.selectedCommit = null
-                root.lastSelectedIndex = -1
-            }
-        }
+        root.allCommits = compiled.slice(0)
+        root.applyFilter(root.filterText, root.filterStartDate, root.filterEndDate, root.filterMode)
     }
 
     /*!
@@ -443,64 +551,63 @@ DetachablePanel {
      * Automatically loads additional pages until we have at least pageSize results or no more commits.
      */
     function ensureMinimumResults() {
-        if (!root.hasAnyFilter) {
+        if (!Filter.hasAnyFilter(root.filterText, root.filterStartDate, root.filterEndDate))
             return
-        }
 
-        var currentResultCount = root.commits ? root.commits.length : 0
-        
-        if (currentResultCount >= root.pageSize || !root.hasMoreCommits || root.isLoadingMore) {
+        if ((root.commits ? root.commits.length : 0) >= pageSize)
             return
-        }
 
-        loadMoreCommitsForFilter()
+        if (!hasMoreCommits || isLoadingMore)
+            return
+
+        loadMoreCommits()
     }
 
     /*!
      * Loads additional commits specifically for filter scenarios.
      * Continues loading until filtered results reach pageSize or no more commits available.
      */
-    function loadMoreCommitsForFilter() {
-        if (root.isLoadingMore || !root.hasMoreCommits) {
+    function loadMoreCommits() {
+        if (isLoadingMore || !hasMoreCommits)
+            return
+
+        var currentContentY = commitsListView ? commitsListView.contentY : 0
+        isLoadingMore = true
+
+        var commitRes = root.commitController.getCommits(pageSize, commitsOffset)
+        if (!commitRes.success || !commitRes.data) {
+            isLoadingMore = false
             return
         }
 
-        root.isLoadingMore = true
-
-        var allBranches = branchController.getBranches();
-        let page = commitController.getCommits(pageSize, commitsOffset);
-        
-        if (!page || page.length === 0) {
-            root.hasMoreCommits = false
-            root.isLoadingMore = false
+        var page = commitRes.data
+        if (!page.length) {
+            hasMoreCommits = false
+            isLoadingMore = false
             return
         }
 
-        var stashes = []
-        if (root.stashController) {
-            var stashRes = root.stashController.list()
-            if (stashRes.success && stashRes.data)
-                stashes = stashRes.data
-        }
+        var compiled = compilePage(page)
+        var withoutStashes = root.allCommits.filter(function(c) { return !c.isStash })
+        root.allCommits = withoutStashes.concat(compiled)
 
-        var compiled = compileGraphCommits(page, allBranches, stashes);
-        var existingWithoutStashes = root.allCommits.filter(function(c) {
-            return !c.isStash
-        })
-        var commits = existingWithoutStashes.concat(compiled)
-        root.commitsOffset = page.length + (root.commitsOffset)
-        root.hasMoreCommits = (page.length === root.pageSize)
+        commitsOffset += page.length
+        hasMoreCommits = (page.length === pageSize)
 
-        root.allCommits = commits.slice(0)
-        
-        var currentText = root.filterText
-        var currentStartDate = root.filterStartDate
-        var currentEndDate = root.filterEndDate
-        var currentModes = root.filterMode
-        
-        root.isLoadingMore = false
-        
-        root.applyFilter(currentText, currentStartDate, currentEndDate, currentModes)
+        root.applyFilter(root.filterText, root.filterStartDate, root.filterEndDate, root.filterMode)
+        if (commitsListView) commitsListView.contentY = currentContentY
+
+        isLoadingMore = false
+    }
+
+    function compilePage(page) {
+        return DataLoader.compileGraphCommits(
+            page,
+            root.branchController ? root.branchController.getBranches() : [],
+            getStashes(),
+            getTags(),
+            root.appModel && root.appModel.appSettings ? root.appModel.appSettings.generalSettings : null
+        )
     }
 
     /**
@@ -509,2146 +616,430 @@ DetachablePanel {
      * stashes change (save/pop/drop).
      */
     function refreshStashNodes() {
-        if (!root.stashController)
+        if (!root.allCommits.length)
             return
 
-        var stashRes = root.stashController.list()
-        var stashes = (stashRes.success && stashRes.data) ? stashRes.data : []
+        var baseCommits = root.allCommits.filter(function(c) { return !c.isStash })
+        root.allCommits = DataLoader.compileGraphCommits(
+            baseCommits,
+            root.branchController ? root.branchController.getBranches() : [],
+            getStashes(),
+            getTags(),
+            root.appModel && root.appModel.appSettings ? root.appModel.appSettings.generalSettings : null
+        )
 
-        var baseCommits = root.allCommits.filter(function(c) {
-            return !c.isStash
-        })
-
-        var allBranches = root.branchController ? root.branchController.getBranches() : []
-
-        var recompiled = compileGraphCommits(baseCommits, allBranches, stashes)
-
-        root.allCommits = recompiled.slice(0)
         root.applyFilter(root.filterText, root.filterStartDate, root.filterEndDate, root.filterMode)
     }
 
-    function clearFilter() {
-        root.filterText = ""
-        root.filterStartDate = ""
-        root.filterEndDate = ""
-        root.navigationRule = "Message"
+    function getTags() {
+        if (!root.tagController)
+            return
+        var tagRes = root.tagController.list()
+        if (!tagRes.success || !tagRes.data)
+            return []
 
-        loadData((root.allCommits || []).slice(0))
+        return tagRes.data
     }
 
-    /**
-     * Load commit data and calculate graph layout positions
-     */
-    function loadData(commits) {
-        commitPositions = GraphLayout.calculateDAGPositions(
-            commits,
-            root.columnSpacing,
-            root.commitItemHeight,
-            root.commitItemSpacing
-        );
+    function getStashes() {
+        if (!root.stashController)
+            return
+        var stashRes = root.stashController.list()
+        if (!stashRes.success || !stashRes.data)
+            return []
 
-        // Color assignment:
-        var colorKeyByHash = {}
+        return stashRes.data
+    }
 
-        for (var j = commits.length - 1; j >= 0; j--) {
-            var c2 = commits[j]
-            var pos2 = root.commitPositions[c2.hash]
-            if (!pos2) continue
+    function isCommitSelected(hash) {
+        return root.selectedCommitHashes && root.selectedCommitHashes.indexOf(hash) !== -1
+    }
 
-            var inheritedKey = ""
-            if (c2.parentHashes && c2.parentHashes.length) {
-                // Find a parent in the same column; if found, inherit its color key.
-                for (var pi = 0; pi < c2.parentHashes.length; pi++) {
-                    var pHash = c2.parentHashes[pi]
-                    var pPos = root.commitPositions[pHash]
-                    if (pPos && pPos.column === pos2.column) {
-                        inheritedKey = colorKeyByHash[pHash] || ""
-                        break
-                    }
-                }
+    function setSingleSelection(commitData, index) {
+        root.selectedCommitHashes = [commitData.hash]
+        root.lastSelectedIndex = index
+    }
+
+    function selectedCommitsInOrder() {
+        var selected = []
+        if (!root.commits || !root.selectedCommitHashes) return selected
+        for (var i = root.commits.length - 1; i >= 0; i--) {
+            var c = root.commits[i]
+            if (c && c.hash && isCommitSelected(c.hash)) selected.push(c)
+        }
+        return selected
+    }
+
+    function handleItemClick(data, button, modifiers, idx, mouseX, mouseY) {
+        if (!data)
+            return
+
+        root.selectedCommit = data
+        root.commitClicked(data.isUncommitted ? "__uncommitted__" : data.hash)
+
+        if (button === Qt.RightButton) {
+            if (data.isUncommitted){
+                root.selectedCommit = data;
+                root.commitClicked("__uncommitted__");
+                return;
             }
 
-            if (inheritedKey) {
-                c2.colorKey = inheritedKey
-            } else {
-                // Start a new segment (unique per checkout / new branch instance)
-                c2.colorKey = "lane-seg:" + pos2.column + ":" + c2.hash
-            }
+            if (!isCommitSelected(data.hash))
+                setSingleSelection(data, idx)
 
-            colorKeyByHash[c2.hash] = c2.colorKey
+            var state = getMenuState(data)
+            var rawMenu = MenuBuilder.buildMenu(state)
+
+            contextMenu.menuModel = buildContextMenuModel(rawMenu)
+
+            contextMenu.x = mouseX
+            contextMenu.y = mouseY
+            contextMenu.open()
+            return
         }
 
-        root.commits = commits.slice(0)
-    }
-
-    /* Children
-     * ****************************************************************************************/
-    Connections {
-        target: Style
-        function onCurrentThemeChanged(){
-            graphCanvas.requestPaint()
-        }
-    }
-
-    Connections {
-        target: addBranchPopup
-
-        function onBranchCreatedSuccessfully() {
-            root.selectedCommit = ""
-            root.selectedCommitHashes = []
-            root.lastSelectedIndex = -1
-            root.reloadAll()
-        }
-    }
-
-    Connections {
-        target: addTagPopup
-
-        function onTagCreatedSuccessfully() {
-            root.selectedCommit = ""
-            root.reloadAll()
+        if (data.isUncommitted) return
+        var selection = Navigation.applySelection(data, idx, modifiers, root.selectedCommitHashes, root.lastSelectedIndex, root.commits)
+        if (selection) {
+            root.selectedCommitHashes = selection.hashes
+            root.lastSelectedIndex = selection.lastIndex
         }
     }
 
-    Rectangle{
-        anchors.fill: parent
-        color : Style.colors.primaryBackground
-
-        // Empty state (no commits to render)
-        EmptyStateView {
-            title: "no commit to show"
-            details: root.emptyStateDetailsText()
-            visible: !root.commits || root.commits.length === 0
-        }
-
-        ColumnLayout {          
-            anchors.fill: parent
-            spacing: 0
-
-            Rectangle {
-                id: header
-                Layout.fillWidth: true
-                visible: root.commits && root.commits.length > 0
-                Layout.preferredHeight: visible ? 30 : 0
-                color: Style.colors.primaryBackground
-
-                RowLayout {
-                    anchors.fill: parent
-                    spacing: 0
-
-                    Rectangle {
-                        Layout.preferredWidth: root.commitsColGraphWidth
-                        Layout.fillHeight: true
-                        color: graphHeaderMouseArea.containsMouse ? Style.colors.hoverTitle : "transparent"
-                        
-                        MouseArea {
-                            id: graphHeaderMouseArea
-                            anchors.fill: parent
-                            hoverEnabled: true
-                            propagateComposedEvents: true
-                            onPressed: function(mouse) { mouse.accepted = false }
-                            onReleased: function(mouse) { mouse.accepted = false }
-                        }
-
-                        Rectangle {
-                            anchors.right: parent.right
-                            anchors.top: parent.top
-                            anchors.bottom: parent.bottom
-                            width: 1
-                            color: graphDividerMouseArea.pressed ? Style.colors.resizeHandlePressed : Style.colors.resizeHandle
-
-                            MouseArea {
-                                id: graphDividerMouseArea
-                                anchors.right: parent.right
-                                anchors.top: parent.top
-                                anchors.bottom: parent.bottom
-                                width: 10
-                                anchors.rightMargin: -5
-                                hoverEnabled: true
-                                cursorShape: Qt.SizeHorCursor
-
-                                property real startX: 0
-                                property int startWidth: 0
-
-                                onPressed: function(mouse) {
-                                    startX = mouseX + mapToItem(header, 0, 0).x
-                                    startWidth = root.commitsColGraphWidth
-                                }
-
-                                onPositionChanged: function(mouse) {
-                                    if (!pressed) return
-
-                                    var currentX = mouseX + mapToItem(header, 0, 0).x
-                                    var delta = currentX - startX
-                                    
-                                    // Calculate new width with minimum constraint
-                                    var newWidth = Math.max(root.minColGraphWidth, startWidth + delta)
-                                    var actualDelta = newWidth - root.commitsColGraphWidth
-                                    
-                                    // Adjust next column (BranchTag) inversely
-                                    var newBranchTagWidth = root.commitsColBranchTagWidth - actualDelta
-                                    
-                                    // Ensure next column doesn't go below minimum
-                                    if (newBranchTagWidth < root.minColBranchTagWidth) {
-                                        newBranchTagWidth = root.minColBranchTagWidth
-                                        newWidth = root.commitsColGraphWidth + (root.commitsColBranchTagWidth - root.minColBranchTagWidth)
-                                    }
-                                    
-                                    if (newWidth !== root.commitsColGraphWidth) {
-                                        root.commitsColGraphWidth = newWidth
-                                        root.commitsColBranchTagWidth = newBranchTagWidth
-                                    }
-                                }
-                            }
-                        }
-                    }
-
-                    Rectangle {
-                        Layout.preferredWidth: root.commitsColBranchTagWidth
-                        Layout.fillHeight: true
-                        color: branchTagHeaderMouseArea.containsMouse ? Style.colors.hoverTitle : "transparent"
-                        
-                        MouseArea {
-                            id: branchTagHeaderMouseArea
-                            anchors.fill: parent
-                            hoverEnabled: true
-                            propagateComposedEvents: true
-                            onPressed: function(mouse) { mouse.accepted = false }
-                            onReleased: function(mouse) { mouse.accepted = false }
-                        }
-
-                        Label {
-                            anchors.left: parent.left
-                            anchors.verticalCenter: parent.verticalCenter
-                            horizontalAlignment: Text.AlignLeft
-                            anchors.leftMargin: 5
-                            text: "Branch/Tag"
-                            color: Style.colors.foreground
-                            font.pixelSize: 11
-                            font.bold: true
-                            elide: Text.ElideRight
-                        }
-
-                        Rectangle {
-                            anchors.right: parent.right
-                            anchors.top: parent.top
-                            anchors.bottom: parent.bottom
-                            width: 1
-                            color: branchTagDividerMouseArea.pressed ? Style.colors.resizeHandlePressed : Style.colors.resizeHandle
-
-                            MouseArea {
-                                id: branchTagDividerMouseArea
-                                anchors.right: parent.right
-                                anchors.top: parent.top
-                                anchors.bottom: parent.bottom
-                                width: 10
-                                anchors.rightMargin: -5
-                                hoverEnabled: true
-                                cursorShape: Qt.SizeHorCursor
-
-                                property real startX: 0
-                                property int startWidth: 0
-
-                                onPressed: function(mouse) {
-                                    startX = mouseX + mapToItem(header, 0, 0).x
-                                    startWidth = root.commitsColBranchTagWidth
-                                }
-
-                                onPositionChanged: function(mouse) {
-                                    if (!pressed) return
-
-                                    var currentX = mouseX + mapToItem(header, 0, 0).x
-                                    var delta = currentX - startX
-                                    
-                                    // Calculate new width with minimum constraint
-                                    var newWidth = Math.max(root.minColBranchTagWidth, startWidth + delta)
-                                    var actualDelta = newWidth - root.commitsColBranchTagWidth
-                                    
-                                    // Adjust next column (Message) inversely
-                                    var newMessageWidth = root.commitsColMessageWidth - actualDelta
-                                    
-                                    // Ensure next column doesn't go below minimum
-                                    if (newMessageWidth < root.minColMessageWidth) {
-                                        newMessageWidth = root.minColMessageWidth
-                                        newWidth = root.commitsColBranchTagWidth + (root.commitsColMessageWidth - root.minColMessageWidth)
-                                    }
-                                    
-                                    if (newWidth !== root.commitsColBranchTagWidth) {
-                                        root.commitsColBranchTagWidth = newWidth
-                                        root.commitsColMessageWidth = newMessageWidth
-                                    }
-                                }
-                            }
-                        }
-                    }
-
-                    Rectangle {
-                        Layout.preferredWidth: root.commitsColMessageWidth
-                        Layout.fillHeight: true
-                        color: messageHeaderMouseArea.containsMouse ? Style.colors.hoverTitle : "transparent"
-                        
-                        MouseArea {
-                            id: messageHeaderMouseArea
-                            anchors.fill: parent
-                            hoverEnabled: true
-                            propagateComposedEvents: true
-                            onPressed: function(mouse) { mouse.accepted = false }
-                            onReleased: function(mouse) { mouse.accepted = false }
-                        }
-
-                        Label {
-                            anchors.left: parent.left
-                            anchors.verticalCenter: parent.verticalCenter
-                            horizontalAlignment: Text.AlignLeft
-                            anchors.leftMargin: 5
-                            text: "Message"
-                            color: Style.colors.foreground
-                            font.pixelSize: 11
-                            font.bold: true
-                            elide: Text.ElideRight
-                        }
-
-                        Rectangle {
-                            anchors.right: parent.right
-                            anchors.top: parent.top
-                            anchors.bottom: parent.bottom
-                            width: 1
-                            color: messageDividerMouseArea.pressed ? Style.colors.resizeHandlePressed : Style.colors.resizeHandle
-
-                            MouseArea {
-                                id: messageDividerMouseArea
-                                anchors.right: parent.right
-                                anchors.top: parent.top
-                                anchors.bottom: parent.bottom
-                                width: 10
-                                anchors.rightMargin: -5
-                                hoverEnabled: true
-                                cursorShape: Qt.SizeHorCursor
-
-                                property real startX: 0
-                                property int startWidth: 0
-
-                                onPressed: function(mouse) {
-                                    startX = mouseX + mapToItem(header, 0, 0).x
-                                    startWidth = root.commitsColMessageWidth
-                                }
-
-                                onPositionChanged: function(mouse) {
-                                    if (!pressed) return
-
-                                    var currentX = mouseX + mapToItem(header, 0, 0).x
-                                    var delta = currentX - startX
-                                    
-                                    // Calculate new width with minimum constraint
-                                    var newWidth = Math.max(root.minColMessageWidth, startWidth + delta)
-                                    var actualDelta = newWidth - root.commitsColMessageWidth
-                                    
-                                    // Adjust next column (Author) inversely
-                                    var newAuthorWidth = root.commitsColAuthorWidth - actualDelta
-                                    
-                                    // Ensure next column doesn't go below minimum
-                                    if (newAuthorWidth < root.minColAuthorWidth) {
-                                        newAuthorWidth = root.minColAuthorWidth
-                                        newWidth = root.commitsColMessageWidth + (root.commitsColAuthorWidth - root.minColAuthorWidth)
-                                    }
-                                    
-                                    if (newWidth !== root.commitsColMessageWidth) {
-                                        root.commitsColMessageWidth = newWidth
-                                        root.commitsColAuthorWidth = newAuthorWidth
-                                    }
-                                }
-                            }
-                        }
-                    }
-
-                    Rectangle {
-                        Layout.preferredWidth: root.commitsColAuthorWidth
-                        Layout.fillHeight: true
-                        color: authorHeaderMouseArea.containsMouse ? Style.colors.hoverTitle : "transparent"
-                        
-                        MouseArea {
-                            id: authorHeaderMouseArea
-                            anchors.fill: parent
-                            hoverEnabled: true
-                            propagateComposedEvents: true
-                            onPressed: function(mouse) { mouse.accepted = false }
-                            onReleased: function(mouse) { mouse.accepted = false }
-                        }
-
-                        Label {
-                            anchors.left: parent.left
-                            anchors.verticalCenter: parent.verticalCenter
-                            horizontalAlignment: Text.AlignLeft
-                            anchors.leftMargin: 5
-                            text: "Author"
-                            color: Style.colors.foreground
-                            font.pixelSize: 11
-                            font.bold: true
-                            elide: Text.ElideRight
-                        }
-
-                        Rectangle {
-                            anchors.right: parent.right
-                            anchors.top: parent.top
-                            anchors.bottom: parent.bottom
-                            width: 1
-                            color: authorDividerMouseArea.pressed ? Style.colors.resizeHandlePressed : Style.colors.resizeHandle
-
-                            MouseArea {
-                                id: authorDividerMouseArea
-                                anchors.right: parent.right
-                                anchors.top: parent.top
-                                anchors.bottom: parent.bottom
-                                width: 10
-                                anchors.rightMargin: -5
-                                hoverEnabled: true
-                                cursorShape: Qt.SizeHorCursor
-
-                                property real startX: 0
-                                property int startWidth: 0
-
-                                onPressed: function(mouse) {
-                                    startX = mouseX + mapToItem(header, 0, 0).x
-                                    startWidth = root.commitsColAuthorWidth
-                                }
-
-                                onPositionChanged: function(mouse) {
-                                    if (!pressed) return
-
-                                    var currentX = mouseX + mapToItem(header, 0, 0).x
-                                    var delta = currentX - startX
-                                    
-                                    // Calculate new width with minimum constraint
-                                    var newWidth = Math.max(root.minColAuthorWidth, startWidth + delta)
-                                    var actualDelta = newWidth - root.commitsColAuthorWidth
-                                    
-                                    // Adjust next column (Date) inversely
-                                    var newDateWidth = root.commitsColDateWidth - actualDelta
-                                    
-                                    // Ensure next column doesn't go below minimum
-                                    if (newDateWidth < root.minColDateWidth) {
-                                        newDateWidth = root.minColDateWidth
-                                        newWidth = root.commitsColAuthorWidth + (root.commitsColDateWidth - root.minColDateWidth)
-                                    }
-                                    
-                                    if (newWidth !== root.commitsColAuthorWidth) {
-                                        root.commitsColAuthorWidth = newWidth
-                                        root.commitsColDateWidth = newDateWidth
-                                    }
-                                }
-                            }
-                        }
-                    }
-
-                    Rectangle {
-                        Layout.preferredWidth: root.commitsColDateWidth
-                        Layout.fillHeight: true
-                        Layout.alignment: Qt.AlignRight
-                        color: dateHeaderMouseArea.containsMouse ? Style.colors.hoverTitle : "transparent"
-                        
-                        MouseArea {
-                            id: dateHeaderMouseArea
-                            anchors.fill: parent
-                            hoverEnabled: true
-                            propagateComposedEvents: true
-                            onPressed: function(mouse) { mouse.accepted = false }
-                            onReleased: function(mouse) { mouse.accepted = false }
-                        }
-
-                        Label {
-                            anchors.left: parent.left
-                            anchors.verticalCenter: parent.verticalCenter
-                            horizontalAlignment: Text.AlignLeft
-                            anchors.leftMargin: 5
-                            text: "Date"
-                            color: Style.colors.foreground
-                            font.pixelSize: 11
-                            font.bold: true
-                            elide: Text.ElideRight
-                        }
-                    }
-                }
-            }
-
-            RowLayout {
-                id: mainRowLayout
-                spacing: 0
-
-                Rectangle {
-                    id: graphColumnRect
-                    Layout.fillWidth: false
-                    Layout.preferredWidth: root.commitsColGraphWidth + root.commitsColBranchTagWidth
-                    Layout.fillHeight: true
-                    color: Style.colors.primaryBackground
-
-                    Flickable {
-                        id: graphFlickable
-                        anchors.fill: parent
-                        clip: true
-                        // Calculate contentWidth based on max columns to avoid binding loop
-                        contentWidth: {
-                            if (root.commits.length === 0) return width
-                            var maxCols = 0
-                            for (var i = 0; i < root.commits.length; i++) {
-                                var commit = root.commits[i]
-                                var pos = root.commitPositions[commit.hash]
-                                if (pos && pos.column > maxCols) {
-                                    maxCols = pos.column
-                                }
-                            }
-                            var minWidth = 40 + (maxCols + 1) * root.columnSpacing + 300
-                            return Math.max(width, minWidth)
-                        }
-                        contentHeight: Math.max(height, root.commits.length * (root.commitItemHeight + (commitItemSpacing * 2)))
-                        boundsBehavior: Flickable.StopAtBounds
-
-                        property bool syncScroll: false
-
-                        // Sync scroll position with commits list
-                        onContentYChanged: {
-                            // Infinite scroll trigger (graph side)
-                            if (!root.isLoadingMore && root.hasMoreCommits) {
-                                var remaining = graphFlickable.contentHeight - (graphFlickable.contentY + graphFlickable.height)
-                                if (remaining < 300) {
-                                    root.loadMoreCommits()
-                                }
-                            }
-
-                            if (!syncScroll && graphFlickable.contentHeight > graphFlickable.height) {
-                                syncScroll = true
-                                var graphMaxY = graphFlickable.contentHeight - graphFlickable.height
-                                if (graphMaxY > 0) {
-                                    var ratio = graphFlickable.contentY / graphMaxY
-                                    var listMaxY = commitsListView.contentHeight - commitsListView.height
-                                    if (listMaxY > 0) {
-                                        commitsListView.syncScroll = true
-                                        commitsListView.contentY = ratio * listMaxY
-                                        commitsListView.syncScroll = false
-                                    }
-                                }
-                                syncScroll = false
-                            }
-                        }
-
-                        // Single Canvas for entire DAG
-                        Canvas {
-                            id: graphCanvas
-                            // Use Flickable's contentWidth
-                            width: graphFlickable.contentWidth
-                            height: root.commits.length * (root.commitItemHeight + (root.commitItemSpacing * 2))
-
-                            Connections {
-                                target: root
-                                function onSelectedCommitChanged() {
-                                    graphCanvas.requestPaint()
-                                }
-                            }
-
-                            Component.onCompleted: {
-                                graphCanvas.requestPaint()
-                            }
-
-                            Connections {
-                                target: root
-                                function onCommitsChanged() {
-                                    var newHeight = Math.max(graphFlickable.height, root.commits.length * (root.commitItemHeight + (commitItemSpacing * 2)))
-                                    graphCanvas.height = newHeight
-                                    graphFlickable.contentHeight = newHeight
-                                    graphCanvas.requestPaint()
-                                    // Force contentWidth recalculation
-                                    graphFlickable.contentWidth = Qt.binding(function() {
-                                        if (root.commits.length === 0) return graphFlickable.width
-                                        var maxCols = 0
-                                        for (var i = 0; i < root.commits.length; i++) {
-                                            var commit = root.commits[i]
-                                            var pos = root.commitPositions[commit.hash]
-                                            if (pos && pos.column > maxCols) {
-                                                maxCols = pos.column
-                                            }
-                                        }
-                                        var minWidth = 40 + (maxCols + 1) * root.columnSpacing + 300
-                                        return Math.max(graphFlickable.width, minWidth)
-                                    })
-                                }
-                            }
-
-                            Connections {
-                                target: root
-                                function onCommitsColGraphWidthChanged() {
-                                    graphCanvas.requestPaint()
-                                }
-                            }
-
-                            property var svgImage: Image {
-                                source: "qrc:/GitEase/Resources/Images/defaultUserIcon.svg"
-                                anchors.centerIn: parent
-                                height: 14.5
-                                width: 14.5
-                            }
-
-                            onPaint: {
-                                // Always clear the canvas first. Otherwise, when commits becomes empty
-                                // (e.g., filter has no results), the old graph remains visible.
-                                var ctx = getContext("2d");
-
-                                // Erase previous frame completely
-                                ctx.clearRect(0, 0, width, height);
-                                ctx.globalAlpha = 1.0;
-                                ctx.fillStyle = Style.colors.primaryBackground;
-                                ctx.fillRect(0, 0, width, height);
-                                
-                                let showAvatar = root.appModel?.appSettings?.generalSettings?.showAvatar ?? true
-
-                                if (!root.commits || root.commits.length === 0)
-                                    return;
-
-                                // Calculate center offset for graph
-                                var maxColumns = 0;
-                                for (var i = 0; i < root.commits.length; i++) {
-                                    var commit = root.commits[i];
-                                    var pos = root.commitPositions[commit.hash];
-                                    if (pos && pos.column > maxColumns) {
-                                        maxColumns = pos.column;
-                                    }
-                                }
-
-                                // Start graph from left side
-                                var centerOffset = root.columnSpacing / 2; // Padding from left edge
-
-                                // Build quick lookup: hash -> commit object (for edge coloring)
-                                var commitByHash = {}
-                                for (var bi0 = 0; bi0 < root.commits.length; bi0++) {
-                                    var c0m = root.commits[bi0]
-                                    if (c0m && c0m.hash)
-                                        commitByHash[c0m.hash] = c0m
-                                }
-
-                                // Track branch HEAD commits for labels.
-                                // No separate branches model: HEAD labels are stored on commits as commit.branchNames.
-                                // Build a map: branchName -> commitHash for quick checks.
-                                var branchLatestCommit = {};
-                                for (var bi = 0; bi < root.commits.length; bi++) {
-                                    var bc = root.commits[bi];
-                                    if (bc && bc.branchNames && bc.branchNames.length) {
-                                        for (var bni = 0; bni < bc.branchNames.length; bni++) {
-                                            var bn = bc.branchNames[bni];
-                                            if (bn)
-                                                branchLatestCommit[bn] = bc.hash;
-                                        }
-                                    }
-                                }
-                                
-                                // Build edge routing information for better visualization
-                                // Track ALL parent connections
-                                var parentInSameLane = {};
-                                var crossLaneEdges = [];  // Store cross-lane edges (different columns)
-                                
-                                for (var j = 0; j < root.commits.length; j++) {
-                                    var c0 = root.commits[j];
-                                    var pos0 = root.commitPositions[c0.hash];
-                                    if (!pos0 || !c0.parentHashes) continue;
-                                    
-                                    // Process ALL parents
-                                    for (var p = 0; p < c0.parentHashes.length; p++) {
-                                        var parentHash = c0.parentHashes[p];
-                                        var parentPos = root.commitPositions[parentHash];
-                                        if (!parentPos) continue;
-                                        
-                                        if (parentPos.column === pos0.column) {
-                                            // Same lane - only store first one for straight line
-                                            if (!parentInSameLane[c0.hash]) {
-                                                parentInSameLane[c0.hash] = parentHash;
-                                            }
-                                        } else {
-                                            // Different lane - draw cross-lane edge
-                                            // For merge commits: draw FROM parent TO merge commit
-                                            // For normal commits: draw FROM child TO parent
-                                            var isMerge = c0.commitType === "merge";
-                                            crossLaneEdges.push({
-                                                from: isMerge ? parentHash : c0.hash,
-                                                to: isMerge ? c0.hash : parentHash,
-                                                fromPos: isMerge ? parentPos : pos0,
-                                                toPos: isMerge ? pos0 : parentPos,
-                                                isMerge: isMerge
-                                            });
-                                        }
-                                    }
-                                }
-
-                                // PHASE 1: Draw all continuation lines (same-lane parent connections)
-                                for (var j = 0; j < root.commits.length; j++) {
-                                    var commit2 = root.commits[j];
-                                    var pos2 = root.commitPositions[commit2.hash];
-                                    if (!pos2) continue;
-
-                                    var centerX = centerOffset + pos2.column * root.columnSpacing + root.columnSpacing / 2;
-                                    var centerY = pos2.y + root.commitItemHeight / 2 + root.commitItemSpacing;
-
-                                    // Draw straight line to parent in same lane
-                                    var parentHash = parentInSameLane[commit2.hash];
-                                    if (parentHash) {
-                                        var parentPos = root.commitPositions[parentHash];
-                                        if (parentPos) {
-                                            var parentX = centerOffset + parentPos.column * root.columnSpacing + root.columnSpacing / 2;
-                                            var parentY = parentPos.y + root.commitItemHeight / 2 + root.commitItemSpacing;
-                                            
-                                            var branchColor2 = commitColor(commit2);
-
-                                            ctx.save();
-                                            ctx.strokeStyle = branchColor2;
-                                            ctx.globalAlpha = 0.9;
-                                            ctx.lineWidth = 2.5;
-
-                                            if (commit2.isUncommitted) {
-                                                ctx.setLineDash([4, 4]);
-                                            } else {
-                                                ctx.setLineDash([]);
-                                            }
-
-                                            ctx.beginPath();
-                                            ctx.moveTo(centerX, centerY);
-                                            ctx.lineTo(parentX, parentY);
-                                            ctx.stroke();
-                                            ctx.setLineDash([]);
-                                            ctx.restore();
-                                        }
-                                    } else {
-                                        let canDraw = false
-                                        for(let i = 0; i < commit2.parentHashes.length; i++){
-                                            if(!allCommitsHash[commit2.parentHashes[i]]){
-                                                canDraw = true
-                                                break
-                                            }
-                                        }
-
-                                        if(canDraw){
-                                            var branchColor2 = commitColor(commit2);
-
-                                            ctx.save();
-                                            ctx.strokeStyle = branchColor2;
-                                            ctx.globalAlpha = 0.9;
-                                            ctx.lineWidth = 2.5;
-
-                                            ctx.beginPath();
-                                            ctx.moveTo(centerX, centerY);
-                                            ctx.lineTo(centerX, graphCanvas.height);
-                                            ctx.stroke();
-                                            ctx.restore();
-                                        }
-                                    }
-                                }
-                                
-                                // PHASE 2: Draw cross-lane edges (Diagonal/Bezier curves for different columns)
-                                for (var edgeIdx = 0; edgeIdx < crossLaneEdges.length; edgeIdx++) {
-                                    var edge = crossLaneEdges[edgeIdx];
-                                    var fromPos = edge.fromPos;
-                                    var toPos = edge.toPos;
-                                    
-                                    // Calculate node center positions
-                                    let fromCenterX = centerOffset + fromPos.column * root.columnSpacing + root.columnSpacing / 2;
-                                    let fromCenterY = fromPos.y + root.commitItemHeight / 2 + root.commitItemSpacing;
-                                    let toCenterX = centerOffset + toPos.column * root.columnSpacing + root.columnSpacing / 2;
-                                    let toCenterY = toPos.y + root.commitItemHeight / 2 + root.commitItemSpacing;
-
-                                    let startX = edge.isMerge ? fromCenterX : toCenterX
-                                    let startY = edge.isMerge ? fromCenterY : toCenterY
-                                    let endX = edge.isMerge ? toCenterX : fromCenterX
-                                    let endY = edge.isMerge ? toCenterY : fromCenterY
-                                    
-                                    // Color edge by the originating commit's lane/graph color
-                                    var edgeColorVal = edgeColor(edge, commitByHash)
-                                    let deltaX = endX - startX;
-                                    let deltaY = endY - startY;
-                                    let horizontalDistance = Math.abs(deltaX);
-                                    
-                                    let curveRadius = Math.min(horizontalDistance * 0.5, root.commitItemHeight);
-                                    curveRadius = Math.max(curveRadius, 8);
-                                                                        
-                                    ctx.save();
-                                    ctx.strokeStyle = edgeColorVal;
-                                    ctx.globalAlpha = 0.85;
-                                    ctx.lineWidth = 2.5;
-                                    
-                                    ctx.beginPath();
-                                    ctx.moveTo(startX, startY);
-                                    
-                                    // Calculate curve radius based on distance
-                                    curveRadius = Math.min(Math.abs(deltaX) / 2, root.commitItemHeight, Math.abs(deltaY) / 2);
-                                    curveRadius = Math.max(curveRadius, 8); // Minimum radius for smooth curves
-                                    
-                                    if (deltaX === 0) {
-                                        ctx.lineTo(endX, endY);
-                                    } else if (deltaX > 0) {
-                                        let horizontalEndX = endX - curveRadius;
-                                        if (deltaY > 0) {
-                                            let verticalStartY = startY + curveRadius;
-                                            ctx.lineTo(horizontalEndX, startY);
-                                            ctx.quadraticCurveTo(endX, startY, endX, verticalStartY);
-                                            ctx.lineTo(endX, endY);
-                                        } else {
-                                            let verticalStartY = startY - curveRadius;
-                                            ctx.lineTo(horizontalEndX, startY);
-                                            ctx.quadraticCurveTo(endX, startY, endX, verticalStartY);
-                                            ctx.lineTo(endX, endY);
-                                        }
-                                    } else {
-                                        if (deltaY > 0) {
-                                            let verticalEndY = endY - curveRadius;
-                                            ctx.lineTo(startX, verticalEndY);
-                                            ctx.quadraticCurveTo(startX, endY, startX - curveRadius, endY);
-                                            ctx.lineTo(endX, endY);
-                                        } else {
-                                            let verticalEndY = endY + curveRadius;
-                                            ctx.lineTo(startX, verticalEndY);
-                                            ctx.quadraticCurveTo(startX, endY, startX - curveRadius, endY);
-                                            ctx.lineTo(endX, endY);
-                                        }
-                                    }
-                                    
-                                    ctx.stroke();
-                                    ctx.restore();
-                                }
-
-                                // First pass: Draw lines from nodes to branch/tag labels (only for HEAD commits)
-                                for (var lineIdx = 0; lineIdx < root.commits.length; lineIdx++) {
-                                    var commitForLine = root.commits[lineIdx];
-                                    var posForLine = root.commitPositions[commitForLine.hash];
-                                    if (!posForLine) continue;
-
-                                    // Check if this commit is a HEAD of ANY branch
-                                    var isHeadCommitForLabels = false;
-                                    var headBranchesForThisCommit = [];
-                                    
-                                    // Check ALL branches to see if this commit is a HEAD
-                                    for (var branchKey in branchLatestCommit) {
-                                        if (branchLatestCommit[branchKey] === commitForLine.hash) {
-                                            isHeadCommitForLabels = true;
-                                            headBranchesForThisCommit.push(branchKey);
-                                        }
-                                    }
-
-                                    // Only show labels for HEAD commits
-                                    if (!isHeadCommitForLabels && (!commitForLine.tagNames || commitForLine.tagNames.length === 0)) {
-                                        continue;
-                                    }
-
-                                    var centerXForLine = centerOffset + posForLine.column * root.columnSpacing + root.columnSpacing / 2;
-                                    var centerYForLine = posForLine.y + root.commitItemHeight / 2 + root.commitItemSpacing;
-
-                                    // Collect all labels (tags first, then branches) for this commit
-                                    // Label colors are based on the commit's lane/graph color
-                                    var laneLabelColor = commitColor(commitForLine)
-                                    var allLabels = [];
-
-                                    // Add tag labels first (left side)
-                                    if (commitForLine.tagNames && commitForLine.tagNames.length > 0) {
-                                        for (var tIdx = 0; tIdx < commitForLine.tagNames.length; tIdx++) {
-                                            var tagName = commitForLine.tagNames[tIdx];
-                                            allLabels.push({
-                                                text: tagName,
-                                                color: "#e2c044",
-                                                isTag: true
-                                            });
-                                        }
-                                    }
-
-                                    // Add branch labels for HEAD branches
-                                    // Each label uses the lane/graph color
-                                    for (var hbi = 0; hbi < headBranchesForThisCommit.length; hbi++) {
-                                        var headBranchName = headBranchesForThisCommit[hbi];
-                                        allLabels.push({
-                                            text: headBranchName, //+ " (HEAD)",
-                                            color: laneLabelColor,
-                                            isTag: false
-                                        });
-                                    }
-
-                                    // Draw all labels on same horizontal line
-                                    if (allLabels.length > 0) {
-                                        // Align labels to start at the Graph/BranchTag divider position
-                                        // But ensure labels start AFTER the commit node (never overlap or go backwards)
-                                        var dividerPosition = root.commitsColGraphWidth + 10;  // Position at divider + small padding
-                                        var nodeEndPosition = centerXForLine + 20;  // Node position + node radius + padding
-                                        var labelStartX = Math.max(dividerPosition, nodeEndPosition);  // Use whichever is further right
-                                        var labelY = centerYForLine;  // Same Y as node (horizontal line)
-                                        var currentLabelX = labelStartX;
-                                        var labelSpacing = 8;  // Horizontal spacing between labels
-
-                                        // Calculate positions for all labels
-                                        var labelPositions = [];
-                                        for (var calcIdx = 0; calcIdx < allLabels.length; calcIdx++) {
-                                            var calcLabelInfo = allLabels[calcIdx];
-                                            var isTag = calcLabelInfo.isTag;
-                                            ctx.font = "bold 11px sans-serif";
-                                            ctx.textAlign = "left";
-                                            var calcTextMetrics = ctx.measureText(calcLabelInfo.text);
-                                            var extraSpace = isTag ? 20 : 8;
-                                            var calcLabelWidth = calcTextMetrics.width + 8 + extraSpace;
-                                            labelPositions.push({
-                                                x: currentLabelX,
-                                                width: calcLabelWidth,
-                                                info: calcLabelInfo
-                                            });
-                                            currentLabelX += calcLabelWidth + labelSpacing;
-                                        }
-
-                                        // Draw single connecting line using first label's color
-                                        if (labelPositions.length > 0) {
-                                            var firstLabel = labelPositions[0];
-                                            var lastLabel = labelPositions[labelPositions.length - 1];
-                                            var lineEndX = lastLabel.x + lastLabel.width;
-                                            
-                                            ctx.save();
-                                            ctx.strokeStyle = laneLabelColor;  // Use commit lane/graph color
-                                            ctx.globalAlpha = 0.8;
-                                            ctx.lineWidth = 5;
-
-                                            ctx.beginPath();
-                                            ctx.moveTo(centerXForLine, centerYForLine);
-                                            ctx.lineTo(lineEndX, labelY);
-                                            ctx.stroke();
-                                            ctx.restore();
-                                        }
-
-                                        // Draw all labels
-                                        for (var labelDrawIdx = 0; labelDrawIdx < labelPositions.length; labelDrawIdx++) {
-                                            var labelPos = labelPositions[labelDrawIdx];
-                                            var labelInfo = labelPos.info;
-                                            var labelX = labelPos.x;
-                                            var labelWidth = labelPos.width;
-                                            var labelHeight = 20;
-                                            var labelRectY = labelY - labelHeight / 2;
-
-                                            ctx.save();
-                                            ctx.fillStyle = labelInfo.color;
-                                            ctx.globalAlpha = 0.95;
-                                            GraphUtils.drawRoundedRect(ctx, labelX, labelRectY, labelWidth, labelHeight, 2);
-                                            ctx.fill();
-
-                                            var contrastColor = GraphUtils.getContrastColor(labelInfo.color);
-                                            ctx.fillStyle = contrastColor;
-                                            ctx.globalAlpha = 1.0;
-                                            ctx.textBaseline = "middle";
-                                            ctx.textAlign = "left";
-
-                                            if (labelInfo.isTag) {
-                                                ctx.font = "9px sans-serif";
-                                                ctx.fillText(Style.icons.tag, labelX + 4, labelY);
-
-                                                ctx.font = "bold 11px sans-serif";
-                                                ctx.fillText(labelInfo.text, labelX + 20, labelY);
-                                            } else {
-                                                ctx.font = "bold 11px sans-serif";
-                                                ctx.fillText(labelInfo.text, labelX + 8, labelY);
-                                            }
-
-                                            ctx.restore();
-                                        }
-                                    }
-                                }
-
-                                // Second pass: Draw commit nodes (on top of lines)
-                                for (var k = 0; k < root.commits.length; k++) {
-                                    var commit3 = root.commits[k];
-                                    var pos3 = root.commitPositions[commit3.hash];
-                                    if (!pos3) continue;
-
-                                    var centerX2 = centerOffset + pos3.column * root.columnSpacing + root.columnSpacing / 2;
-                                    var centerY2 = pos3.y + root.commitItemHeight / 2 + root.commitItemSpacing;
-
-                                    var branchColor3 = commitColor(commit3);
-
-                                    // Determine HEAD status without falling back to "main"
-                                    var isHeadCommit = false;
-                                    if (commit3.branchNames && commit3.branchNames.length) {
-                                        for (var hb = 0; hb < commit3.branchNames.length; hb++) {
-                                            var bname = commit3.branchNames[hb]
-                                            if (branchLatestCommit && branchLatestCommit[bname] === commit3.hash) {
-                                                isHeadCommit = true;
-                                                break;
-                                            }
-                                        }
-                                    }
-                                    var isSelected = root.isCommitSelected(commit3.hash);
-                                    let isHead = commit3.hash === root.headHash
-                                    // Highlight selected commit row
-                                    if (isSelected) {
-                                        ctx.fillStyle = "#6088B2DF";
-                                        ctx.fillRect(0, pos3.y, graphCanvas.width, root.commitItemHeight + (root.commitItemSpacing * 2));
-                                    } else if (isHead) {
-                                        ctx.fillStyle = "#40FFA500";
-                                        ctx.fillRect(0, pos3.y, graphCanvas.width, root.commitItemHeight + (root.commitItemSpacing * 2));
-                                    }
-
-                                    ctx.save();
-                                    ctx.strokeStyle = isSelected ? GraphUtils.darkenColor(branchColor3, 0.2): GraphUtils.lightenColor(branchColor3, 0.3);
-                                    ctx.lineWidth = isSelected ? 4 : 2.5;
-
-                                    var avatarSize = showAvatar ? root.commitItemHeight : 10;
-                                    var avatarRadius = avatarSize / 2;
-
-                                    var isStashNode = commit3.isStash === true;
-
-                                    if (isStashNode) {
-                                        var sqSize = avatarRadius;
-                                        var sqRadius = 2;
-
-                                        ctx.beginPath();
-                                        ctx.moveTo(centerX2 - sqSize + sqRadius, centerY2 - sqSize);
-                                        ctx.arcTo(centerX2 + sqSize, centerY2 - sqSize, centerX2 + sqSize, centerY2 + sqSize, sqRadius);
-                                        ctx.arcTo(centerX2 + sqSize, centerY2 + sqSize, centerX2 - sqSize, centerY2 + sqSize, sqRadius);
-                                        ctx.arcTo(centerX2 - sqSize, centerY2 + sqSize, centerX2 - sqSize, centerY2 - sqSize, sqRadius);
-                                        ctx.arcTo(centerX2 - sqSize, centerY2 - sqSize, centerX2 + sqSize, centerY2 - sqSize, sqRadius);
-                                        ctx.closePath();
-
-                                        ctx.fillStyle = branchColor3;
-                                        ctx.fill();
-                                        ctx.stroke();
-
-                                        if (showAvatar) {
-                                            ctx.fillStyle = "#ffffff";
-                                            ctx.textAlign = "center";
-                                            ctx.textBaseline = "middle";
-                                            ctx.fillText(Style.icons.archive, centerX2, centerY2);
-                                        }
-
-                                        ctx.restore();
-                                    } else {
-                                        ctx.beginPath();
-                                        ctx.arc(centerX2, centerY2, avatarRadius, 0, 2 * Math.PI);
-                                        ctx.fillStyle = showAvatar ? "#D9D9D9" : GraphUtils.lightenColor(branchColor3, 0.3);
-                                        ctx.fill();
-                                        ctx.stroke();
-
-                                        if (showAvatar) {
-                                            // Draw avatar icon
-                                            ctx.fillStyle = "#ffffff";
-                                            ctx.font = (avatarSize * 0.8) + "px sans-serif";
-                                            ctx.textAlign = "center";
-                                            ctx.textBaseline = "middle";
-
-                                            var drawX = centerX2 - svgImage.width / 2;
-                                            var drawY = centerY2 - svgImage.height / 2;
-                                            ctx.drawImage(svgImage, drawX, drawY);
-                                        }
-                                        ctx.restore();
-                                    }
-                                }
-
-                            }
-                        }
-                    }
-                }
-
-                // Commits ListView
-                ListView {
-                    id: commitsListView
-                    Layout.fillWidth: true
-                    Layout.preferredWidth: root.commitsColMessageWidth + root.commitsColAuthorWidth+ root.commitsColDateWidth
-                    Layout.fillHeight: true
-                    model: root.commits
-                    clip: true
-
-                    property bool syncScroll: false
-
-                    // Sync scroll position with graph
-                    onContentYChanged: {
-                        // Infinite scroll trigger (list side)
-                        if (!root.isLoadingMore && root.hasMoreCommits) {
-                            var remaining = commitsListView.contentHeight - (commitsListView.contentY + commitsListView.height)
-                            if (remaining < 300) {
-                                root.loadMoreCommits()
-                            }
-                        }
-
-                        if (!syncScroll && commitsListView.contentHeight > commitsListView.height) {
-                            syncScroll = true
-                            var listMaxY = commitsListView.contentHeight - commitsListView.height
-                            if (listMaxY > 0) {
-                                var ratio = commitsListView.contentY / listMaxY
-                                var graphMaxY = graphFlickable.contentHeight - graphFlickable.height
-                                if (graphMaxY > 0) {
-                                    graphFlickable.syncScroll = true
-                                    graphFlickable.contentY = ratio * graphMaxY
-                                    graphFlickable.syncScroll = false
-                                }
-                            }
-                            syncScroll = false
-                        }
-                    }
-
-                    delegate: Rectangle {
-                        id: commitItem
-                        width: ListView.view.width
-                        height: root.commitItemHeight + commitItemSpacing + commitItemSpacing
-
-                        property var commitData: modelData
-                        property bool isHovered: false
-                        property bool isSelected: root.isCommitSelected(commitData.hash)
-                        property bool isHead: modelData.hash === root.headHash
-
-                        property bool isStash: modelData.isStash === true
-
-                        color: {
-                            if (isSelected) {
-                                return "#6088B2DF";
-                            }
-                            if (commitData.isUncommitted) {
-                                if (isHovered) {
-                                    return Qt.darker(Style.colors.hoverTitle, 1.03);
-                                }
-                                return Style.colors.secondaryBackground || Style.colors.primaryBackground;
-                            }
-                            if (isHovered) {
-                                return Style.colors.hoverTitle;
-                            }
-                            if (isHead) {
-                                return "#40FFA500";
-                            }
-
-                            return Style.colors.primaryBackground;
-                        }
-
-                        radius: (isSelected || isHovered) ? 4 : 0
-
-
-                        RowLayout {
-                            anchors.fill: parent
-                            spacing: 0
-                            anchors.topMargin: commitItemSpacing
-                            anchors.bottomMargin: commitItemSpacing
-
-                            // Column 1: Commit Message
-                            ColumnLayout {
-                                Layout.fillWidth: false
-                                Layout.preferredWidth: root.commitsColMessageWidth
-                                Layout.fillHeight: true
-                                spacing: 0
-
-                                RowLayout {
-                                    Layout.fillWidth: true
-
-                                    Rectangle {
-                                        Layout.preferredWidth: 1
-                                        Layout.fillHeight: true
-                                        width: 1
-                                        color: Style.colors.hoverTitle
-                                    }
-
-                                    // Branch color indicator bar
-                                    Rectangle {
-                                        id: branchColorIndicator
-                                        Layout.preferredWidth: 3
-                                        Layout.preferredHeight: commitItemHeight * 0.8
-                                        Layout.alignment: Qt.AlignVCenter
-                                        radius: 6
-
-                                        // Color indicator by graph lane/column (same color as the drawn graph line)
-                                        color: {
-                                            return commitColor(commitData)
-                                        }
-                                    }
-
-                                    // Stash badge (only visible for stash nodes)
-                                    Rectangle {
-                                        visible: commitItem.isStash
-                                        Layout.preferredWidth: stashBadgeRow.implicitWidth + 10
-                                        Layout.preferredHeight: 17
-                                        Layout.alignment: Qt.AlignVCenter
-                                        Layout.leftMargin: 4
-                                        radius: 2
-                                        color:  {
-                                            return commitColor(commitData)
-                                        }
-
-                                        Row {
-                                            id: stashBadgeRow
-                                            anchors.centerIn: parent
-                                            spacing: 3
-
-                                            Text {
-                                                text: Style.icons.archive
-                                                font.family: Style.fontTypes.font6ProSolid
-                                                font.pixelSize: 9
-                                                color: {
-                                                    return GraphUtils.getContrastColor(commitColor(commitData))
-                                                }
-                                                verticalAlignment: Text.AlignVCenter
-                                            }
-                                            Text {
-                                                text: commitData.stashLabel || "stash"
-                                                font.family: Style.fontTypes.roboto
-                                                font.pixelSize: 9
-                                                color: {
-                                                    return GraphUtils.getContrastColor(commitColor(commitData))
-                                                }
-                                                verticalAlignment: Text.AlignVCenter
-                                            }
-                                        }
-                                    }
-
-                                    Label {
-                                        text: commitData.summary || ""
-                                        color: Style.colors.foreground
-                                        verticalAlignment: Text.AlignVCenter
-                                        font.pixelSize: 10
-                                        font.family: Style.fontTypes.roboto
-                                        font.weight: commitData.isUncommitted ? 700 : (commitItem.isHead ? 900 : 400)
-                                        font.letterSpacing: 0.2
-                                        Layout.fillWidth: true
-                                        Layout.leftMargin: 6
-                                        elide: Text.ElideRight
-                                    }
-                                }
-                            }
-
-                            // Column 2: Author
-                            ColumnLayout {
-                                Layout.preferredWidth: root.commitsColAuthorWidth
-                                Layout.fillHeight: true
-                                spacing: 0
-
-                                RowLayout {
-                                    Layout.fillWidth: true
-
-                                    Rectangle {
-                                        Layout.preferredWidth: 1
-                                        Layout.fillHeight: true
-                                        width: 1
-                                        color: Style.colors.hoverTitle
-                                    }
-
-                                    Label {
-                                        text: commitData.author || ""
-                                        color: Style.colors.foreground
-                                        verticalAlignment: Text.AlignVCenter
-                                        font.pixelSize: 12
-                                        Layout.fillWidth: true
-                                        horizontalAlignment: Text.AlignLeft
-                                        elide: Text.ElideRight
-                                        wrapMode: Text.NoWrap
-                                    }
-                                }
-                            }
-
-                            // Column 3: Date and Time (in one line)
-                            ColumnLayout {
-                                Layout.preferredWidth: root.commitsColDateWidth
-                                Layout.fillHeight: true
-                                spacing: 0
-
-                                RowLayout {
-                                    Layout.fillWidth: true
-
-                                    Rectangle {
-                                        Layout.preferredWidth: 1
-                                        Layout.fillHeight: true
-                                        width: 1
-                                        color: Style.colors.hoverTitle
-                                    }
-
-                                    Label {
-                                        text: GraphUtils.formatDate(commitData.authorDate) + " " + GraphUtils.formatTime(commitData.authorDate)
-                                        color: Style.colors.foreground
-                                        verticalAlignment: Text.AlignVCenter
-                                        font.pixelSize: 10
-                                        Layout.fillWidth: true
-                                        horizontalAlignment: Text.AlignLeft
-                                        wrapMode: Text.NoWrap
-                                    }
-                                }
-                            }
-                        }
-
-                        MouseArea {
-                            id: commitMouseArea
-                            anchors.fill: parent
-                            hoverEnabled: true
-                            acceptedButtons: Qt.LeftButton | Qt.RightButton
-
-                            onClicked: (mouse) => {
-                               root.selectedCommit = commitData;
-                               root.commitClicked(commitData.hash);
-
-                                if (mouse.button === Qt.RightButton) {
-                                    if (commitData.isUncommitted)
-                                        return;
-
-                                    if(!root.isCommitSelected(commitData.hash))
-                                        root.setSingleSelection(commitData, index)
-
-                                    contextMenu.x = mouse.x;
-                                    contextMenu.y = mouse.y;
-                                    contextMenu.open();
-
-                                } else {
-                                    if (commitData.isUncommitted) {
-                                        root.selectedCommit = commitData;
-                                        root.commitClicked("__uncommitted__");
-                                        return;
-                                    }
-                                    root.applySelection(commitData, index, mouse.modifiers)
-                                }
-                            }
-
-                            onDoubleClicked: (mouse) => {
-                                if (mouse.button !== Qt.LeftButton)
-                                    return;
-
-                                if (commitData.isUncommitted)
-                                    return;
-
-                                if (commitData.isStash)
-                                    return;
-
-                                let isCurrentHead = (commitData.hash === root.headHash);
-                                if (isCurrentHead)
-                                    return;
-
-                                let branches = commitData.branchNames || [];
-                                let shortHash = commitData.shortHash || commitData.hash.substring(0, 7);
-
-                                if (branches.length === 0) {
-                                    let res = branchController.checkoutCommit(commitData.hash);
-                                    contextMenu.handleResponse(res, "Checked out commit " + shortHash);
-                                } else {
-                                    let allBranches = branchController.getBranches();
-                                    let localNames = {};
-                                    for (let bi = 0; bi < allBranches.length; bi++) {
-                                        let b = allBranches[bi];
-                                        if (b && b.isLocal)
-                                            localNames[b.name] = true;
-                                    }
-
-                                    let seen = {};
-                                    let dedupedBranches = [];
-                                    for (let i = 0; i < branches.length; i++) {
-                                        let name = branches[i];
-                                        let baseName = name.replace(/^[^/]+\//, "");
-                                        if (!seen[baseName]) {
-                                            seen[baseName] = true;
-                                            dedupedBranches.push(localNames[baseName] ? baseName : name);
-                                        }
-                                    }
-
-                                    if (dedupedBranches.length === 1) {
-                                        checkoutBranchOrCreate(dedupedBranches[0], commitData.hash);
-                                    } else {
-                                        checkoutBranchSelector.commitHash = commitData.hash;
-                                        checkoutBranchSelector.branches = dedupedBranches;
-                                        checkoutBranchSelector.open();
-                                    }
-                                }
-                            }
-
-                            function checkoutBranchOrCreate(branchName, commitHash) {
-                                let allBranches = branchController.getBranches();
-                                let localBranchNames = {};
-                                for (let bi = 0; bi < allBranches.length; bi++) {
-                                    let b = allBranches[bi];
-                                    if (b && b.isLocal)
-                                        localBranchNames[b.name] = true;
-                                }
-
-                                if (localBranchNames[branchName]) {
-                                    let res = branchController.checkoutBranch(branchName);
-                                    contextMenu.handleResponse(res, "Checked out branch " + branchName);
-                                } else {
-                                    let localName = branchName.replace(/^[^/]+\//, "");
-                                    let createRes = branchController.createBranch(commitHash, localName);
-                                    if (!createRes.success) {
-                                        contextMenu.handleResponse(createRes, "");
-                                    } else {
-                                        let checkoutRes = branchController.checkoutBranch(localName);
-                                        contextMenu.handleResponse(checkoutRes, "Created and checked out branch " + localName);
-                                    }
-                                }
-                            }
-
-                            onEntered: {
-                                isHovered = true
-                            }
-                            onExited: {
-                                isHovered = false
-                            }
-                        }
-
-                        ContextMenu {
-                            id: contextMenu
-                            width: 250
-
-                            onAboutToShow: {
-                                var branches = commitData.branchNames || [];
-                                var shortHash = commitData.shortHash || commitData.hash.substring(0, 7);
-                                var isCurrentHead = (commitData.hash === root.currentHeadHash);
-
-                                var checkoutSubMenu = [];
-                                branches.forEach(function(bName) {
-                                    checkoutSubMenu.push({
-                                        text: bName,
-                                        icon: Style.icons.gitBranch,
-                                        action: function() {
-                                            let res = branchController.checkoutBranch(bName);
-                                            handleResponse(res, "Checked out branch " + bName);
-                                        }
-                                    });
-                                });
-
-                                checkoutSubMenu.push({
-                                    text: "Checkout " + shortHash + " (Detached)",
-                                    icon: Style.icons.hash,
-                                    action: function() {
-                                        let res = branchController.checkoutCommit(commitData.hash);
-                                        handleResponse(res, "Checked out commit " + shortHash);
-                                    }
-                                });
-
-                                var finalModel = [];
-
-                                if (branches.length > 0) {
-                                    finalModel.push({
-                                        text: "Checkout",
-                                        icon: Style.icons.gitBranch,
-                                        enabled: !isCurrentHead,
-                                        subItems: checkoutSubMenu
-                                    });
-                                } else {
-                                    finalModel.push({
-                                        text: "Checkout Commit " + shortHash,
-                                        icon: Style.icons.hash,
-                                        enabled: !isCurrentHead,
-                                        action: function() {
-                                            let res = branchController.checkoutCommit(commitData.hash);
-                                            handleResponse(res, "Checked out commit " + shortHash);
-                                        }
-                                    });
-                                }
-
-                                finalModel.push({
-                                    text: "New Branch from here",
-                                    icon: Style.icons.branchPlus,
-                                    enabled: true,
-                                    action: function() {
-                                        addBranchPopup.branchController = root.branchController;
-                                        addBranchPopup.targetHash = commitData.hash;
-                                        addBranchPopup.open();
-                                    }
-                                });
-
-                                finalModel.push({
-                                    text: "Create Tag here",
-                                    icon: Style.icons.tag,
-                                    enabled: true,
-                                    action: function() {
-                                        addTagPopup.tagController = root.tagController || (typeof uiSession !== "undefined" ? uiSession.tagController : null);
-                                        addTagPopup.targetHash = commitData.hash;
-                                        addTagPopup.open();
-                                    }
-                                });
-
-                                // Merge
-                                var currentBranch = root.branchController
-                                        ? root.branchController.getCurrentBranchName()
-                                        : "";
-
-                                // Merge (adds its own leading separator when branches exist)
-                                addMergeEntries(finalModel, branches, currentBranch, isCurrentHead);
-
-                                // Rebase
-                                addRebaseEntries(finalModel, commitData, currentBranch, isCurrentHead);
-
-                                // Cherry-pick
-                                addCherrypickEntries(finalModel, commitData, shortHash, isCurrentHead)
-
-                                menuModel = finalModel;
-                            }
-
-                            function handleResponse(res, successMsg) {
-                                if (res.success) {
-                                    if (root.notificationController) {
-                                        root.notificationController.success(successMsg, "Checkout", 3000);
-                                    }
-                                } else if (root.notificationController) {
-                                    root.notificationController.error(res.errorMessage || "Failed to checkout", "Checkout Error", 5000);
-                                }
-                                root.selectedCommit = "";
-                                root.selectedCommitHashes = []
-                                root.lastSelectedIndex = -1
-                                root.reloadAll();
-                            }
-                        }
-
-                        CheckoutBranchSelectorPopup {
-                            id: checkoutBranchSelector
-
-                            property string commitHash: ""
-
-                            onBranchSelected: function(branchName) {
-                                commitMouseArea.checkoutBranchOrCreate(branchName, commitHash);
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    /**
-     * Load all commits from repository
-     */
-    // Build graph-ready commits by combining:
-    // - getCommits(): list of commits (hash, summary, author, ...)
-    // - getCommit(hash): per-commit details (parentHashes, etc)
-    // - getBranches(): to attach branch name labels to tip commits (targetHash)
-    function compileGraphCommits(rawCommits, rawBranches, rawStashes) {
-        if (!rawCommits) return []
-
-        var hashToTags = {};
-
-        var tagController = root.tagController || (typeof uiSession !== "undefined" ? uiSession.tagController : null);
-        if (tagController) {
-            var allTags = tagController.list().data;
-            var keys = Object.keys(allTags);
-            for (var i = 0; i < keys.length; i++) {
-                var tag = allTags[i];
-                var cHash = tag.commitId;
-                if (cHash) {
-                    if (!hashToTags[cHash]) {
-                        hashToTags[cHash] = [];
-                    }
-                    hashToTags[cHash].push(tag.name);
-                }
-            }
-        }
-
-        // tip commit hash -> [branchName,...]
-        var tipHashToBranches = {}
-        var branchTipHashes = []
-        if (rawBranches && rawBranches.length) {
-            for (var i = 0; i < rawBranches.length; i++) {
-                var b = rawBranches[i]
-                if (!b || !b.targetHash) continue
-                if (!tipHashToBranches[b.targetHash]) {
-                    tipHashToBranches[b.targetHash] = []
-                    branchTipHashes.push(b.targetHash)
-                }
-                tipHashToBranches[b.targetHash].push(b.name)
-            }
-        }
-
-        var commitHashSet = {}
-        for (var ci = 0; ci < rawCommits.length; ci++) {
-            if (rawCommits[ci] && rawCommits[ci].hash)
-                commitHashSet[rawCommits[ci].hash] = true
-        }
-
-        var showStashes = root.appModel?.appSettings?.generalSettings?.showStashNodes ?? false
-
-        var stashNodes = {}        // id -> stash node obj
-        var stashNodeList = []
-        if (showStashes && rawStashes && rawStashes.length) {
-            for (var stashIdx = 0; stashIdx < rawStashes.length; stashIdx++) {
-                var stash = rawStashes[stashIdx]
-                if (!stash || !stash.id)
-                    continue
-
-                if (stashNodes[stash.id])
-                    continue
-
-                stashNodes[stash.id] = true
-
-                var stashParentHashes = stash.parentId ? [stash.parentId] : []
-                var stashLabel = "stash@{" + stash.index + "}"
-                var stashObj = {
-                    hash: stash.id,
-                    shortHash: stash.id.substring(0, 7),
-                    message: stash.message || stashLabel,
-                    summary: stash.message || stashLabel,
-                    author: stash.author || "",
-                    authorEmail: "",
-                    authorDate: stash.dateTime || "",
-
-                    parentHashes: stashParentHashes,
-                    commitType: "stash",
-
-                    branchNames: [stashLabel],
-                    tagNames: [],
-                    colorKey: "",
-
-                    isStash: true,
-                    stashIndex: stash.index,
-                    stashLabel: stashLabel,
-                    stashParentId: stash.parentId || "",
-
-                    files: commit.files ?? null,
-                    isUncommitted: commit.isUncommitted ?? false
-                }
-                stashNodeList.push(stashObj)
-            }
-        }
-
-        // Build commits
-        var compiled = []
-
-        var stashInserted = {}
-
-        for (var c = 0; c < rawCommits.length; c++) {
-            var commit = rawCommits[c]
-
-            for (var sj = 0; sj < stashNodeList.length; sj++) {
-                var sn = stashNodeList[sj]
-                if (!stashInserted[sn.hash] && sn.stashParentId === commit.hash) {
-                    compiled.push(sn)
-                    stashInserted[sn.hash] = true
-                }
-            }
-
-            var parentHashes = []
-            var details = commit
-            if (details && details.parentHashes) {
-                parentHashes = details.parentHashes
-            }
-
-            var obj = {
-                hash: commit.hash,
-                shortHash: commit.shortHash,
-                message: commit.message,
-                summary: commit.summary,
-                author: commit.author,
-                authorEmail: commit.authorEmail,
-                authorDate: commit.authorDate,
-
-                parentHashes: parentHashes,
-                commitType: (parentHashes.length > 1) ? "merge" : "normal",
-
-                // Only branch tips start with branch names; we'll propagate membership below
-                branchNames: tipHashToBranches[commit.hash] || [],
-                tagNames: hashToTags[commit.hash] || [],
-
-                // assigned in loadData() after layout (lane -> category)
-                colorKey: "",
-
-                isStash: false,
-                stashIndex: -1,
-                stashLabel: "",
-                stashParentId: "",
-
-                files: commit.files ?? null,
-                isUncommitted: commit.isUncommitted ?? false
-            }
-
-            compiled.push(obj)
-        }
-
-        // Append any stashes whose parent wasn't found in the commit list (edge case)
-        for (var sk = 0; sk < stashNodeList.length; sk++) {
-            if (!stashInserted[stashNodeList[sk].hash])
-                compiled.push(stashNodeList[sk])
-        }
-
-        return compiled
-    }
-
-    function createUncommittedNode() {
-        if (!statusController)
-            return null;
-
-        let res = statusController.status();
-        if (!res.success || !res.data)
-            return null;
-
-        let staged = [];
-        let unstaged = [];
-
-        res.data.forEach((file) => {
-            if (file.isStaged)
-            {
-                staged.push(file);
-            }
-            else if (file.isUnstaged || file.isUntracked)
-            {
-                unstaged.push(file);
-            }
-        });
-
-        let total = staged.length + unstaged.length;
-        if (total === 0)
-            return null;
+    function getMenuState(commitData) {
+        var branches        = commitData.branchNames || []
+        var shortHash       = commitData.shortHash || commitData.hash.substring(0, 7)
+        var isHead          = commitData.hash === root.headHash
+        var currentBranch   = root.branchController.getCurrentBranchName()
+        var mergeable       = branches.filter(function(b) { return b !== currentBranch && !b.startsWith("origin/") })
 
         return {
-            hash: "__uncommitted__",
-            shortHash: "",
-            message: "Working tree Changes",
-            summary: "Working tree Changes (" + total + " files)",
+            currentBranch       : currentBranch,
+            isHead              : isHead,
+            shortHash           : shortHash,
+            fullHash            : commitData.hash,
+            branchNames         : branches,
+            isStash             : commitData.isStash || false,
+            canCherryPick       : !commitData.isStash && !isHead,
+            canRebase           : !!currentBranch && !isHead,
+            numSelected         : selectedCommitHashesInOrder().length,
+            cherryPickEnabled   : !selectionHasStash() && !selectionHasHead(),
+            hasMergeableBranches: mergeable.length > 0,
+            mergeableBranches   : mergeable
+        }
+    }
 
-            author: "",
-            authorEmail: "",
-            authorDate: "",
+    function selectedCommitHashesInOrder() {
+        var selected = selectedCommitsInOrder()
+        var hashes = []
+        for (var i = 0; i < selected.length; i++) hashes.push(selected[i].hash)
+        return hashes
+    }
 
-            parentHashes: root.headHash ? [root.headHash] : [],
-            commitType: "uncommitted",
+    function selectionHasStash() {
+        var selected = selectedCommitsInOrder()
+        for (var i = 0; i < selected.length; i++) if (selected[i].isStash) return true
+        return false
+    }
 
-            branchNames: [],
-            tagNames: [],
-            colorKey: "uncommitted",
+    function selectionHasHead() {
+        var selected = selectedCommitsInOrder()
+        for (var i = 0; i < selected.length; i++) if (selected[i].hash === root.headHash) return true
+        return false
+    }
 
-            isUncommitted: true,
-            isStash: false,
+    function buildContextMenuModel(raw) {
+        return raw.map(function(item) {
 
-            files: {
-                staged: staged,
-                unstaged: unstaged
+            if (item.separator)
+                return { separator: true }
+
+            var result = {
+                text    : item.text,
+                icon    : resolveMenuIcon(item.icon),
+                enabled : item.enabled !== false
             }
-        };
-    }
 
-    function selectedIndex() {
-        if (!root.selectedCommit || !root.selectedCommit.hash)
-            return -1
-
-        for (var i = 0; i < root.commits.length; i++) {
-            if (root.commits[i] && root.commits[i].hash === root.selectedCommit.hash)
-                return i
-        }
-        return -1
-    }
-
-    function selectCommitAtIndex(index) {
-        if (!root.commits || root.commits.length === 0)
-            return
-
-        var i = Math.max(0, Math.min(index, root.commits.length - 1))
-        var c = root.commits[i]
-        if (!c)
-            return
-
-        root.setSingleSelection(c, i)
-
-        root.selectedCommit = c
-        root.commitClicked(c.hash)
-
-        commitsListView.positionViewAtIndex(i, ListView.Contain)
-    }
-
-    function selectPrevious(navigationRule) {
-        if (navigationRule !== undefined)
-            root.navigationRule = navigationRule
-        
-        if (!root.commits || root.commits.length === 0)
-            return
-
-        var idx = selectedIndex()
-        if (idx < 0) {
-            selectCommitAtIndex(0)
-            return
-        }
-
-        var currentCommit = root.selectedCommit
-        if (!currentCommit)
-            return
-
-        if (root.navigationRule === "Parent 1") {
-            for (var i = idx - 1; i >= 0; i--) {
-                var commit = root.commits[i]
-                if (commit && commit.parentHashes && commit.parentHashes.length > 0) {
-                    if (commit.parentHashes[0] === currentCommit.hash) {
-                        selectCommitAtIndex(i)
-                        return
-                    }
+            if (item.subItems) {
+                result.subItems = buildContextMenuModel(item.subItems)
+            } else {
+                result.action = function() {
+                    root.executeMenuAction(item)
                 }
             }
-            return
-        }
 
-        if (root.navigationRule === "Branch") {
-            var laneKey = currentCommit.colorKey
-            if (!laneKey)
-                return
-
-            for (var i = idx - 1; i >= 0; i--) {
-                var commit = root.commits[i]
-                if (commit && commit.colorKey === laneKey) {
-                    selectCommitAtIndex(i)
-                    return
-                }
-            }
-            return
-        }
-
-        var matchValue = getNavigationRuleValue(currentCommit, root.navigationRule)
-        
-        for (var i = idx - 1; i >= 0; i--) {
-            var commit = root.commits[i]
-            if (commit && getNavigationRuleValue(commit, root.navigationRule) === matchValue) {
-                selectCommitAtIndex(i)
-                return
-            }
-        }
-    }
-
-    function selectNext(navigationRule) {
-        if (navigationRule !== undefined)
-            root.navigationRule = navigationRule
-        
-        if (!root.commits || root.commits.length === 0)
-            return
-
-        var idx = selectedIndex()
-        if (idx < 0) {
-            selectCommitAtIndex(0)
-            return
-        }
-
-        var currentCommit = root.selectedCommit
-        if (!currentCommit)
-            return
-
-        if (root.navigationRule === "Parent 1") {
-            if (!currentCommit.parentHashes || currentCommit.parentHashes.length === 0) {
-                return
-            }
-            
-            var parentHash = currentCommit.parentHashes[0]
-            
-            for (var i = idx + 1; i < root.commits.length; i++) {
-                var commit = root.commits[i]
-                if (commit && commit.hash === parentHash) {
-                    selectCommitAtIndex(i)
-                    return
-                }
-            }
-            return
-        }
-
-        if (root.navigationRule === "Branch") {
-            var laneKey = currentCommit.colorKey
-            if (!laneKey)
-                return
-
-            for (var i = idx + 1; i < root.commits.length; i++) {
-                var commit = root.commits[i]
-                if (commit && commit.colorKey === laneKey) {
-                    selectCommitAtIndex(i)
-                    return
-                }
-            }
-            return
-        }
-
-        var matchValue = getNavigationRuleValue(currentCommit, root.navigationRule)
-        
-        for (var i = idx + 1; i < root.commits.length; i++) {
-            var commit = root.commits[i]
-            if (commit && getNavigationRuleValue(commit, root.navigationRule) === matchValue) {
-                selectCommitAtIndex(i)
-                return
-            }
-        }
-    }
-
-    /*!
-     * Helper function to extract the value from a commit based on the navigation rule
-     */
-    function getNavigationRuleValue(commit, rule) {
-        if (!commit)
-            return null
-        
-        switch(rule) {
-            case "Author":
-                return normalizeFilterString(commit.author)
-            case "Author Email":
-                return normalizeFilterString(commit.authorEmail)
-            case "Parent 1":
-                // For Parent 1, return the first parent hash
-                return (commit.parentHashes && commit.parentHashes.length > 0) 
-                    ? commit.parentHashes[0] 
-                    : null
-            case "Branch":
-                return commit.colorKey
-            case "Message":
-            default:
-                return normalizeFilterString(commit.summary)
-        }
-    }
-
-    function reloadAll() {
-        if (!commitController || !branchController || !root.appModel || !root.appModel.currentRepository) {
-            return;
-        }
-
-        GraphUtils.clearBranchColorCache();
-        GraphUtils.clearTagColorCache();
-        GraphUtils.clearCategoryColorCache();
-
-        commitsOffset = 0
-        hasMoreCommits = true
-        isLoadingMore = false
-
-        root.headHash = statusController.getHeadHash()
-        let allBranches = branchController.getBranches();
-        let commitRes = commitController.getCommits(pageSize, commitsOffset);
-
-        if (!commitRes.success)
-            return;
-        let page = commitRes.data;
-
-        var stashes = []
-        if (root.stashController) {
-            var stashRes = root.stashController.list()
-            if (stashRes.success && stashRes.data)
-                stashes = stashRes.data
-        }
-
-        var commits = compileGraphCommits(page, allBranches, stashes);
-        var uncommitted = createUncommittedNode();
-        if (uncommitted)
-            commits.unshift(uncommitted);
-        commitsOffset = page ? page.length : 0
-        hasMoreCommits = (page && page.length === pageSize)
-
-        // Store full dataset and apply current filter
-        root.allCommits = commits.slice(0)
-        root.applyFilter(root.filterText, root.filterStartDate, root.filterEndDate)
-    }
-
-    function loadMoreCommits() {
-        if (isLoadingMore || !hasMoreCommits)
-            return
-        if (!branchController || !root.appModel || !root.appModel.currentRepository)
-            return
-
-        var currentContentY = commitsListView.contentY;
-        isLoadingMore = true
-
-        let allBranches = branchController.getBranches();
-        let commitRes = commitController.getCommits(pageSize, commitsOffset);
-
-        if (!commitRes.success)
-            return;
-        let page = commitRes.data;
-        if (!page || page.length === 0) {
-            hasMoreCommits = false
-            isLoadingMore = false
-            return
-        }
-
-        var stashes = []
-        if (root.stashController) {
-            var stashRes = root.stashController.list()
-            if (stashRes.success && stashRes.data)
-                stashes = stashRes.data
-        }
-
-        var compiled = compileGraphCommits(page, allBranches, stashes);
-
-        var existingWithoutStashes = root.allCommits.filter(function(c) {
-            return !c.isStash
-        })
-
-        var commits = existingWithoutStashes.concat(compiled)
-        commitsOffset = page.length + commitsOffset
-        hasMoreCommits = (page.length === pageSize)
-
-        root.allCommits = commits.slice(0)
-        root.applyFilter(root.filterText, root.filterStartDate, root.filterEndDate)
-
-        commitsListView.contentY = currentContentY;
-
-        isLoadingMore = false
-    }
-
-    function update() {
-        graphCanvas.requestPaint()
-    }
-
-    function addMergeEntries(finalModel, branches, currentBranch, isCurrentHead) {
-
-        if (!branches || branches.length === 0)
-            return;
-
-        if (!currentBranch)
-            return;
-
-        var mergeable = branches.filter(function(b) {
-            return b !== currentBranch && !b.startsWith("origin/")
-        });
-
-        if (mergeable.length === 0)
-            return;
-
-        function handleMergeResult(res) {
-            if (mergeController.hasMergeConflicts()) {
-                mergeConflictPopup.show()
-                if (notificationController)
-                    notificationController.warning(
-                        "Merge conflicts detected. Resolve them then continue.", "Merge", 4000)
-                return
-            }
-            if (!res.success) {
-                if (notificationController)
-                    notificationController.error(res.errorMessage || "Merge failed", "Merge", 5000)
-                return
-            }
-            if (notificationController)
-                notificationController.success("Merge completed successfully", "Merge", 3000)
-        }
-
-        finalModel.push({ separator: true });
-
-        mergeable.forEach(function(bName) {
-            finalModel.push({
-                text: "Merge '" + bName + "' into '" + currentBranch + "'",
-                icon: Style.icons.arowLeftRight,
-                enabled: !isCurrentHead,
-                action: function() {
-                    mergeMethodPopup.sourceBranch = bName
-                    mergeMethodPopup.targetBranch = currentBranch
-                    mergeMethodPopup.accepted.connect(function(noFF) {
-                        handleMergeResult(mergeController.mergeBranchIntoCurrent(bName, noFF))
-                        mergeMethodPopup.accepted.disconnect(arguments.callee)
-                    })
-                    mergeMethodPopup.open()
-                }
-            });
-        });
-    }
-
-    function addRebaseEntries(finalModel, commitData, currentBranch, isCurrentHead) {
-        if (!rebaseController || !branchController)
-            return
-
-        if (!currentBranch)
-            return
-
-        if (!commitData || !commitData.hash)
-            return
-
-        var shortHash = commitData.shortHash || commitData.hash.substring(0, 7)
-
-        finalModel.push({
-            text: "Rebase onto " + shortHash,
-            icon: Style.icons.clockRotateLeft,
-            enabled: !isCurrentHead,
-            action: function() {
-                if (!rebaseController)
-                    return
-
-                var res = rebaseController.rebase(commitData.hash)
-
-                if (res && res.success) {
-                    if (notificationController)
-                        notificationController.success("Rebase completed successfully", "Rebase", 3000)
-                    return
-                }
-
-                if (res && res.data && (res.data.status === "conflict" || res.data.hasConflicts)) {
-                    if (rebaseConflictPopup)
-                        rebaseConflictPopup.show()
-                    if (notificationController)
-                        notificationController.warning("Rebase conflicts detected. Resolve them then continue.", "Rebase", 4000)
-                    return
-                }
-
-                if (notificationController)
-                    notificationController.error(res?.errorMessage || "Rebase failed", "Rebase", 5000)
-            }
+            return result
         })
     }
 
-    function addCherrypickEntries(finalModel, commitData, shortHash, isCurrentHead){
+    function resolveMenuIcon(iconName) {
+        switch (iconName) {
 
-        var selectedHashes = root.selectedCommitHashesInOrder()
-        var selectionCount = selectedHashes.length
-        var cherryPickEnabled = !!root.cherryPickController &&
-                                selectionCount > 0 &&
-                                !root.selectionHasStash() &&
-                                !root.selectionHasHead()
+            case "gitBranch":
+                return Style.icons.gitBranch
 
-        if (selectionCount > 1) {
-            finalModel.push({
-                text: "Cherry-Pick Selected (" + selectionCount + ")",
-                icon: Style.icons.copy,
-                enabled: cherryPickEnabled,
-                action: function() {
-                    if (!root.cherryPickController)
-                        return
+            case "hash":
+                return Style.icons.hash
 
-                    var res = root.cherryPickController.cherryPickCommits(selectedHashes)
-                    handleCherryPickResult(res, selectionCount)
-                }
-            })
-        } else {
-            finalModel.push({
-                text: "Cherry-Pick " + shortHash,
-                icon: Style.icons.copy,
-                enabled: !!root.cherryPickController && !commitData.isStash && !isCurrentHead,
-                action: function() {
-                    if (!root.cherryPickController)
-                        return
+            case "branchPlus":
+                return Style.icons.branchPlus
 
-                    var res = root.cherryPickController.cherryPickCommit(commitData.hash)
-                    handleCherryPickResult(res, 1)
-                }
-            })
+            case "tag":
+                return Style.icons.tag
+
+            case "arowLeftRight":
+                return Style.icons.arowLeftRight
+
+            case "clockRotateLeft":
+                return Style.icons.clockRotateLeft
+
+            case "copy":
+                return Style.icons.copy
+
+            default: return ""
         }
     }
 
-    function handleCherryPickResult(res, selectionCount) {
+    function executeMenuAction(item) {
+        switch (item.action) {
+
+        case "checkoutBranch":
+            executeCheckoutBranch(item.payload.branch)
+            break
+
+        case "checkoutCommit":
+            executeCheckoutCommit(item.payload.hash)
+            break
+
+        case "newBranch":
+            executeNewBranch(item.payload.hash)
+            break
+
+        case "newTag":
+            executeNewTag(item.payload.hash)
+            break
+
+        case "mergeBranch":
+            executeMergeBranch(item.payload.source, item.payload.target)
+            break
+
+        case "rebase":
+            executeRebase(item.payload.hash)
+            break
+        case "cherryPickSelected":
+            executeCherryPickSelected()
+            break
+
+        case "cherryPickSingle":
+            executeCherryPickSingle(item.payload.hash)
+            break
+        }
+    }
+
+    function executeCheckoutBranch(branchName) {
+        handleContextResponse(root.branchController.checkoutBranch(branchName), "Checked out branch " + branchName)
+    }
+
+    function executeCheckoutCommit(commitHash) {
+        handleContextResponse(root.branchController.checkoutCommit(commitHash), "Checked out commit " + commitHash.substring(0, 7))
+    }
+
+    function executeNewBranch(commitHash) {
+        if (!root.addBranchPopup)
+            return
+
+        root.addBranchPopup.branchController    = root.branchController
+        root.addBranchPopup.targetHash          = commitHash
+        root.addBranchPopup.open()
+    }
+
+    function executeNewTag(commitHash) {
+        if (!root.addTagPopup)
+            return
+
+        root.addTagPopup.tagController  = root.tagController || null
+        root.addTagPopup.targetHash     = commitHash
+        root.addTagPopup.open()
+    }
+
+    function executeMergeBranch(source, target) {
+        mergeMethodPopup.sourceBranch = source
+        mergeMethodPopup.targetBranch = target
+        mergeMethodPopup.accepted.connect(function(noFF) {
+            var res = root.mergeController.mergeBranchIntoCurrent(source, noFF)
+            if (root.mergeController.hasMergeConflicts()) {
+                mergeConflictPopup.open()
+                if (root.notificationController) root.notificationController.warning("Merge conflicts detected.", "Merge", 4000)
+            } else if (!res.success) {
+                if (root.notificationController) root.notificationController.error(res.errorMessage || "Merge failed", "Merge", 5000)
+            } else {
+                if (root.notificationController) root.notificationController.success("Merge completed", "Merge", 3000)
+            }
+            mergeMethodPopup.accepted.disconnect(arguments.callee)
+            root.reloadAll()
+        })
+        mergeMethodPopup.open()
+    }
+
+    function executeRebase(commitHash) {
+        var res = root.rebaseController.rebase(commitHash)
         if (res && res.success) {
-            if (root.notificationController) {
-                root.notificationController.success(
-                    selectionCount > 1 ? ("Cherry-picked " + selectionCount + " commits") : "Cherry-pick completed",
-                    "Cherry-Pick",
-                    3000
-                );
+            root.notificationController.success("Rebase completed", "Rebase", 3000)
+        }
+
+        else if (res && res.data && (res.data.status === "conflict" || res.data.hasConflicts)) {
+            rebaseConflictPopup.open()
+            root.notificationController.warning("Rebase conflicts detected.", "Rebase", 4000)
+        }
+
+        else {
+            root.notificationController.error(res ? res.errorMessage : "Rebase failed", "Rebase", 5000)
+        }
+
+        root.reloadAll()
+    }
+
+    function executeCherryPickSelected() {
+        console.log("2")
+        var hashes = selectedCommitHashesInOrder()
+        var res = root.cherryPickController.cherryPickCommits(hashes)
+        if (res && res.success) {
+            root.notificationController.success("Cherry-pick completed", "Cherry-Pick", 3000)
+        }
+
+        else if (res && res.data && (res.data.status === "conflict" || res.data.hasConflicts)) {
+            cherryPickConflictPopup.open()
+            root.notificationController.warning("Cherry-pick conflicts detected.", "Cherry-Pick", 4000)
+        }
+
+        else {
+            root.notificationController.error(res ? res.errorMessage : "Cherry-pick failed", "Cherry-Pick", 5000)
+        }
+
+        root.reloadAll()
+    }
+
+    function executeCherryPickSingle(commitHash) {
+        console.log("1")
+        var res = root.cherryPickController.cherryPickCommit(commitHash)
+        if (res && res.success) {
+            if (root.notificationController) root.notificationController.success("Cherry-pick completed", "Cherry-Pick", 3000)
+        }
+
+        else if (res && res.data && (res.data.status === "conflict" || res.data.hasConflicts)) {
+            cherryPickConflictPopup.open()
+            root.notificationController.warning("Cherry-pick conflicts detected.", "Cherry-Pick", 4000)
+        }
+
+        else {
+            root.notificationController.error(res ? res.errorMessage : "Cherry-pick failed", "Cherry-Pick", 5000)
+        }
+
+        root.reloadAll()
+    }
+
+    function handleItemDoubleClick(data, button, modifiers, idx) {
+        if (button !== Qt.LeftButton || !data)
+            return
+
+        if (data.isUncommitted || data.isStash || data.hash === root.headHash)
+            return
+
+        var branches    = data.branchNames || []
+        var shortHash   = data.shortHash || data.hash.substring(0, 7)
+
+        if (!branches.length) {
+            var checkoutCommitRes = root.branchController.checkoutCommit(data.hash)
+            handleContextResponse(checkoutCommitRes, "Checked out commit " + shortHash)
+            return
+        }
+
+        var allBranches = root.branchController.getBranches()
+        var localNames  = {}
+        for (var i = 0; i < allBranches.length; i++) {
+            var b = allBranches[i]
+            if (b && b.isLocal) localNames[b.name] = true
+        }
+
+        var seen = {}
+        var deduped = []
+        for (var j = 0; j < branches.length; j++) {
+            var name = branches[j]
+            var base = name.replace(/^[^/]+\//, "")
+            if (!seen[base]) {
+                seen[base] = true
+                deduped.push(localNames[base] ? base : name)
             }
-            root.reloadAll();
-            return;
         }
 
-        if (res && res.data && (res.data.status === "conflict" || res.data.hasConflicts)) {
-            if (cherryPickConflictPopup) cherryPickConflictPopup.show();
-            if (root.notificationController) {
-                root.notificationController.warning("Cherry-pick conflicts detected. Please resolve them.", "Cherry-Pick", 4000);
-            }
-            return;
-        }
-
-        if (root.notificationController) {
-            root.notificationController.error(res ? res.errorMessage : "Cherry-pick failed", "Cherry-Pick", 5000);
+        if (deduped.length === 1) {
+            handleCheckoutBranchOrCreate(deduped[0], data.hash)
+        } else {
+            checkoutBranchSelector.commitHash = data.hash
+            checkoutBranchSelector.branches = deduped
+            checkoutBranchSelector.open()
         }
     }
 
-
-    onRepositoryControllerChanged: reloadAll();
-
-    onStashControllerChanged: {
-        if (root.stashController && root.allCommits && root.allCommits.length > 0) {
-            root.refreshStashNodes()
+    function handleCheckoutBranchOrCreate(branchName, commitHash) {
+        var allBranches = root.branchController.getBranches()
+        var localNames  = {}
+        for (var i = 0; i < allBranches.length; i++) {
+            var b = allBranches[i]
+            if (b && b.isLocal) localNames[b.name] = true
         }
+
+        if (localNames[branchName]) {
+            handleContextResponse(root.branchController.checkoutBranch(branchName), "Checked out branch " + branchName)
+            return
+        }
+
+        var localName = branchName.replace(/^[^/]+\//, "")
+        var createRes = root.branchController.createBranch(commitHash, localName)
+        if (!createRes.success) {
+            handleContextResponse(createRes, "")
+            return
+        }
+
+        handleContextResponse(root.branchController.checkoutBranch(localName), "Created and checked out branch " + localName)
     }
 
-    onAllCommitsChanged: {
-        root.allCommitsHash = {}
-        for(let i = 0 ; i < root.allCommits.length; ++i)
-            root.allCommitsHash[root.allCommits[i].hash] = root.allCommits[i].hash
+
+
+    function handleContextResponse(res, successMsg) {
+        if (res && res.success)
+            root.notificationController.success(successMsg, "Checkout", 3000)
+
+        else
+            root.notificationController.error(res ? (res.errorMessage || "Operation failed") : "Operation failed", "Operation Error", 5000)
+
+        root.selectedCommit = null
+        root.selectedCommitHashes = []
+        root.lastSelectedIndex = -1
+        root.reloadAll()
     }
 
-    Connections {
-        target: repositoryController
-        function onRepositorySelected(repo) {
-            reloadAll();
-        }
+    function selectNext(rule) {
+        var idx = Navigation.selectedIndex(root.commits, root.selectedCommit)
+        var result = Navigation.selectNext(root.commits, root.selectedCommit, idx, root.navigationRule, rule)
+        if (!result) return
+
+        if (rule !== undefined) root.navigationRule = rule
+        setSingleSelection(result.selected, result.index)
+        root.selectedCommit = result.selected
+        root.commitClicked(result.selected.hash)
+        if (result.scroll) commitsListView.positionViewAtIndex(result.index, ListView.Center)
     }
 
-    Connections {
-        target: appModel?.appSettings?.generalSettings ?? null
-        function onShowAvatarChanged() {
-            graphCanvas.requestPaint()
-        }
+    function selectPrevious(rule) {
+        var idx = Navigation.selectedIndex(root.commits, root.selectedCommit)
+        var result = Navigation.selectPrevious(root.commits, root.selectedCommit, idx, root.navigationRule, rule)
+        if (!result) return
 
-        function onShowStashNodesChanged() {
-            root.refreshStashNodes()
-        }
+        if (rule !== undefined) root.navigationRule = rule
+        setSingleSelection(result.selected, result.index)
+        root.selectedCommit = result.selected
+        root.commitClicked(result.selected.hash)
+        if (result.scroll) commitsListView.positionViewAtIndex(result.index, ListView.Center)
     }
 }

--- a/Qml/View/Components/Docks/CommitGraphDock.qml
+++ b/Qml/View/Components/Docks/CommitGraphDock.qml
@@ -348,31 +348,34 @@ DetachablePanel {
 
     ConflictPopup {
         id: mergeConflictPopup
-        currentOperation: ConflictPopup.OperationType.Merge
-        mergeController: root.mergeController
-        conflictController: root.conflictController
-        notificationController: root.notificationController
-        statusController: root.statusController
+        currentOperation        : ConflictPopup.OperationType.Merge
+        mergeController         : root.mergeController
+        conflictController      : root.conflictController
+        notificationController  : root.notificationController
+        statusController        : root.statusController
+        onOperationCompleted    : reloadAll()
     }
 
     MergeMethodPopup { id: mergeMethodPopup }
 
     ConflictPopup {
         id: rebaseConflictPopup
-        currentOperation: ConflictPopup.OperationType.Rebase
-        rebaseController: root.rebaseController
-        conflictController: root.conflictController
-        notificationController: root.notificationController
-        statusController: root.statusController
+        currentOperation        : ConflictPopup.OperationType.Rebase
+        rebaseController        : root.rebaseController
+        conflictController      : root.conflictController
+        notificationController  : root.notificationController
+        statusController        : root.statusController
+        onOperationCompleted    : reloadAll()
     }
 
     ConflictPopup {
         id: cherryPickConflictPopup
-        currentOperation: ConflictPopup.OperationType.CherryPick
-        cherryPickController: root.cherryPickController
-        conflictController: root.conflictController
-        notificationController: root.notificationController
-        statusController: root.statusController
+        currentOperation        : ConflictPopup.OperationType.CherryPick
+        cherryPickController    : root.cherryPickController
+        conflictController      : root.conflictController
+        notificationController  : root.notificationController
+        statusController        : root.statusController
+        onOperationCompleted    : reloadAll()
     }
 
     CheckoutBranchSelectorPopup {

--- a/Qml/View/Components/Docks/CommitGraphDock.qml
+++ b/Qml/View/Components/Docks/CommitGraphDock.qml
@@ -247,6 +247,17 @@ DetachablePanel {
                     model   : root.commits
                     clip    : true
 
+                    // Sync scroll position with graph
+                    onContentYChanged: {
+                        // Infinite scroll trigger (list side)
+                        if (!root.isLoadingMore && root.hasMoreCommits) {
+                            var remaining = commitsListView.contentHeight - (commitsListView.contentY + commitsListView.height)
+                            if (remaining < 300) {
+                                root.loadMoreCommits()
+                            }
+                        }
+                    }
+
                     delegate: CommitListDelegate {
                         height: root.commitItemHeight + root.commitItemSpacing * 2
 

--- a/Qml/View/Components/Docks/CommitGraphDock.qml
+++ b/Qml/View/Components/Docks/CommitGraphDock.qml
@@ -265,15 +265,7 @@ DetachablePanel {
                         authorWidth : root.commitsColAuthorWidth
                         dateWidth   : root.commitsColDateWidth
 
-                        indicatorColor: {
-                            if (modelData && modelData.isUncommitted)
-                                return "#888888"
-
-                            if (!modelData || !modelData.colorKey)
-                                return GraphUtils.getCategoryColor("default")
-
-                            return GraphUtils.getCategoryColor(modelData.colorKey)
-                        }
+                        indicatorColor: graphCanvas.commitColor(modelData)
 
                         isSelected  : root.isCommitSelected(modelData.hash)
                         isHead      : modelData ? modelData.hash === root.headHash  : false

--- a/Qml/View/Components/Docks/CommitGraphDock.qml
+++ b/Qml/View/Components/Docks/CommitGraphDock.qml
@@ -116,8 +116,8 @@ DetachablePanel {
                     ResizableColumnHeader {
                         Layout.preferredWidth: root.commitsColGraphWidth
                         label: "Graph"
-                        onResized: function(delta) {
-                            var newWidth = Math.max(root.minColGraphWidth, root.commitsColGraphWidth + delta)
+                        onResized: function(delta, startWidth) {
+                            var newWidth = Math.max(root.minColGraphWidth, startWidth + delta)
                             var actualDelta = newWidth - root.commitsColGraphWidth
                             var nextWidth = root.commitsColBranchTagWidth - actualDelta
                             if (nextWidth < root.minColBranchTagWidth) {
@@ -132,8 +132,8 @@ DetachablePanel {
                     ResizableColumnHeader {
                         Layout.preferredWidth: root.commitsColBranchTagWidth
                         label: "Branch/Tag"
-                        onResized: function(delta) {
-                            var newWidth = Math.max(root.minColBranchTagWidth, root.commitsColBranchTagWidth + delta)
+                        onResized: function(delta, startWidth) {
+                            var newWidth = Math.max(root.minColBranchTagWidth, startWidth + delta)
                             var actualDelta = newWidth - root.commitsColBranchTagWidth
                             var nextWidth = root.commitsColMessageWidth - actualDelta
                             if (nextWidth < root.minColMessageWidth) {
@@ -148,8 +148,8 @@ DetachablePanel {
                     ResizableColumnHeader {
                         Layout.preferredWidth: root.commitsColMessageWidth
                         label: "Message"
-                        onResized: function(delta) {
-                            var newWidth = Math.max(root.minColMessageWidth, root.commitsColMessageWidth + delta)
+                        onResized: function(delta, startWidth) {
+                            var newWidth = Math.max(root.minColMessageWidth, startWidth + delta)
                             var actualDelta = newWidth - root.commitsColMessageWidth
                             var nextWidth = root.commitsColAuthorWidth - actualDelta
                             if (nextWidth < root.minColAuthorWidth) {
@@ -164,8 +164,8 @@ DetachablePanel {
                     ResizableColumnHeader {
                         Layout.preferredWidth: root.commitsColAuthorWidth
                         label: "Author"
-                        onResized: function(delta) {
-                            var newWidth = Math.max(root.minColAuthorWidth, root.commitsColAuthorWidth + delta)
+                        onResized: function(delta, startWidth) {
+                            var newWidth = Math.max(root.minColAuthorWidth, startWidth + delta)
                             var actualDelta = newWidth - root.commitsColAuthorWidth
                             var nextWidth = root.commitsColDateWidth - actualDelta
                             if (nextWidth < root.minColDateWidth) {
@@ -328,17 +328,6 @@ DetachablePanel {
 
         function onShowStashNodesChanged() {
             root.refreshStashNodes()
-        }
-    }
-
-    Connections {
-        target: root
-        function onGraphColumnWidthChanged() {
-            graphCanvas.requestPaint()
-        }
-
-        function onBranchTagColumnWidthChanged() {
-            graphCanvas.requestPaint()
         }
     }
 

--- a/Qml/View/Components/Docks/CommitGraphDock.qml
+++ b/Qml/View/Components/Docks/CommitGraphDock.qml
@@ -356,7 +356,7 @@ DetachablePanel {
         conflictController      : root.conflictController
         notificationController  : root.notificationController
         statusController        : root.statusController
-        onOperationCompleted    : reloadAll()
+        // onOperationCompleted    : reloadAll()        //TODO
     }
 
     MergeMethodPopup { id: mergeMethodPopup }
@@ -368,7 +368,7 @@ DetachablePanel {
         conflictController      : root.conflictController
         notificationController  : root.notificationController
         statusController        : root.statusController
-        onOperationCompleted    : reloadAll()
+        // onOperationCompleted    : reloadAll()        //TODO
     }
 
     ConflictPopup {
@@ -378,7 +378,7 @@ DetachablePanel {
         conflictController      : root.conflictController
         notificationController  : root.notificationController
         statusController        : root.statusController
-        onOperationCompleted    : reloadAll()
+        // onOperationCompleted    : reloadAll()        //TODO
     }
 
     CheckoutBranchSelectorPopup {

--- a/Qml/View/Components/Docks/CommitGraphDock.qml
+++ b/Qml/View/Components/Docks/CommitGraphDock.qml
@@ -985,8 +985,6 @@ DetachablePanel {
         handleContextResponse(root.branchController.checkoutBranch(localName), "Created and checked out branch " + localName)
     }
 
-
-
     function handleContextResponse(res, successMsg) {
         if (res && res.success)
             root.notificationController.success(successMsg, "Checkout", 3000)
@@ -1001,26 +999,38 @@ DetachablePanel {
     }
 
     function selectNext(rule) {
-        var idx = Navigation.selectedIndex(root.commits, root.selectedCommit)
-        var result = Navigation.selectNext(root.commits, root.selectedCommit, idx, root.navigationRule, rule)
-        if (!result) return
+        var idx     = Navigation.selectedIndex(root.commits, root.selectedCommit)
+        var result  = Navigation.selectNext(root.commits, root.selectedCommit, idx, root.navigationRule, rule)
 
-        if (rule !== undefined) root.navigationRule = rule
+        if (!result)
+            return
+
+        if (rule !== undefined)
+            root.navigationRule = rule
+
         setSingleSelection(result.selected, result.index)
         root.selectedCommit = result.selected
         root.commitClicked(result.selected.hash)
-        if (result.scroll) commitsListView.positionViewAtIndex(result.index, ListView.Center)
+
+        if (result.scroll)
+            commitsListView.positionViewAtIndex(result.index, ListView.Contain)
     }
 
     function selectPrevious(rule) {
-        var idx = Navigation.selectedIndex(root.commits, root.selectedCommit)
-        var result = Navigation.selectPrevious(root.commits, root.selectedCommit, idx, root.navigationRule, rule)
-        if (!result) return
+        var idx     = Navigation.selectedIndex(root.commits, root.selectedCommit)
+        var result  = Navigation.selectPrevious(root.commits, root.selectedCommit, idx, root.navigationRule, rule)
 
-        if (rule !== undefined) root.navigationRule = rule
+        if (!result)
+            return
+
+        if (rule !== undefined)
+            root.navigationRule = rule
+
         setSingleSelection(result.selected, result.index)
         root.selectedCommit = result.selected
         root.commitClicked(result.selected.hash)
-        if (result.scroll) commitsListView.positionViewAtIndex(result.index, ListView.Center)
+
+        if (result.scroll)
+            commitsListView.positionViewAtIndex(result.index, ListView.Contain)
     }
 }

--- a/Qml/View/Components/Docks/CommitGraphDock.qml
+++ b/Qml/View/Components/Docks/CommitGraphDock.qml
@@ -510,6 +510,7 @@ DetachablePanel {
 
     function update() {
         graphCanvas.requestPaint()
+
     }
 
     function reloadAll() {
@@ -521,8 +522,7 @@ DetachablePanel {
         hasMoreCommits  = true
         isLoadingMore   = false
 
-        var headRes = root.statusController ? root.statusController.getHeadHash() : null
-        root.headHash = (headRes && headRes.success) ? headRes.data : ""
+        root.headHash = root.statusController.getHeadHash()
 
         var commitRes = root.commitController.getCommits(pageSize, commitsOffset)
         if (!commitRes.success || !commitRes.data) return

--- a/Qml/View/Components/GraphView/CommitGraphCanvas.qml
+++ b/Qml/View/Components/GraphView/CommitGraphCanvas.qml
@@ -17,26 +17,28 @@ import "qrc:/GitEase/Qml/Core/Scripts/GraphUtils.js" as GraphUtils
 Item {
     id: root
 
-    // ---------- Public properties (bound from dock) ----------
-    property var commits: []
-    property var commitPositions: ({})
-    property int columnSpacing: 30
-    property int commitItemHeight: 24
-    property int commitItemSpacing: 4
-    property var selectedHashes: []
-    property string headHash: ""
-    property bool showAvatar: true
-    property real graphColumnWidth: 60
-    property real branchTagColumnWidth: 80
-    property var allCommitsHash: ({})
+    /*! ***********************************************************************************************
+     * Property Declarations
+     * ************************************************************************************************/
 
+    property var    commits             : []
+    property var    commitPositions     : ({})
+    property int    columnSpacing       : 30
+    property int    commitItemHeight    : 24
+    property int    commitItemSpacing   : 4
+    property var    selectedHashes      : []
+    property string headHash            : ""
+    property bool   showAvatar          : true
+    property real   graphColumnWidth    : 60
+    property real   branchTagColumnWidth: 80
+    property var    allCommitsHash      : ({})
+
+    /* Signals
+     * ****************************************************************************************/
     signal infiniteScroll()
 
-    function requestPaint() {
-        graphCanvas.requestPaint()
-    }
-
-    // ---------- Flickable (fills the whole Item) ----------
+    /* Children
+     * ****************************************************************************************/
     Flickable {
         id: flick
         anchors.fill: parent

--- a/Qml/View/Components/GraphView/CommitGraphCanvas.qml
+++ b/Qml/View/Components/GraphView/CommitGraphCanvas.qml
@@ -121,11 +121,6 @@ Item {
                 }
 
                 // Helper functions (local for convenience)
-                function commitColor(commitObj) {
-                    if (commitObj && commitObj.isUncommitted) return "#888888";
-                    if (!commitObj || !commitObj.colorKey) return GraphUtils.getCategoryColor("default");
-                    return GraphUtils.getCategoryColor(commitObj.colorKey);
-                }
                 function edgeColor(edge, commitByHash) {
                     if (commitByHash && edge && edge.from) {
                         var fromCommit = commitByHash[edge.from];
@@ -179,7 +174,7 @@ Item {
                         if (pp) {
                             var parentX = centerOffset + pp.column * root.columnSpacing + root.columnSpacing / 2;
                             var parentY = pp.y + root.commitItemHeight / 2 + root.commitItemSpacing;
-                            var branchColor2 = commitColor(commit2);
+                            var branchColor2 = root.commitColor(commit2);
 
                             ctx.save();
                             ctx.strokeStyle = branchColor2;
@@ -204,7 +199,7 @@ Item {
                             }
                         }
                         if (canDraw) {
-                            var branchColor2 = commitColor(commit2);
+                            var branchColor2 = root.commitColor(commit2);
                             ctx.save();
                             ctx.strokeStyle = branchColor2;
                             ctx.globalAlpha = 0.9;
@@ -294,7 +289,7 @@ Item {
 
                     var centerXForLine = centerOffset + posForLine.column * root.columnSpacing + root.columnSpacing / 2;
                     var centerYForLine = posForLine.y + root.commitItemHeight / 2 + root.commitItemSpacing;
-                    var laneLabelColor = commitColor(commitForLine);
+                    var laneLabelColor = root.commitColor(commitForLine);
 
                     var allLabels = [];
                     if (commitForLine.tagNames && commitForLine.tagNames.length > 0) {
@@ -382,7 +377,7 @@ Item {
 
                     var centerX2 = centerOffset + pos3.column * root.columnSpacing + root.columnSpacing / 2;
                     var centerY2 = pos3.y + root.commitItemHeight / 2 + root.commitItemSpacing;
-                    var branchColor3 = commitColor(commit3);
+                    var branchColor3 = root.commitColor(commit3);
 
                     var isSelected = isCommitSelected(commit3.hash);
                     var isHead = commit3.hash === root.headHash;
@@ -439,6 +434,12 @@ Item {
 
     /* Functions
      * ****************************************************************************************/
+
+    function commitColor(commitObj) {
+        if (commitObj && commitObj.isUncommitted) return "#888888"
+        if (!commitObj || !commitObj.colorKey) return GraphUtils.getCategoryColor("default")
+        return GraphUtils.getCategoryColor(commitObj.colorKey)
+    }
 
     onWidthChanged  :  graphCanvas.requestPaint()
     onHeightChanged : graphCanvas.requestPaint()

--- a/Qml/View/Components/GraphView/CommitGraphCanvas.qml
+++ b/Qml/View/Components/GraphView/CommitGraphCanvas.qml
@@ -434,4 +434,10 @@ Item {
             }
         }
     }
+
+    /* Functions
+     * ****************************************************************************************/
+
+    onWidthChanged  :  graphCanvas.requestPaint()
+    onHeightChanged : graphCanvas.requestPaint()
 }

--- a/Qml/View/Components/GraphView/CommitGraphCanvas.qml
+++ b/Qml/View/Components/GraphView/CommitGraphCanvas.qml
@@ -1,0 +1,437 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import GitEase_Style
+import GitEase_Style_Impl
+import "qrc:/GitEase/Qml/Core/Scripts/GraphUtils.js" as GraphUtils
+
+/*! ***********************************************************************************************
+ * CommitGraphCanvas – outer Item (layout-friendly) + internal Flickable + Canvas
+ *
+ * Properties to bind from parent:
+ *   commits, commitPositions, columnSpacing, commitItemHeight, commitItemSpacing
+ *   selectedHashes, headHash, showAvatar, allCommitsHash
+ *   graphColumnWidth, branchTagColumnWidth (for label positioning)
+ *   onInfiniteScroll() signal – fired when near bottom
+ * ************************************************************************************************/
+Item {
+    id: root
+
+    // ---------- Public properties (bound from dock) ----------
+    property var commits: []
+    property var commitPositions: ({})
+    property int columnSpacing: 30
+    property int commitItemHeight: 24
+    property int commitItemSpacing: 4
+    property var selectedHashes: []
+    property string headHash: ""
+    property bool showAvatar: true
+    property real graphColumnWidth: 60
+    property real branchTagColumnWidth: 80
+    property var allCommitsHash: ({})
+
+    signal infiniteScroll()
+
+    function requestPaint() {
+        graphCanvas.requestPaint()
+    }
+
+    // ---------- Flickable (fills the whole Item) ----------
+    Flickable {
+        id: flick
+        anchors.fill: parent
+        clip: true
+
+        contentWidth: {
+            if (!commits.length) return width
+            var maxCols = 0
+            for (var i = 0; i < commits.length; i++) {
+                var hash = commits[i].hash
+                var pos = commitPositions[hash]
+                if (pos && pos.column > maxCols) maxCols = pos.column
+            }
+            return Math.max(width, 40 + (maxCols+1) * columnSpacing + 300)
+        }
+        contentHeight: Math.max(height, commits.length * (commitItemHeight + commitItemSpacing*2))
+        boundsBehavior: Flickable.StopAtBounds
+
+        property bool syncScroll: false
+
+        onContentYChanged: {
+            if (flick.contentHeight > flick.height) {
+                var remaining = flick.contentHeight - (flick.contentY + flick.height)
+                if (remaining < 300) root.infiniteScroll()
+            }
+        }
+
+        // ---------- Canvas (draws the entire DAG) ----------
+        Canvas {
+            id: graphCanvas
+            width: flick.contentWidth
+            height: commits.length * (commitItemHeight + commitItemSpacing*2)
+
+            property var svgImage: Image {
+                source: "qrc:/GitEase/Resources/Images/defaultUserIcon.svg"
+                anchors.centerIn: parent
+                height: 14.5; width: 14.5
+            }
+
+            // Trigger repaint when data changes
+            Connections {
+                target: root
+                function onCommitsChanged() { graphCanvas.requestPaint() }
+                function onSelectedHashesChanged() { graphCanvas.requestPaint() }
+            }
+
+            onPaint: {
+                var ctx = getContext("2d");
+                ctx.clearRect(0, 0, width, height);
+
+                if (!root.commits || root.commits.length === 0) return;
+
+                var maxCols = 0;
+                for (var i = 0; i < root.commits.length; i++) {
+                    var p = root.commitPositions[root.commits[i].hash];
+                    if (p && p.column > maxCols) maxCols = p.column;
+                }
+
+                // ---- Start of original drawing logic (adapted) ----
+
+                var centerOffset = root.columnSpacing / 2;
+
+                // Build quick lookup
+                var commitByHash = {};
+                for (var bi0 = 0; bi0 < root.commits.length; bi0++) {
+                    var c0m = root.commits[bi0];
+                    if (c0m && c0m.hash) commitByHash[c0m.hash] = c0m;
+                }
+
+                // Branch HEAD mapping
+                var branchLatestCommit = {};
+                for (var bi = 0; bi < root.commits.length; bi++) {
+                    var bc = root.commits[bi];
+                    if (bc && bc.branchNames && bc.branchNames.length) {
+                        for (var bni = 0; bni < bc.branchNames.length; bni++) {
+                            var bn = bc.branchNames[bni];
+                            if (bn) branchLatestCommit[bn] = bc.hash;
+                        }
+                    }
+                }
+
+                // Helper functions (local for convenience)
+                function commitColor(commitObj) {
+                    if (commitObj && commitObj.isUncommitted) return "#888888";
+                    if (!commitObj || !commitObj.colorKey) return GraphUtils.getCategoryColor("default");
+                    return GraphUtils.getCategoryColor(commitObj.colorKey);
+                }
+                function edgeColor(edge, commitByHash) {
+                    if (commitByHash && edge && edge.from) {
+                        var fromCommit = commitByHash[edge.from];
+                        if (fromCommit && fromCommit.colorKey)
+                            return GraphUtils.getCategoryColor(fromCommit.colorKey);
+                    }
+                    return GraphUtils.getCategoryColor("edge:" + edge.from + ":" + edge.to);
+                }
+                function isCommitSelected(hash) {
+                    return root.selectedHashes && root.selectedHashes.indexOf(hash) !== -1;
+                }
+
+                // --- Build edge routing data ---
+                var parentInSameLane = {};
+                var crossLaneEdges = [];
+                for (var j = 0; j < root.commits.length; j++) {
+                    var c0 = root.commits[j];
+                    var pos0 = root.commitPositions[c0.hash];
+                    if (!pos0 || !c0.parentHashes) continue;
+                    for (var p2 = 0; p2 < c0.parentHashes.length; p2++) {
+                        var parentHash = c0.parentHashes[p2];
+                        var parentPos = root.commitPositions[parentHash];
+                        if (!parentPos) continue;
+                        if (parentPos.column === pos0.column) {
+                            if (!parentInSameLane[c0.hash]) parentInSameLane[c0.hash] = parentHash;
+                        } else {
+                            var isMerge = c0.commitType === "merge";
+                            crossLaneEdges.push({
+                                from: isMerge ? parentHash : c0.hash,
+                                to: isMerge ? c0.hash : parentHash,
+                                fromPos: isMerge ? parentPos : pos0,
+                                toPos: isMerge ? pos0 : parentPos,
+                                isMerge: isMerge
+                            });
+                        }
+                    }
+                }
+
+                // Phase 1: Same-lane straight lines
+                for (var j2 = 0; j2 < root.commits.length; j2++) {
+                    var commit2 = root.commits[j2];
+                    var pos2 = root.commitPositions[commit2.hash];
+                    if (!pos2) continue;
+
+                    var centerX = centerOffset + pos2.column * root.columnSpacing + root.columnSpacing / 2;
+                    var centerY = pos2.y + root.commitItemHeight / 2 + root.commitItemSpacing;
+                    var parentHash = parentInSameLane[commit2.hash];
+
+                    if (parentHash) {
+                        var pp = root.commitPositions[parentHash];
+                        if (pp) {
+                            var parentX = centerOffset + pp.column * root.columnSpacing + root.columnSpacing / 2;
+                            var parentY = pp.y + root.commitItemHeight / 2 + root.commitItemSpacing;
+                            var branchColor2 = commitColor(commit2);
+
+                            ctx.save();
+                            ctx.strokeStyle = branchColor2;
+                            ctx.globalAlpha = 0.9;
+                            ctx.lineWidth = 2.5;
+                            if (commit2.isUncommitted) ctx.setLineDash([4, 4]);
+                            else ctx.setLineDash([]);
+                            ctx.beginPath();
+                            ctx.moveTo(centerX, centerY);
+                            ctx.lineTo(parentX, parentY);
+                            ctx.stroke();
+                            ctx.setLineDash([]);
+                            ctx.restore();
+                        }
+                    } else {
+                        // Check if any parent is outside loaded set
+                        var canDraw = false;
+                        for (var i2 = 0; i2 < commit2.parentHashes.length; i2++) {
+                            if (!root.allCommitsHash || !root.allCommitsHash[commit2.parentHashes[i2]]) {
+                                canDraw = true;
+                                break;
+                            }
+                        }
+                        if (canDraw) {
+                            var branchColor2 = commitColor(commit2);
+                            ctx.save();
+                            ctx.strokeStyle = branchColor2;
+                            ctx.globalAlpha = 0.9;
+                            ctx.lineWidth = 2.5;
+                            ctx.beginPath();
+                            ctx.moveTo(centerX, centerY);
+                            ctx.lineTo(centerX, graphCanvas.height);
+                            ctx.stroke();
+                            ctx.restore();
+                        }
+                    }
+                }
+
+                // Phase 2: Cross-lane bezier curves
+                for (var edgeIdx = 0; edgeIdx < crossLaneEdges.length; edgeIdx++) {
+                    var edge = crossLaneEdges[edgeIdx];
+                    var fromPos = edge.fromPos;
+                    var toPos = edge.toPos;
+
+                    var fromCenterX = centerOffset + fromPos.column * root.columnSpacing + root.columnSpacing / 2;
+                    var fromCenterY = fromPos.y + root.commitItemHeight / 2 + root.commitItemSpacing;
+                    var toCenterX = centerOffset + toPos.column * root.columnSpacing + root.columnSpacing / 2;
+                    var toCenterY = toPos.y + root.commitItemHeight / 2 + root.commitItemSpacing;
+
+                    var startX = edge.isMerge ? fromCenterX : toCenterX;
+                    var startY = edge.isMerge ? fromCenterY : toCenterY;
+                    var endX = edge.isMerge ? toCenterX : fromCenterX;
+                    var endY = edge.isMerge ? toCenterY : fromCenterY;
+
+                    var edgeColorVal = edgeColor(edge, commitByHash);
+                    var deltaX = endX - startX;
+                    var deltaY = endY - startY;
+                    var curveRadius = Math.min(Math.abs(deltaX) / 2, root.commitItemHeight, Math.abs(deltaY) / 2);
+                    curveRadius = Math.max(curveRadius, 8);
+
+                    ctx.save();
+                    ctx.strokeStyle = edgeColorVal;
+                    ctx.globalAlpha = 0.85;
+                    ctx.lineWidth = 2.5;
+                    ctx.beginPath();
+                    ctx.moveTo(startX, startY);
+
+                    if (deltaX === 0) {
+                        ctx.lineTo(endX, endY);
+                    } else if (deltaX > 0) {
+                        var horizontalEndX = endX - curveRadius;
+                        if (deltaY > 0) {
+                            ctx.lineTo(horizontalEndX, startY);
+                            ctx.quadraticCurveTo(endX, startY, endX, startY + curveRadius);
+                            ctx.lineTo(endX, endY);
+                        } else {
+                            ctx.lineTo(horizontalEndX, startY);
+                            ctx.quadraticCurveTo(endX, startY, endX, startY - curveRadius);
+                            ctx.lineTo(endX, endY);
+                        }
+                    } else {
+                        if (deltaY > 0) {
+                            ctx.lineTo(startX, endY - curveRadius);
+                            ctx.quadraticCurveTo(startX, endY, startX - curveRadius, endY);
+                            ctx.lineTo(endX, endY);
+                        } else {
+                            ctx.lineTo(startX, endY + curveRadius);
+                            ctx.quadraticCurveTo(startX, endY, startX - curveRadius, endY);
+                            ctx.lineTo(endX, endY);
+                        }
+                    }
+                    ctx.stroke();
+                    ctx.restore();
+                }
+
+                // Phase 3: Branch/Tag labels
+                for (var lineIdx = 0; lineIdx < root.commits.length; lineIdx++) {
+                    var commitForLine = root.commits[lineIdx];
+                    var posForLine = root.commitPositions[commitForLine.hash];
+                    if (!posForLine) continue;
+
+                    var isHeadCommitForLabels = false;
+                    var headBranchesForThisCommit = [];
+                    for (var branchKey in branchLatestCommit) {
+                        if (branchLatestCommit[branchKey] === commitForLine.hash) {
+                            isHeadCommitForLabels = true;
+                            headBranchesForThisCommit.push(branchKey);
+                        }
+                    }
+                    if (!isHeadCommitForLabels && (!commitForLine.tagNames || commitForLine.tagNames.length === 0))
+                        continue;
+
+                    var centerXForLine = centerOffset + posForLine.column * root.columnSpacing + root.columnSpacing / 2;
+                    var centerYForLine = posForLine.y + root.commitItemHeight / 2 + root.commitItemSpacing;
+                    var laneLabelColor = commitColor(commitForLine);
+
+                    var allLabels = [];
+                    if (commitForLine.tagNames && commitForLine.tagNames.length > 0) {
+                        for (var tIdx = 0; tIdx < commitForLine.tagNames.length; tIdx++) {
+                            allLabels.push({ text: commitForLine.tagNames[tIdx], color: "#e2c044", isTag: true });
+                        }
+                    }
+                    for (var hbi = 0; hbi < headBranchesForThisCommit.length; hbi++) {
+                        allLabels.push({ text: headBranchesForThisCommit[hbi], color: laneLabelColor, isTag: false });
+                    }
+
+                    if (allLabels.length > 0) {
+                        var divider = root.graphColumnWidth + 10;
+                        var nodeEnd = centerXForLine + 20;
+                        var labelStartX = Math.max(divider, nodeEnd);
+                        var labelY = centerYForLine;
+                        var curX = labelStartX;
+                        var labelSpacing = 8;
+
+                        var labelPositions = [];
+                        for (var calcIdx = 0; calcIdx < allLabels.length; calcIdx++) {
+                            var lblInfo = allLabels[calcIdx];
+                            ctx.font = "bold 11px sans-serif";
+                            ctx.textAlign = "left";
+                            var textW = ctx.measureText(lblInfo.text).width;
+                            var extra = lblInfo.isTag ? 20 : 8;
+                            var lblW = textW + 8 + extra;
+                            labelPositions.push({ x: curX, width: lblW, info: lblInfo });
+                            curX += lblW + labelSpacing;
+                        }
+
+                        if (labelPositions.length > 0) {
+                            var lastLabel = labelPositions[labelPositions.length - 1];
+                            var lineEndX = lastLabel.x + lastLabel.width;
+                            ctx.save();
+                            ctx.strokeStyle = laneLabelColor;
+                            ctx.globalAlpha = 0.8;
+                            ctx.lineWidth = 5;
+                            ctx.beginPath();
+                            ctx.moveTo(centerXForLine, centerYForLine);
+                            ctx.lineTo(lineEndX, labelY);
+                            ctx.stroke();
+                            ctx.restore();
+                        }
+
+                        for (var drawIdx = 0; drawIdx < labelPositions.length; drawIdx++) {
+                            var lblPos = labelPositions[drawIdx];
+                            var lblInfo = lblPos.info;
+                            var lx = lblPos.x;
+                            var lw = lblPos.width;
+                            var lh = 20;
+                            var ly = labelY - lh / 2;
+
+                            ctx.save();
+                            ctx.fillStyle = lblInfo.color;
+                            ctx.globalAlpha = 0.95;
+                            GraphUtils.drawRoundedRect(ctx, lx, ly, lw, lh, 2);
+                            ctx.fill();
+
+                            var contrast = GraphUtils.getContrastColor(lblInfo.color);
+                            ctx.fillStyle = contrast;
+                            ctx.globalAlpha = 1.0;
+                            ctx.textBaseline = "middle";
+                            ctx.textAlign = "left";
+
+                            if (lblInfo.isTag) {
+                                ctx.font = "9px sans-serif";
+                                ctx.fillText(typeof Style !== "undefined" ? Style.icons.tag : "🏷", lx + 4, labelY);
+                                ctx.font = "bold 11px sans-serif";
+                                ctx.fillText(lblInfo.text, lx + 20, labelY);
+                            } else {
+                                ctx.font = "bold 11px sans-serif";
+                                ctx.fillText(lblInfo.text, lx + 8, labelY);
+                            }
+                            ctx.restore();
+                        }
+                    }
+                }
+
+                // Phase 4: Commit nodes
+                for (var k = 0; k < root.commits.length; k++) {
+                    var commit3 = root.commits[k];
+                    var pos3 = root.commitPositions[commit3.hash];
+                    if (!pos3) continue;
+
+                    var centerX2 = centerOffset + pos3.column * root.columnSpacing + root.columnSpacing / 2;
+                    var centerY2 = pos3.y + root.commitItemHeight / 2 + root.commitItemSpacing;
+                    var branchColor3 = commitColor(commit3);
+
+                    var isSelected = isCommitSelected(commit3.hash);
+                    var isHead = commit3.hash === root.headHash;
+
+                    if (isSelected) {
+                        ctx.fillStyle = "#6088B2DF";
+                        ctx.fillRect(0, pos3.y, graphCanvas.width, root.commitItemHeight + root.commitItemSpacing*2);
+                    } else if (isHead) {
+                        ctx.fillStyle = "#40FFA500";
+                        ctx.fillRect(0, pos3.y, graphCanvas.width, root.commitItemHeight + root.commitItemSpacing*2);
+                    }
+
+                    ctx.save();
+                    ctx.strokeStyle = isSelected ? GraphUtils.darkenColor(branchColor3, 0.2) : GraphUtils.lightenColor(branchColor3, 0.3);
+                    ctx.lineWidth = isSelected ? 4 : 2.5;
+
+                    var avatarSize = root.showAvatar ? root.commitItemHeight : 10;
+                    var avatarRadius = avatarSize / 2;
+                    var isStashNode = commit3.isStash === true;
+
+                    if (isStashNode) {
+                        var sqSize = avatarRadius;
+                        ctx.beginPath();
+                        ctx.moveTo(centerX2 - sqSize + 2, centerY2 - sqSize);
+                        ctx.arcTo(centerX2 + sqSize, centerY2 - sqSize, centerX2 + sqSize, centerY2 + sqSize, 2);
+                        ctx.arcTo(centerX2 + sqSize, centerY2 + sqSize, centerX2 - sqSize, centerY2 + sqSize, 2);
+                        ctx.arcTo(centerX2 - sqSize, centerY2 + sqSize, centerX2 - sqSize, centerY2 - sqSize, 2);
+                        ctx.arcTo(centerX2 - sqSize, centerY2 - sqSize, centerX2 + sqSize, centerY2 - sqSize, 2);
+                        ctx.closePath();
+                        ctx.fillStyle = branchColor3;
+                        ctx.fill();
+                        ctx.stroke();
+                        if (root.showAvatar) {
+                            ctx.fillStyle = "#ffffff";
+                            ctx.textAlign = "center";
+                            ctx.textBaseline = "middle";
+                            ctx.fillText(typeof Style !== "undefined" ? Style.icons.archive : "📦", centerX2, centerY2);
+                        }
+                    } else {
+                        ctx.beginPath();
+                        ctx.arc(centerX2, centerY2, avatarRadius, 0, 2 * Math.PI);
+                        ctx.fillStyle = root.showAvatar ? "#D9D9D9" : GraphUtils.lightenColor(branchColor3, 0.3);
+                        ctx.fill();
+                        ctx.stroke();
+                        if (root.showAvatar) {
+                            ctx.drawImage(graphCanvas.svgImage, centerX2 - graphCanvas.svgImage.width/2, centerY2 - graphCanvas.svgImage.height/2);
+                        }
+                    }
+                    ctx.restore();
+                }
+            }
+        }
+    }
+}

--- a/Qml/View/Components/GraphView/CommitListDelegate.qml
+++ b/Qml/View/Components/GraphView/CommitListDelegate.qml
@@ -1,0 +1,217 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+import GitEase_Style
+import GitEase_Style_Impl
+import GitEase
+
+import "qrc:/GitEase/Qml/Core/Scripts/GraphUtils.js" as GraphUtils
+
+/*! ***********************************************************************************************
+ * CommitListDelegate
+ * ************************************************************************************************/
+
+Rectangle {
+    id: commitItem
+
+    /* Property Declarations
+     * ****************************************************************************************/
+    property var    commitData      : typeof modelData !== "undefined" ? modelData : null
+
+    property real   messageWidth    : 0
+    property real   authorWidth     : 0
+    property real   dateWidth       : 0
+
+    property color  indicatorColor  : "gray"
+
+    property bool   isSelected      : false
+    property bool   isHead          : false
+    property bool   isStash         : false
+
+    property bool   isHovered       : mouseArea.containsMouse
+
+    /* Signals
+     * ****************************************************************************************/
+    signal itemClicked(int mouseButton, int mouseModifiers, int _index, real mouseX, real mouseY)
+    signal itemDoubleClicked(int mouseButton, int mouseModifiers, var _index)
+
+    /* Object Properties
+     * ****************************************************************************************/
+    width   : ListView.view ? ListView.view.width : parent.width
+    height  : 24 + 4*2
+
+    radius  : (isSelected || isHovered) ? 4 : 0
+
+    color: {
+        if (!commitData)
+            return Style.colors.primaryBackground;
+
+        if (isSelected)
+            return "#6088B2DF";
+
+        if (commitData.isUncommitted) {
+            return isHovered ? Qt.darker(Style.colors.hoverTitle, 1.03)
+                             : (Style.colors.secondaryBackground || Style.colors.primaryBackground);
+        }
+
+        if (isHovered)
+            return Style.colors.hoverTitle;
+
+        if (isHead)
+            return "#40FFA500";
+
+        return Style.colors.primaryBackground;
+    }
+
+    /* Children
+     * ****************************************************************************************/
+    RowLayout {
+        anchors.fill: parent
+        spacing: 0
+        anchors.topMargin: 4
+        anchors.bottomMargin: 4
+
+        // Message column
+        ColumnLayout {
+            Layout.fillWidth: false
+            Layout.preferredWidth: commitItem.messageWidth
+            Layout.fillHeight: true
+            spacing: 0
+
+            RowLayout {
+                Layout.fillWidth: true
+
+                // separator
+                Rectangle {
+                    Layout.preferredWidth: 1
+                    Layout.fillHeight: true
+                    color: Style.colors.hoverTitle
+                }
+
+                // Lane colour bar
+                Rectangle {
+                    Layout.preferredWidth: 3
+                    Layout.preferredHeight: parent.height * 0.8
+                    Layout.alignment: Qt.AlignVCenter
+                    radius: 6
+                    color: indicatorColor
+                }
+
+                // Stash badge
+                Rectangle {
+                    visible: commitItem.isStash
+                    Layout.preferredWidth: stashBadgeRow.implicitWidth + 10
+                    Layout.preferredHeight: 17
+                    Layout.alignment: Qt.AlignVCenter
+                    Layout.leftMargin: 4
+                    radius: 2
+                    color: indicatorColor
+                    Row {
+                        id: stashBadgeRow
+                        anchors.centerIn: parent
+                        spacing: 3
+                        Text {
+                            text: Style.icons.archive
+                            font.family: Style.fontTypes.font6ProSolid
+                            font.pixelSize: 9
+                            color: GraphUtils.getContrastColor(indicatorColor.toString())
+                            verticalAlignment: Text.AlignVCenter
+                        }
+                        Text {
+                            text: commitData ? (commitData.stashLabel || "stash") : ""
+                            font.family: Style.fontTypes.roboto
+                            font.pixelSize: 9
+                            color: GraphUtils.getContrastColor(indicatorColor.toString())
+                            verticalAlignment: Text.AlignVCenter
+                        }
+                    }
+                }
+
+                // Summary text
+                Label {
+                    text: commitData ? (commitData.summary || "") : ""
+                    color: Style.colors.foreground
+                    verticalAlignment: Text.AlignVCenter
+                    font.pixelSize: 10
+                    font.family: Style.fontTypes.roboto
+                    font.weight: commitData && commitData.isUncommitted ? 700 :
+                                  (isHead ? 900 : 400)
+                    font.letterSpacing: 0.2
+                    Layout.fillWidth: true
+                    Layout.leftMargin: 6
+                    elide: Text.ElideRight
+                }
+            }
+        }
+
+        // Author column
+        ColumnLayout {
+            Layout.fillWidth: false
+            Layout.preferredWidth: commitItem.authorWidth
+            Layout.fillHeight: true
+            spacing: 0
+
+            RowLayout {
+                Layout.fillWidth: true
+                Rectangle {
+                    Layout.preferredWidth: 1
+                    Layout.fillHeight: true
+                    color: Style.colors.hoverTitle
+                }
+                Label {
+                    text: commitData ? (commitData.author || "") : ""
+                    color: Style.colors.foreground
+                    verticalAlignment: Text.AlignVCenter
+                    font.pixelSize: 12
+                    Layout.fillWidth: true
+                    horizontalAlignment: Text.AlignLeft
+                    elide: Text.ElideRight
+                }
+            }
+        }
+
+        // Date column
+        ColumnLayout {
+            Layout.fillWidth: false
+            Layout.preferredWidth: commitItem.dateWidth
+            Layout.fillHeight: true
+            spacing: 0
+
+            RowLayout {
+                Layout.fillWidth: true
+                Rectangle {
+                    Layout.preferredWidth: 1
+                    Layout.fillHeight: true
+                    color: Style.colors.hoverTitle
+                }
+                Label {
+                    text: commitData ? (
+                        GraphUtils.formatDate(commitData.authorDate) + " " +
+                        GraphUtils.formatTime(commitData.authorDate)
+                    ) : ""
+                    color: Style.colors.foreground
+                    verticalAlignment: Text.AlignVCenter
+                    font.pixelSize: 10
+                    Layout.fillWidth: true
+                    horizontalAlignment: Text.AlignLeft
+                    wrapMode: Text.NoWrap
+                }
+            }
+        }
+    }
+
+    MouseArea {
+        id: mouseArea
+        anchors.fill: parent
+        hoverEnabled: true
+        acceptedButtons: Qt.LeftButton | Qt.RightButton
+
+        onClicked: function(mouse) {
+            commitItem.itemClicked(mouse.button, mouse.modifiers, index, mouse.x, mouse.y)
+        }
+        onDoubleClicked: function(mouse) {
+            commitItem.itemDoubleClicked(mouse.button, mouse.modifiers, index)
+        }
+    }
+}

--- a/Qml/View/Components/GraphView/CommitListDelegate.qml
+++ b/Qml/View/Components/GraphView/CommitListDelegate.qml
@@ -31,6 +31,8 @@ Rectangle {
 
     property bool   isHovered       : mouseArea.containsMouse
 
+    property Item   parentRoot      : null
+
     /* Signals
      * ****************************************************************************************/
     signal itemClicked(int mouseButton, int mouseModifiers, int _index, real mouseX, real mouseY)
@@ -207,10 +209,12 @@ Rectangle {
         hoverEnabled: true
         acceptedButtons: Qt.LeftButton | Qt.RightButton
 
-        onClicked: function(mouse) {
-            commitItem.itemClicked(mouse.button, mouse.modifiers, index, mouse.x, mouse.y)
+        onClicked: (mouse) => {
+            var pos = parentRoot ? commitItem.mapToItem(parentRoot, mouse.x, mouse.y) : Qt.point(mouse.x, mouse.y)
+            commitItem.itemClicked(mouse.button, mouse.modifiers, index, pos.x, pos.y)
         }
-        onDoubleClicked: function(mouse) {
+
+        onDoubleClicked: (mouse) => {
             commitItem.itemDoubleClicked(mouse.button, mouse.modifiers, index)
         }
     }

--- a/Qml/View/Components/GraphView/DateField.qml
+++ b/Qml/View/Components/GraphView/DateField.qml
@@ -1,0 +1,70 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+import GitEase_Style
+import GitEase_Style_Impl
+import GitEase
+
+/*! ***********************************************************************************************
+ * DateField
+ * ************************************************************************************************/
+
+Item {
+    id: root
+
+    /* Property Declarations
+     * ****************************************************************************************/
+    property string dateString  : ""
+    property string placeholder : "YYYY-MM-DD"
+    property bool   compact     : false
+
+    /* Signals
+     * ****************************************************************************************/
+    signal clicked()
+
+    /* Children
+     * ****************************************************************************************/
+    implicitWidth: compact ? 22 : 90
+    implicitHeight: 25
+
+    TextField {
+        id: textField
+        anchors.fill: parent
+        minHeight: 25
+        rightPadding: caret.width + 5
+        placeholderTextColor: Style.colors.descriptionText
+        backgroundColor: mouseArea.containsMouse ? Style.colors.cardBackground : Style.colors.secondaryBackground
+        placeholderText: root.compact ? "" : root.placeholder
+        text: root.compact ? "" : root.dateString
+        font.family: Style.fontTypes.roboto
+        font.weight: 400
+        font.pixelSize: 10
+        borderRadius: 5
+        borderWidth: 0
+        focusBorderWidth: 1
+        readOnly: true
+        enabled: text.trim().length > 0
+    }
+
+    RoniaTextIcon {
+        id: caret
+        anchors.right: parent.right
+        anchors.rightMargin: 6
+        anchors.verticalCenter: parent.verticalCenter
+        width: 12;
+        height: 12
+        text: Style.icons.caretDown
+        font.pixelSize: 15
+        color: Style.colors.descriptionText
+    }
+
+    MouseArea {
+        id: mouseArea
+        anchors.fill: parent
+        acceptedButtons: Qt.LeftButton
+        hoverEnabled: true
+        cursorShape: Qt.PointingHandCursor
+        onClicked: root.clicked()
+    }
+}

--- a/Qml/View/Components/GraphView/GraphViewHeader.qml
+++ b/Qml/View/Components/GraphView/GraphViewHeader.qml
@@ -1,0 +1,292 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+import GitEase_Style
+import GitEase_Style_Impl
+import GitEase
+
+/*! ***********************************************************************************************
+ * GraphViewHeader
+ * ************************************************************************************************/
+RowLayout {
+    id: headerRow
+
+    /* Property Declarations
+     * ****************************************************************************************/
+    property var    commitGraph     : null
+    property string filterText      : ""
+    property string filterStartDate : ""
+    property string filterEndDate   : ""
+
+    readonly property bool  compact         : headerRow.parent ? headerRow.parent.width < 650 : false
+    property var            navigationRules : ["Author Email", "Author", "Parent 1", "Branch"]
+    property string         navigationRule  : navigationRules[0]
+
+    spacing: (parent && parent.width < Style.appHeight) ? 6 : 10
+    anchors.leftMargin: (parent && parent.width < Style.appHeight) ? 8 : 20
+    anchors.rightMargin: (parent && parent.width < Style.appHeight) ? 4 : 5
+
+    TextField {
+        id: textFilterField
+        placeholderTextColor: Style.colors.descriptionText
+        backgroundColor: hovered ? Style.colors.cardBackground : Style.colors.secondaryBackground
+        Layout.fillWidth: true
+        minHeight: 25
+        placeholderText: {
+            var selected = filterOptionsPopup.selectedItems
+            var display = selected && selected.length > 0
+                          ? selected.map(function(it) { return it.text }).join(", ")
+                          : ""
+            return display.length > 0 ? "Write Filter By " + display : "Write Filter By"
+        }
+        text: headerRow.filterText
+        font.family: Style.fontTypes.roboto
+        font.weight: 400
+        font.pixelSize: 9
+        borderRadius: 5
+        borderWidth: 0
+        focusBorderWidth: 1
+        onTextChanged: {
+            headerRow.filterText = text
+            headerRow.applyFilter()
+        }
+    }
+
+    ToolButton {
+        id: filterButton
+        Layout.preferredWidth: 25
+        Layout.preferredHeight: 25
+        hoverEnabled: true
+
+        text: Style.icons.filter
+        font.family: (filterOptionsPopup.visible || hovered)
+                     ? Style.fontTypes.font6ProSolid
+                     : Style.fontTypes.font6Pro
+        font.pixelSize: 14
+
+        contentItem: Text {
+            anchors.centerIn: parent
+            text: filterButton.text
+            font: filterButton.font
+            color: filterButton.enabled ? Style.colors.foreground : Style.colors.mutedText
+            horizontalAlignment: Text.AlignHCenter
+            verticalAlignment: Text.AlignVCenter
+        }
+
+        background: Rectangle {
+            radius: 5
+            color: !filterButton.enabled ? Style.colors.primaryBackground :
+                   filterButton.down ? Style.colors.surfaceMuted :
+                   filterButton.hovered ? Style.colors.cardBackground : Style.colors.secondaryBackground
+        }
+
+        onClicked: filterOptionsPopup.open()
+    }
+
+    ItemSelectorPopup {
+        id: filterOptionsPopup
+        x: filterButton.x
+        y: filterButton.y + filterButton.height + 6
+        model: filterOptionsModel
+
+        onOpened: {
+            x = Math.max(0, Math.min(x, parent.width - width))
+        }
+        onSelectionChanged: function(items) {
+            headerRow.applyFilter()
+        }
+    }
+
+    ListModel {
+        id: filterOptionsModel
+        ListElement { text: "Messages"; checked: false }
+        ListElement { text: "Subjects"; checked: false }
+        ListElement { text: "Authors";  checked: false }
+        ListElement { text: "Emails";   checked: false }
+        ListElement { text: "SHA-1";    checked: false }
+    }
+
+    CalendarPopup {
+        id: calendarPopup
+    }
+
+    Label {
+        Layout.leftMargin: compact ? 8 : 40
+        color: Style.colors.descriptionText
+        text: "From:"
+        font.family: Style.fontTypes.roboto
+        font.weight: 400
+        font.pixelSize: 12
+    }
+
+    DateField {
+        id: startDateField
+        Layout.preferredWidth: compact ? 22 : 90
+        Layout.preferredHeight: 25
+        compact: compact
+        placeholder: "2025-08-30"
+        dateString: headerRow.filterStartDate
+
+        onClicked: calendarPopup.openForField(startDateField, headerRow, true)
+    }
+
+    Label {
+        color: Style.colors.descriptionText
+        text: "To:"
+        font.family: Style.fontTypes.roboto
+        font.weight: 400
+        font.pixelSize: 12
+    }
+
+    DateField {
+        id: endDateField
+        Layout.preferredWidth: compact ? 22 : 90
+        Layout.preferredHeight: 25
+        compact: compact
+        placeholder: "2025-09-30"
+        dateString: headerRow.filterEndDate
+
+        onClicked: calendarPopup.openForField(endDateField, headerRow, false)
+    }
+
+    ComboBox {
+        id: columnCombo
+        model: navigationRules
+
+        Layout.leftMargin: compact ? 6 : 20
+        minHeight: 26
+        visible: !compact
+        borderWidth: 0
+        focusBorderWidth: 1
+        font.family: Style.fontTypes.roboto
+        font.weight: 400
+        font.pixelSize: 10
+
+        Material.background: Style.colors.primaryBackground
+        Material.foreground: Style.colors.secondaryText
+
+        background: Rectangle {
+            radius: 5
+            color: columnCombo.hovered ? Style.colors.cardBackground : Style.colors.secondaryBackground
+        }
+
+        Layout.preferredWidth: 90
+        currentIndex: navigationRules.indexOf(navigationRule)
+        onActivated: function(index) {
+            navigationRule = navigationRules[index]
+            headerRow.applyFilter()
+        }
+    }
+
+    ToolButton {
+        id: downButton
+        Layout.preferredWidth: 26
+        Layout.preferredHeight: 26
+
+        visible: !compact
+        enabled: !!headerRow.commitGraph
+        hoverEnabled: true
+
+        text: Style.icons.caretDown
+        font.family: Style.fontTypes.font6ProSolid
+        font.pixelSize: 15
+
+        contentItem: Text {
+            anchors.centerIn: parent
+            text: downButton.text
+            font: downButton.font
+            color: downButton.enabled ? Style.colors.foreground : Style.colors.mutedText
+            horizontalAlignment: Text.AlignHCenter
+            verticalAlignment: Text.AlignVCenter
+        }
+
+        background: Rectangle {
+            radius: 5
+            color: !downButton.enabled ? Style.colors.primaryBackground :
+                   downButton.down ? Style.colors.surfaceMuted :
+                   downButton.hovered ? Style.colors.cardBackground : Style.colors.secondaryBackground
+        }
+
+        onClicked: headerRow.commitGraph.selectNext(navigationRule)
+    }
+
+    ToolButton {
+        id: upButton
+        Layout.preferredWidth: 26
+        Layout.preferredHeight: 26
+
+        visible: !compact
+        enabled: !!headerRow.commitGraph
+        hoverEnabled: true
+
+        text: Style.icons.caretUp
+        font.family: Style.fontTypes.font6ProSolid
+        font.pixelSize: 15
+
+        contentItem: Text {
+            anchors.centerIn: parent
+            text: upButton.text
+            font: upButton.font
+            color: upButton.enabled ? Style.colors.foreground : Style.colors.mutedText
+            horizontalAlignment: Text.AlignHCenter
+            verticalAlignment: Text.AlignVCenter
+        }
+
+        background: Rectangle {
+            radius: 5
+            color: !upButton.enabled ? Style.colors.primaryBackground :
+                   upButton.down ? Style.colors.surfaceMuted :
+                   upButton.hovered ? Style.colors.cardBackground : Style.colors.secondaryBackground
+        }
+
+        onClicked: headerRow.commitGraph.selectPrevious(navigationRule)
+    }
+
+    ToolButton {
+        id: reloadButton
+        Layout.preferredWidth: 26
+        Layout.preferredHeight: 26
+        Layout.leftMargin: 10
+
+        enabled: !!headerRow.commitGraph
+        hoverEnabled: true
+
+        text: Style.icons.refresh
+        font.family: Style.fontTypes.font6Pro
+        font.pixelSize: 14
+
+        contentItem: Text {
+            anchors.centerIn: parent
+            text: reloadButton.text
+            font: reloadButton.font
+            color: reloadButton.enabled ? Style.colors.foreground : Style.colors.mutedText
+            horizontalAlignment: Text.AlignHCenter
+            verticalAlignment: Text.AlignVCenter
+        }
+
+        background: Rectangle {
+            radius: 5
+            color: !reloadButton.enabled ? Style.colors.primaryBackground :
+                   reloadButton.down ? Style.colors.surfaceMuted :
+                   reloadButton.hovered ? Style.colors.cardBackground : Style.colors.secondaryBackground
+        }
+
+        onClicked: headerRow.commitGraph.reloadAll()
+    }
+
+    function applyFilter() {
+        if (!headerRow.commitGraph)
+            return;
+
+        var selectedItems = filterOptionsPopup.selectedItems;
+        var modes = selectedItems && selectedItems.length > 0
+                     ? selectedItems.map(function(it) { return it.text })
+                     : [];
+        headerRow.commitGraph.applyFilter(headerRow.filterText,
+                                          headerRow.filterStartDate,
+                                          headerRow.filterEndDate,
+                                          modes);
+
+    }
+}

--- a/Qml/View/Components/GraphView/GraphViewHeader.qml
+++ b/Qml/View/Components/GraphView/GraphViewHeader.qml
@@ -14,7 +14,7 @@ RowLayout {
 
     /* Property Declarations
      * ****************************************************************************************/
-    property var    commitGraph     : null
+    property bool   isGraphReady    : false
     property string filterText      : ""
     property string filterStartDate : ""
     property string filterEndDate   : ""
@@ -23,9 +23,27 @@ RowLayout {
     property var            navigationRules : ["Author Email", "Author", "Parent 1", "Branch"]
     property string         navigationRule  : navigationRules[0]
 
-    spacing: (parent && parent.width < Style.appHeight) ? 6 : 10
-    anchors.leftMargin: (parent && parent.width < Style.appHeight) ? 8 : 20
-    anchors.rightMargin: (parent && parent.width < Style.appHeight) ? 4 : 5
+    /* Signals
+     * ****************************************************************************************/
+    signal filterRequested(string text, string startDate, string endDate, var modes)
+    signal nextRequested(string rule)
+    signal previousRequested(string rule)
+    signal reloadRequested()
+
+    /* Object Properties
+     * ****************************************************************************************/
+    spacing             : (parent && parent.width < Style.appHeight) ? 6 : 10
+    anchors.leftMargin  : (parent && parent.width < Style.appHeight) ? 8 : 20
+    anchors.rightMargin : (parent && parent.width < Style.appHeight) ? 4 : 5
+
+ListModel {
+        id: filterOptionsModel
+        ListElement { text: "Messages"; checked: false }
+        ListElement { text: "Subjects"; checked: false }
+        ListElement { text: "Authors";  checked: false }
+        ListElement { text: "Emails";   checked: false }
+        ListElement { text: "SHA-1";    checked: false }
+    }
 
     TextField {
         id: textFilterField
@@ -98,19 +116,6 @@ RowLayout {
         }
     }
 
-    ListModel {
-        id: filterOptionsModel
-        ListElement { text: "Messages"; checked: false }
-        ListElement { text: "Subjects"; checked: false }
-        ListElement { text: "Authors";  checked: false }
-        ListElement { text: "Emails";   checked: false }
-        ListElement { text: "SHA-1";    checked: false }
-    }
-
-    CalendarPopup {
-        id: calendarPopup
-    }
-
     Label {
         Layout.leftMargin: compact ? 8 : 40
         color: Style.colors.descriptionText
@@ -128,7 +133,8 @@ RowLayout {
         placeholder: "2025-08-30"
         dateString: headerRow.filterStartDate
 
-        onClicked: calendarPopup.openForField(startDateField, headerRow, true)
+        onClicked: calendarPopup.prepareAndOpen(startDateField, true, headerRow.filterStartDate, headerRow.filterEndDate)
+
     }
 
     Label {
@@ -147,7 +153,8 @@ RowLayout {
         placeholder: "2025-09-30"
         dateString: headerRow.filterEndDate
 
-        onClicked: calendarPopup.openForField(endDateField, headerRow, false)
+        onClicked: calendarPopup.prepareAndOpen(endDateField, false, headerRow.filterEndDate, headerRow.filterStartDate)
+
     }
 
     ComboBox {
@@ -185,7 +192,7 @@ RowLayout {
         Layout.preferredHeight: 26
 
         visible: !compact
-        enabled: !!headerRow.commitGraph
+        enabled: headerRow.isGraphReady
         hoverEnabled: true
 
         text: Style.icons.caretDown
@@ -208,7 +215,7 @@ RowLayout {
                    downButton.hovered ? Style.colors.cardBackground : Style.colors.secondaryBackground
         }
 
-        onClicked: headerRow.commitGraph.selectNext(navigationRule)
+        onClicked: headerRow.previousRequested(navigationRule)
     }
 
     ToolButton {
@@ -217,7 +224,7 @@ RowLayout {
         Layout.preferredHeight: 26
 
         visible: !compact
-        enabled: !!headerRow.commitGraph
+        enabled: headerRow.isGraphReady
         hoverEnabled: true
 
         text: Style.icons.caretUp
@@ -240,7 +247,7 @@ RowLayout {
                    upButton.hovered ? Style.colors.cardBackground : Style.colors.secondaryBackground
         }
 
-        onClicked: headerRow.commitGraph.selectPrevious(navigationRule)
+        onClicked: headerRow.nextRequested(navigationRule)
     }
 
     ToolButton {
@@ -249,7 +256,7 @@ RowLayout {
         Layout.preferredHeight: 26
         Layout.leftMargin: 10
 
-        enabled: !!headerRow.commitGraph
+        enabled: headerRow.isGraphReady
         hoverEnabled: true
 
         text: Style.icons.refresh
@@ -272,21 +279,47 @@ RowLayout {
                    reloadButton.hovered ? Style.colors.cardBackground : Style.colors.secondaryBackground
         }
 
-        onClicked: headerRow.commitGraph.reloadAll()
+        onClicked: headerRow.reloadRequested()
     }
 
-    function applyFilter() {
-        if (!headerRow.commitGraph)
-            return;
+    CalendarPopup {
+        id: calendarPopup
 
+        onDateSelected: headerRow.handleDateSelected(dateString, isStart)
+
+        onClearRequested: headerRow.handleClearRequested(isStart)
+    }
+
+    /* Functions
+     * ****************************************************************************************/
+    function applyFilter() {
         var selectedItems = filterOptionsPopup.selectedItems;
+
         var modes = selectedItems && selectedItems.length > 0
                      ? selectedItems.map(function(it) { return it.text })
                      : [];
-        headerRow.commitGraph.applyFilter(headerRow.filterText,
-                                          headerRow.filterStartDate,
-                                          headerRow.filterEndDate,
-                                          modes);
+        headerRow.filterRequested(headerRow.filterText,
+                                  headerRow.filterStartDate,
+                                  headerRow.filterEndDate,
+                                  modes);
 
+    }
+
+    function handleDateSelected(dateString, isStart) {
+        if (isStart)
+            headerRow.filterStartDate = dateString;
+        else
+            headerRow.filterEndDate = dateString;
+
+        headerRow.applyFilter();
+    }
+
+    function handleClearRequested(isStart) {
+        if (isStart)
+            headerRow.filterStartDate = "";
+        else
+            headerRow.filterEndDate = "";
+
+        headerRow.applyFilter();
     }
 }

--- a/Qml/View/Components/GraphView/GraphViewHeader.qml
+++ b/Qml/View/Components/GraphView/GraphViewHeader.qml
@@ -36,7 +36,7 @@ RowLayout {
     anchors.leftMargin  : (parent && parent.width < Style.appHeight) ? 8 : 20
     anchors.rightMargin : (parent && parent.width < Style.appHeight) ? 4 : 5
 
-ListModel {
+    ListModel {
         id: filterOptionsModel
         ListElement { text: "Messages"; checked: false }
         ListElement { text: "Subjects"; checked: false }
@@ -178,7 +178,7 @@ ListModel {
             color: columnCombo.hovered ? Style.colors.cardBackground : Style.colors.secondaryBackground
         }
 
-        Layout.preferredWidth: 90
+        Layout.preferredWidth: 120
         currentIndex: navigationRules.indexOf(navigationRule)
         onActivated: function(index) {
             navigationRule = navigationRules[index]

--- a/Qml/View/Components/GraphView/GraphViewHeader.qml
+++ b/Qml/View/Components/GraphView/GraphViewHeader.qml
@@ -285,9 +285,13 @@ RowLayout {
     CalendarPopup {
         id: calendarPopup
 
-        onDateSelected: headerRow.handleDateSelected(dateString, isStart)
+        onDateSelected: function(dateString, isStart) {
+            headerRow.handleDateSelected(dateString, isStart)
+        }
 
-        onClearRequested: headerRow.handleClearRequested(isStart)
+        onClearRequested: function(isStart) {
+            headerRow.handleClearRequested(isStart)
+        }
     }
 
     /* Functions

--- a/Qml/View/Components/GraphView/ResizableColumnHeader.qml
+++ b/Qml/View/Components/GraphView/ResizableColumnHeader.qml
@@ -1,0 +1,90 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import GitEase_Style
+
+/*! ***********************************************************************************************
+ * ResizableColumnHeader – a column header with a draggable right divider.
+ * signal resized(delta) is emitted when the divider is dragged.
+ * ************************************************************************************************/
+Rectangle {
+    id: root
+
+    /* Property Declarations
+     * ****************************************************************************************/
+    property string label: ""
+
+    /* Signals
+     * ****************************************************************************************/
+    signal resized(real delta)
+    signal resizeStarted()
+    signal resizeFinished()
+
+    /* Object Properties
+     * ****************************************************************************************/
+
+    Layout.fillHeight: true
+    color: headerMouse.containsMouse ? Style.colors.hoverTitle : "transparent"
+
+    /* Children
+     * ****************************************************************************************/
+    Label {
+        anchors.left: parent.left
+        anchors.verticalCenter: parent.verticalCenter
+        leftPadding: 5
+        text: root.label
+        color: Style.colors.foreground
+        font.pixelSize: 11
+        font.bold: true
+        elide: Text.ElideRight
+    }
+
+    MouseArea {
+        id: headerMouse
+        anchors.fill: parent
+        hoverEnabled: true
+        propagateComposedEvents: true
+        onPressed: (mouse) => mouse.accepted = false
+        onReleased: (mouse) => mouse.accepted = false
+    }
+
+    // Right edge divider + drag area
+    Rectangle {
+        anchors.right: parent.right
+        anchors.top: parent.top
+        anchors.bottom: parent.bottom
+        width: 1
+        color: dividerMouse.pressed ? Style.colors.resizeHandlePressed : Style.colors.resizeHandle
+
+        MouseArea {
+            id: dividerMouse
+            anchors.right: parent.right
+            anchors.top: parent.top
+            anchors.bottom: parent.bottom
+            width: 10
+            anchors.rightMargin: -5
+            hoverEnabled: true
+            cursorShape: Qt.SizeHorCursor
+
+            property real startX: 0
+            property real startWidth: parent.parent.Layout.preferredWidth
+
+            onPressed: (mouse) => {
+                startX = mouseX + mapToItem(parent.parent.parent, 0, 0).x
+                startWidth = parent.parent.Layout.preferredWidth
+                root.resizeStarted()
+            }
+
+            onPositionChanged: (mouse) => {
+                if (!pressed) return
+                var currentX = mouseX + mapToItem(parent.parent.parent, 0, 0).x
+                var delta = currentX - startX
+                root.resized(delta)
+            }
+
+            onReleased: {
+                root.resizeFinished()
+            }
+        }
+    }
+}

--- a/Qml/View/Components/GraphView/ResizableColumnHeader.qml
+++ b/Qml/View/Components/GraphView/ResizableColumnHeader.qml
@@ -5,29 +5,23 @@ import GitEase_Style
 
 /*! ***********************************************************************************************
  * ResizableColumnHeader – a column header with a draggable right divider.
- * signal resized(delta) is emitted when the divider is dragged.
+ * signal resized(delta, startWidth) is emitted when the divider is dragged.
  * ************************************************************************************************/
 Rectangle {
     id: root
 
-    /* Property Declarations
-     * ****************************************************************************************/
     property string label: ""
 
-    /* Signals
-     * ****************************************************************************************/
-    signal resized(real delta)
+    // width at the moment the drag began (captured in onPressed)
+    property real dragStartWidth: 0
+
+    signal resized(real delta, real startWidth)
     signal resizeStarted()
     signal resizeFinished()
-
-    /* Object Properties
-     * ****************************************************************************************/
 
     Layout.fillHeight: true
     color: headerMouse.containsMouse ? Style.colors.hoverTitle : "transparent"
 
-    /* Children
-     * ****************************************************************************************/
     Label {
         anchors.left: parent.left
         anchors.verticalCenter: parent.verticalCenter
@@ -66,20 +60,20 @@ Rectangle {
             hoverEnabled: true
             cursorShape: Qt.SizeHorCursor
 
-            property real startX: 0
-            property real startWidth: parent.parent.Layout.preferredWidth
+            // Global coordinate tracking to avoid feedback loop
+            property real startGlobalX: 0
 
             onPressed: (mouse) => {
-                startX = mouseX + mapToItem(parent.parent.parent, 0, 0).x
-                startWidth = parent.parent.Layout.preferredWidth
+                startGlobalX = dividerMouse.mapToItem(null, mouse.x, mouse.y).x
+                root.dragStartWidth = parent.parent.Layout.preferredWidth
                 root.resizeStarted()
             }
 
             onPositionChanged: (mouse) => {
                 if (!pressed) return
-                var currentX = mouseX + mapToItem(parent.parent.parent, 0, 0).x
-                var delta = currentX - startX
-                root.resized(delta)
+                var currentGlobalX = dividerMouse.mapToItem(null, mouse.x, mouse.y).x
+                var delta = currentGlobalX - startGlobalX
+                root.resized(delta, root.dragStartWidth)
             }
 
             onReleased: {

--- a/Qml/View/Popups/CalendarPopup.qml
+++ b/Qml/View/Popups/CalendarPopup.qml
@@ -13,9 +13,14 @@ IPopup {
 
     /* Property Declarations
      * ****************************************************************************************/
-    property var    headerRef   : null
     property bool   isStart     : true
     property point  fieldOrigin : Qt.point(0, 0)
+    property string otherDateStr: ""
+
+    /* Signals
+     * ****************************************************************************************/
+    signal dateSelected(string dateString, bool isStart)
+    signal clearRequested(bool isStart)
 
     /* Object Properties
      * ****************************************************************************************/
@@ -47,15 +52,14 @@ IPopup {
 
     /* Functions
      * ****************************************************************************************/
-    function openForField(field, header, isStartMode) {
-        root.headerRef  = header;
-        root.isStart    = isStartMode;
+    function prepareAndOpen(field, isStartMode, currentDateStr, oppositeDateStr) {
+        root.isStart      = isStartMode;
+        root.otherDateStr = oppositeDateStr;
 
         cal.errorMessage = "";
 
-        var dateStr = isStartMode ? header.filterStartDate : header.filterEndDate;
-        if (dateStr && dateStr.length === 10) {
-            cal.setDate(dateStr);
+        if (currentDateStr && currentDateStr.length === 10) {
+            cal.setDate(currentDateStr);
         } else {
             cal.selectedDate = new Date();
         }
@@ -65,40 +69,29 @@ IPopup {
     }
 
     function handleDateSelected(date) {
-        if (!root.headerRef)
-            return;
-
         var formatted = cal.dateToString(date);
+
         cal.errorMessage = "";
 
         if (root.isStart) {
-            if (root.headerRef.filterEndDate && formatted > root.headerRef.filterEndDate) {
+            if (root.otherDateStr && formatted > root.otherDateStr) {
                 cal.errorMessage = "Start date cannot be greater than end date";
                 return;
             }
-            root.headerRef.filterStartDate = formatted;
         }
         else {
-            if (root.headerRef.filterStartDate && formatted < root.headerRef.filterStartDate) {
+            if (root.otherDateStr && formatted < root.otherDateStr) {
                 cal.errorMessage = "End date cannot be less than start date";
                 return;
             }
-            root.headerRef.filterEndDate = formatted;
         }
-        root.headerRef.applyFilter();
+
+        root.dateSelected(formatted, root.isStart);
         root.close();
     }
 
     function handleClearRequested() {
-        if (!root.headerRef)
-            return;
-
-        if (root.isStart)
-            root.headerRef.filterStartDate = "";
-        else
-            root.headerRef.filterEndDate = "";
-
-        root.headerRef.applyFilter();
+        root.clearRequested(root.isStart);
         root.close();
     }
 }

--- a/Qml/View/Popups/CalendarPopup.qml
+++ b/Qml/View/Popups/CalendarPopup.qml
@@ -1,0 +1,104 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+import GitEase_Style
+import GitEase_Style_Impl
+
+/*! ***********************************************************************************************
+ * CalendarPopup
+ * ************************************************************************************************/
+IPopup {
+    id: root
+
+    /* Property Declarations
+     * ****************************************************************************************/
+    property var    headerRef   : null
+    property bool   isStart     : true
+    property point  fieldOrigin : Qt.point(0, 0)
+
+    /* Object Properties
+     * ****************************************************************************************/
+    width: 280
+    height: 260
+    padding: 8
+
+    x: Math.min(fieldOrigin.x, window.width - width - 10)
+    y: fieldOrigin.y
+
+    /* Children
+     * ****************************************************************************************/
+    contentItem: Rectangle {
+        color: Style.colors.primaryBackground
+        radius: 8
+        border.width: 1
+        border.color: Style.colors.primaryBorder
+
+        Calendar {
+            id: cal
+            anchors.fill: parent
+            anchors.margins: 4
+
+            onDateSelected: function(date) {root.handleDateSelected(date)}
+
+            onClearRequested: root.handleClearRequested()
+        }
+    }
+
+    /* Functions
+     * ****************************************************************************************/
+    function openForField(field, header, isStartMode) {
+        root.headerRef  = header;
+        root.isStart    = isStartMode;
+
+        cal.errorMessage = "";
+
+        var dateStr = isStartMode ? header.filterStartDate : header.filterEndDate;
+        if (dateStr && dateStr.length === 10) {
+            cal.setDate(dateStr);
+        } else {
+            cal.selectedDate = new Date();
+        }
+
+        root.fieldOrigin = field.mapToItem(null, 0, field.height);
+        root.open();
+    }
+
+    function handleDateSelected(date) {
+        if (!root.headerRef)
+            return;
+
+        var formatted = cal.dateToString(date);
+        cal.errorMessage = "";
+
+        if (root.isStart) {
+            if (root.headerRef.filterEndDate && formatted > root.headerRef.filterEndDate) {
+                cal.errorMessage = "Start date cannot be greater than end date";
+                return;
+            }
+            root.headerRef.filterStartDate = formatted;
+        }
+        else {
+            if (root.headerRef.filterStartDate && formatted < root.headerRef.filterStartDate) {
+                cal.errorMessage = "End date cannot be less than start date";
+                return;
+            }
+            root.headerRef.filterEndDate = formatted;
+        }
+        root.headerRef.applyFilter();
+        root.close();
+    }
+
+    function handleClearRequested() {
+        if (!root.headerRef)
+            return;
+
+        if (root.isStart)
+            root.headerRef.filterStartDate = "";
+        else
+            root.headerRef.filterEndDate = "";
+
+        root.headerRef.applyFilter();
+        root.close();
+    }
+}

--- a/Resources.cmake
+++ b/Resources.cmake
@@ -160,7 +160,8 @@ set(RESOURCES_COMPONENTS
     Qml/View/Components/Pages/CommittingPage/CommittingPageHeader.qml
     Qml/View/Components/GraphView/GraphViewHeader.qml
     Qml/View/Components/GraphView/DateField.qml
-
+    Qml/View/Components/GraphView/ResizableColumnHeader.qml
+    Qml/View/Components/GraphView/CommitGraphCanvas.qml
     Qml/View/Components/GraphView/CommitListDelegate.qml
 )
 

--- a/Resources.cmake
+++ b/Resources.cmake
@@ -41,6 +41,7 @@ set(RESOURCES_CORE
     Qml/Core/Scripts/GraphUtils.js
     Qml/Core/Scripts/GraphLayout.js
     Qml/Core/Scripts/ConflictPopupUtils.js
+    Qml/Core/Scripts/GraphViewPresenter.js
 )
 
 

--- a/Resources.cmake
+++ b/Resources.cmake
@@ -183,6 +183,8 @@ set(RESOURCES_POPUPS
     Qml/View/Popups/MergeMethodPopup.qml
 
     Qml/View/Popups/AddTagPopup.qml
+    Qml/View/Popups/CalendarPopup.qml
+
 )
 
 

--- a/Resources.cmake
+++ b/Resources.cmake
@@ -153,6 +153,8 @@ set(RESOURCES_COMPONENTS
 
     # Pages Components
     Qml/View/Components/Pages/CommittingPage/CommittingPageHeader.qml
+    Qml/View/Components/GraphView/GraphViewHeader.qml
+    Qml/View/Components/GraphView/DateField.qml
 )
 
 

--- a/Resources.cmake
+++ b/Resources.cmake
@@ -42,6 +42,10 @@ set(RESOURCES_CORE
     Qml/Core/Scripts/GraphLayout.js
     Qml/Core/Scripts/ConflictPopupUtils.js
     Qml/Core/Scripts/GraphViewPresenter.js
+    Qml/Core/Scripts/CommitGraphDataLoader.js
+    Qml/Core/Scripts/CommitGraphFilter.js
+    Qml/Core/Scripts/CommitGraphNavigation.js
+    Qml/Core/Scripts/CommitGraphMenuBuilder.js
 )
 
 

--- a/Resources.cmake
+++ b/Resources.cmake
@@ -156,6 +156,8 @@ set(RESOURCES_COMPONENTS
     Qml/View/Components/Pages/CommittingPage/CommittingPageHeader.qml
     Qml/View/Components/GraphView/GraphViewHeader.qml
     Qml/View/Components/GraphView/DateField.qml
+
+    Qml/View/Components/GraphView/CommitListDelegate.qml
 )
 
 


### PR DESCRIPTION
Summary
A complete separation‑of‑concerns refactoring of the Graph View page, breaking the monolithic CommitGraphDock.qml and GraphViewPage.qml into clean layers – pure JavaScript logic modules, thin QML orchestrators, and reusable view components.

Motivation
- CommitGraphDock.qml had grown to ~1600 lines mixing data fetching, filtering, graph layout, navigation, context‑menu building, and UI rendering.
- Hard to test, debug, or extend without risking regressions.
- No clear boundary between “what computes data” and “what paints the screen”.


Approach
- MVC‑like separation – pure JS for algorithms and data transformation, QML for presentation and orchestration.
- JS files receive plain data and return plain data; they never touch QML objects, controllers, or popups.
- The Dock becomes a thin coordinator that owns state, calls pure functions, and updates bindings.

Key Changes
- Data loading, filtering, selection, and context‑menu building are fully extracted into stateless, testable JS modules.
- The commit list delegate is a pure‑UI component; it receives data properties and emits signals.
- Graph canvas painting is isolated in CommitGraphCanvas.qml.
- Navigation and selection helpers return plain result objects applied by the Dock.
- Column resizing stabilised (global coordinate tracking).
- Dependency validation at startup (essential vs. non‑essential).