### PR TITLE
fix: ensure graceful shutdown by cleaning up notification windows

### DIFF
--- a/Qml/Core/Controllers/NotificationController.qml
+++ b/Qml/Core/Controllers/NotificationController.qml
@@ -198,7 +198,29 @@ QtObject {
     function saveNotifications() {
         saveNotificationsForRepository(root.currentRepositoryKey)
     }
-    
+
+    function shutdown() {
+        saveNotifications()
+
+        queuedNotifications = []
+
+        var notificationsToClose = activeNotifications.slice()
+        for (var i = 0; i < notificationsToClose.length; i++) {
+            var window = notificationsToClose[i]
+            if (window) {
+                window.close()
+                window.destroy()
+            }
+        }
+        activeNotifications = []
+
+        if (closeAllHeader) {
+            closeAllHeader.close()
+            closeAllHeader.destroy()
+            closeAllHeader = null
+        }
+    }
+
     function saveNotificationsForRepository(repositoryKey) {
         var filePath = getNotificationFilePathForRepository(repositoryKey)
         

--- a/Qml/Main.qml
+++ b/Qml/Main.qml
@@ -33,8 +33,18 @@ ApplicationWindow {
     
     /* Event Handlers
      * ****************************************************************************************/
-    onClosing: {
-        uiSession?.notificationController?.saveNotifications()
+    onClosing: function(close) {
+        close.accepted = true
+
+        try {
+            uiSession?.notificationController?.shutdown()
+        } catch (e) {
+            console.error("[MainWindow] notification shutdown failed:", e)
+        }
+
+        Qt.callLater(function() {
+            Qt.exit(0)
+        })
     }
 
 


### PR DESCRIPTION
Summary
This PR fixes a shutdown issue where closing GitEase (X, Alt+F4, normal close) could leave GitEase running in Task Manager and keep resources locked.

Root Cause
Floating notification UI uses separate top-level Window objects. In some close paths, the app window closed visually but the process/event loop did not fully terminate.

Changes

1. Added robust app close handling in Qml/Main.qml:

                 - on window close, run notification cleanup safely (try/catch)
                 - force application event loop exit with Qt.exit(0) via Qt.callLater(...)

2. Added shutdown() in Qml/Core/Controllers/NotificationController.qml:

                 - save notifications before exit
                 - clear queued notifications
                 - close/destroy all active floating notification windows
                 - close/destroy notification header window
                 - clear references to released windows


Behavior After Fix

- Closing app now fully terminates process.
- No lingering GitEase instances remain in Task Manager after close.
- Notification popup windows are properly cleaned up.
- File/folder locks caused by lingering process are resolved.

Validation

- Ran app, closed via custom X button: process exits completely.
- Repeated open/close cycles no longer accumulate GitEase processes.
- Confirmed cleanup path executes without blocking app shutdown.