### PR TITLE
Fix #290 – Fetch race condition with sequential remote iteration

### DIFF
--- a/Qml/View/Components/RepoForest/RepoForest.qml
+++ b/Qml/View/Components/RepoForest/RepoForest.qml
@@ -29,6 +29,14 @@ Rectangle {
     property   bool                   isProcessingQueue:        false
     property   var                    scannedRepositories:      []
 
+    property   bool                   fetchFlowActive:          false
+    property   int                    fetchFlowItemIndex:       -1
+    property   string                 fetchFlowPat:             ""
+    property   var                    fetchFlowRemotes:         []
+    property   int                    fetchFlowRemoteIndex:     0
+    property   string                 fetchFlowCurrentRemote:   ""
+
+
     readonly property bool allSelected:     reposModel.length > 0 && selectedIndexes.length === reposModel.length
     readonly property bool noneSelected:    selectedIndexes.length === 0
     readonly property bool someSelected:    !allSelected && !noneSelected
@@ -130,44 +138,61 @@ Rectangle {
             return
         }
 
-        remotesRes.data.forEach(remote => {
-            let remoteUrlRes = scanRemoteController.getRemoteUrl(remote.name)
+        root.fetchFlowActive        = true
+        root.fetchFlowItemIndex     = itemIndex
+        root.fetchFlowPat           = pat
+        root.fetchFlowRemotes       = remotesRes.data
+        root.fetchFlowRemoteIndex   = 0
+        root.fetchFlowCurrentRemote = ""
 
-            if(!remoteUrlRes.success) {
-                root.updateStatus(itemIndex, "Canceled")
-                processNextOperation()
-                return
-            }
+        fetchStartNextRemote()
+    }
 
-            let protocol = root.repositoryController.detectGitProtocol(remoteUrlRes.data.url)
+    function fetchStartNextRemote() {
+        if (!root.fetchFlowActive)
+            return
 
-            if (protocol !== RepositoryController.GitProtocol.SSH && pat === "") {
-                root.updateStatus(itemIndex, "PAT waiting")
-                processNextOperation()
-                return
-            }
+        if (root.fetchFlowRemoteIndex >= root.fetchFlowRemotes.length) {
+            finishFetchFlow("Done")
+            return
+        }
 
-            let onFetchFinished = (result) => {
-                root.updateStatus(itemIndex, result.success ? "Done" : "Canceled")
-                scanRemoteController.fetchFinished.disconnect(onFetchFinished)
-                processNextOperation()
-            }
+        let remote = root.fetchFlowRemotes[root.fetchFlowRemoteIndex]
+        root.fetchFlowRemoteIndex += 1
+        root.fetchFlowCurrentRemote = remote.name
 
-           scanRemoteController.fetchFinished.connect(onFetchFinished)
+        let remoteUrlRes = scanRemoteController.getRemoteUrl(remote.name)
+        if(!remoteUrlRes.success) {
+            finishFetchFlow("Canceled")
 
-            let fetchRes
-            if (protocol === RepositoryController.GitProtocol.SSH) {
-                fetchRes = scanRemoteController.fetch(remote.name)
-            } else{
-                fetchRes = scanRemoteController.fetchWithToken(remote.name, pat)
-            }
+            return
+        }
 
-            if(!fetchRes || !fetchRes.success) {
-                root.updateStatus(itemIndex, "Canceled")
-                scanRemoteController.fetchFinished.disconnect(onFetchFinished)
-                processNextOperation()
-            }
-        })
+        let protocol = root.repositoryController.detectGitProtocol(remoteUrlRes.data.url)
+
+        if (protocol !== RepositoryController.GitProtocol.SSH && root.fetchFlowPat === "") {
+            root.finishFetchFlow("PAT waiting")
+            return
+        }
+
+        if (protocol === RepositoryController.GitProtocol.SSH) {
+            scanRemoteController.fetch(remote.name)
+        } else {
+            scanRemoteController.fetchWithToken(remote.name, root.fetchFlowPat)
+        }
+    }
+
+    function finishFetchFlow(status: string) {
+        let idx = root.fetchFlowItemIndex
+        root.fetchFlowActive        = false
+        root.fetchFlowItemIndex     = -1
+        root.fetchFlowPat           = ""
+        root.fetchFlowRemotes       = []
+        root.fetchFlowRemoteIndex   = 0
+        root.fetchFlowCurrentRemote = ""
+
+        root.updateStatus(idx, status)
+        processNextOperation()
     }
 
     function executePull(itemIndex: int, pat: string) {
@@ -258,6 +283,24 @@ Rectangle {
 
     RemoteController {
         id: scanRemoteController
+    }
+
+    Connections {
+        target: scanRemoteController
+
+        function onFetchFinished(result) {
+            if (!root.fetchFlowActive || !result || !result.remote)
+                return
+
+            if (result.remote !== root.fetchFlowCurrentRemote)
+                return
+
+            if (!result.success) {
+                finishFetchFlow("Canceled")
+            }else {
+                fetchStartNextRemote()
+            }
+        }
     }
 
     Connections {

--- a/Src/Git/GitRemote.cpp
+++ b/Src/Git/GitRemote.cpp
@@ -1080,3 +1080,36 @@ GitResult GitRemote::fetchInternal(const QString& remoteName, std::unique_ptr<IG
 
     return GitResult(true, fetchResult);
 }
+
+QHash<QString, QString> GitRemote::getRemoteTrackingTipsSnapshot(const QString& remoteName)
+{
+    QHash<QString, QString> tips;
+    if (!m_currentRepo || !m_currentRepo->repo) {
+        return tips;
+    }
+
+    git_branch_iterator* it = nullptr;
+    if (git_branch_iterator_new(&it, m_currentRepo->repo, GIT_BRANCH_REMOTE) == GIT_OK && it) {
+        git_reference* ref = nullptr;
+        git_branch_t branchType = GIT_BRANCH_REMOTE;
+        while (git_branch_next(&ref, &branchType, it) == GIT_OK) {
+            const char* shorthand = nullptr;
+            if (git_branch_name(&shorthand, ref) == GIT_OK && shorthand) {
+                const QString fullName = QString::fromUtf8(shorthand); // e.g. origin/main
+                const QString prefix = remoteName + "/";
+                if (fullName.startsWith(prefix)) {
+                    const git_oid* target = git_reference_target(ref);
+                    if (target) {
+                        tips.insert(
+                            fullName.mid(prefix.size()),
+                            QString::fromLatin1(git_oid_tostr_s(target)));
+                    }
+                }
+            }
+            git_reference_free(ref);
+        }
+        git_branch_iterator_free(it);
+    }
+    return tips;
+}
+

--- a/Src/Git/GitRemote.cpp
+++ b/Src/Git/GitRemote.cpp
@@ -949,12 +949,6 @@ GitResult GitRemote::fetchInternal(const QString& remoteName, std::unique_ptr<IG
 
     QHash<QString, QString> beforeTrackingTips = getRemoteTrackingTipsSnapshot(remoteName);
 
-    qDebug().noquote() << QString("[GitRemote][FetchTrace] START remote=%1 headRef=%2 headOid=%3 wt=%4")
-                              .arg(remoteName,
-                                   currentHeadRefName(m_currentRepo->repo),
-                                   currentHeadOid(m_currentRepo->repo),
-                                   workingTreeSummary(m_currentRepo->repo));
-
     result = git_remote_fetch(remote, nullptr, &opts, nullptr);
 
     git_remote_free(remote);
@@ -989,11 +983,6 @@ GitResult GitRemote::fetchInternal(const QString& remoteName, std::unique_ptr<IG
     fetchResult["remote"] = remoteName;
     fetchResult["timestamp"] = QDateTime::currentDateTime().toString(Qt::ISODate);
     fetchResult["status"] = "Successfully fetched from remote";
-    qDebug().noquote() << QString("[GitRemote][FetchTrace] DONE remote=%1 headRef=%2 headOid=%3 wt=%4")
-                              .arg(remoteName,
-                                   currentHeadRefName(m_currentRepo->repo),
-                                   currentHeadOid(m_currentRepo->repo),
-                                   workingTreeSummary(m_currentRepo->repo));
 
     // Collect fetched heads with before/after info
     QVariantList fetchedHeads;

--- a/Src/Git/GitRemote.cpp
+++ b/Src/Git/GitRemote.cpp
@@ -946,7 +946,9 @@ GitResult GitRemote::fetchInternal(const QString& remoteName, std::unique_ptr<IG
 
     opts.callbacks.payload = &payload;
     auth->applyFetch(opts);
-    
+
+    QHash<QString, QString> beforeTrackingTips = getRemoteTrackingTipsSnapshot(remoteName);
+
     qDebug().noquote() << QString("[GitRemote][FetchTrace] START remote=%1 headRef=%2 headOid=%3 wt=%4")
                               .arg(remoteName,
                                    currentHeadRefName(m_currentRepo->repo),
@@ -959,18 +961,18 @@ GitResult GitRemote::fetchInternal(const QString& remoteName, std::unique_ptr<IG
 
     if (result != GIT_OK) {
         qDebug().noquote() << QString("[GitRemote][FetchTrace] FAIL remote=%1 rc=%2 err=%3")
-                                  .arg(remoteName)
-                                  .arg(result)
-                                  .arg(lastGitErrorMessage());
+        .arg(remoteName)
+            .arg(result)
+            .arg(lastGitErrorMessage());
         if (result == GIT_EUSER) {
             return GitResult(false, QVariant(),
-                           "Authentication failed. Check your credentials or SSH keys.");
+                             "Authentication failed. Check your credentials or SSH keys.");
         } else if (result == GIT_EEXISTS) {
             return GitResult(false, QVariant(),
-                           "Fetch conflict: Unable to update refs");
+                             "Fetch conflict: Unable to update refs");
         } else if (result == GIT_EUNBORNBRANCH) {
             return GitResult(false, QVariant(),
-                           "Cannot fetch: repository has no commits");
+                             "Cannot fetch: repository has no commits");
         }
 
         // Get libgit2 error message if available
@@ -993,15 +995,16 @@ GitResult GitRemote::fetchInternal(const QString& remoteName, std::unique_ptr<IG
                                    currentHeadOid(m_currentRepo->repo),
                                    workingTreeSummary(m_currentRepo->repo));
 
-    // Collect fetched heads with before/after info 
+    // Collect fetched heads with before/after info
     QVariantList fetchedHeads;
     QStringList logLines;
+
     struct FetchHeadPayload {
-        git_repository* repo;
+        QHash<QString, QString>* beforeTips;
         QVariantList* heads;
         QString remoteName;
         QStringList* logs;
-    } headPayload { m_currentRepo->repo, &fetchedHeads, remoteName, &logLines };
+    } headPayload { &beforeTrackingTips, &fetchedHeads, remoteName, &logLines };
 
     auto fetchHeadCb = [](const char* ref_name,
                           const char* remote_url,
@@ -1009,7 +1012,7 @@ GitResult GitRemote::fetchInternal(const QString& remoteName, std::unique_ptr<IG
                           unsigned int is_merge,
                           void* payload) -> int {
         auto* data = static_cast<FetchHeadPayload*>(payload);
-        auto* repo = data->repo;
+        auto* beforeTips = data->beforeTips;
         auto* heads = data->heads;
         auto* logs = data->logs;
         const QString remoteName = data->remoteName;
@@ -1029,43 +1032,36 @@ GitResult GitRemote::fetchInternal(const QString& remoteName, std::unique_ptr<IG
         QString trackingRef = QString("refs/remotes/%1/%2").arg(remoteName, branchName);
         entry["trackingRef"] = trackingRef;
 
-        git_reflog* log = nullptr;
-        if (git_reflog_read(&log, repo, trackingRef.toUtf8().constData()) == 0 && log) {
-            size_t count = git_reflog_entrycount(log);
-            if (count > 0) {
-                const git_reflog_entry* latest = git_reflog_entry_byindex(log, 0);
-                const git_oid* oldOid = git_reflog_entry_id_old(latest);
-                const git_oid* newOid = git_reflog_entry_id_new(latest);
-                char bufOld[GIT_OID_HEXSZ + 1] = {0};
-                char bufNew[GIT_OID_HEXSZ + 1] = {0};
-                if (oldOid) git_oid_tostr(bufOld, sizeof(bufOld), oldOid);
-                if (newOid) git_oid_tostr(bufNew, sizeof(bufNew), newOid);
-                entry["oldCommit"] = QString::fromLatin1(bufOld);
-                entry["newCommit"] = QString::fromLatin1(bufNew);
-                QString shortOld = entry["oldCommit"].toString().left(7);
-                QString shortNew = entry["newCommit"].toString().left(7);
-                QString summary;
-                if (shortOld.isEmpty() || shortOld == "0000000") {
-                    summary = QString(" * [new branch]     %1 -> %2/%1 (%3)")
-                                  .arg(branchName,
-                                       remoteName,
-                                       shortNew.isEmpty() ? "0000000" : shortNew);
-                } else if (shortOld == shortNew) {
-                    summary = QString(" = up to date       %1 (%2)")
-                                  .arg(branchName,
-                                       shortNew.isEmpty() ? "0000000" : shortNew);
-                } else {
-                    summary = QString("   %1..%2  %3 -> %4/%3")
-                                  .arg(shortOld.isEmpty() ? "0000000" : shortOld,
-                                       shortNew.isEmpty() ? "0000000" : shortNew,
-                                       branchName,
-                                       remoteName);
-                }
-                entry["summary"] = summary;
-                if (logs) logs->append(summary);
-            }
-            git_reflog_free(log);
+        const QString newCommit = entry["commit"].toString();
+        const QString oldCommit = beforeTips ? beforeTips->value(branchName) : QString();
+        entry["oldCommit"] = oldCommit;
+        entry["newCommit"] = newCommit;
+
+        QString shortOld = oldCommit.left(7);
+        QString shortNew = newCommit.left(7);
+        QString summary;
+
+        if (oldCommit.isEmpty() || shortOld == "0000000") {
+            summary = QString(" * [new branch]     %1 -> %2/%1 (%3)")
+            .arg(branchName,
+                 remoteName,
+                 shortNew.isEmpty() ? "0000000" : shortNew);
+        } else if (oldCommit  == newCommit) {
+            summary.clear();
+        } else {
+            summary = QString("   %1..%2  %3 -> %4/%3")
+            .arg(shortOld.isEmpty() ? "0000000" : shortOld,
+                 shortNew.isEmpty() ? "0000000" : shortNew,
+                 branchName,
+                 remoteName);
         }
+
+        if (summary.isEmpty())
+            return 0;
+
+        entry["summary"] = summary;
+        if (logs)
+            logs->append(summary);
 
         heads->append(entry);
         return 0;

--- a/Src/Git/GitRemote.h
+++ b/Src/Git/GitRemote.h
@@ -211,6 +211,18 @@ private:
                             std::unique_ptr<IGitAuth> auth);
 
     /**
+     * @brief Captures the current commit IDs for all tracking branches of a specific remote.
+     *
+     * This helper iterates through all remote-tracking branches (e.g., refs/remotes/origin/*)
+     * and stores their current OID. This snapshot is used to compare states before and
+     * after a fetch to determine which branches were updated or newly created.
+     *
+     * @param remoteName The name of the remote to snapshot (e.g., "origin").
+     * @return A QHash mapping branch names (without the remote prefix) to their commit OID strings.
+     */
+    QHash<QString, QString> getRemoteTrackingTipsSnapshot(const QString& remoteName);
+
+    /**
      * @brief Launch asynchronous fetch and wire completion signal.
      */
     GitResult startAsyncFetch(const QString& remoteName,


### PR DESCRIPTION
Summary
The original executeFetch used forEach over remotes, starting multiple asynchronous fetches simultaneously and calling processNextOperation multiple times. This caused queue corruption, overlapping operations, and incorrect status updates.

This PR replaces the forEach loop with a sequential state machine that processes remotes one by one, waiting for the async fetchFinished signal before advancing to the next remote.

Changes

- Added flow‑state properties (fetchFlowActive, fetchFlowItemIndex, fetchFlowPat, fetchFlowRemotes, etc.) to track progress safely.

- executeFetch initializes the flow and calls fetchStartNextRemote for the first remote.

- fetchStartNextRemote handles one remote at a time: detects protocol, checks for PAT, starts the fetch, then waits for the signal.

- onFetchFinished triggers the next remote on success, or aborts the repo on failure.

- finishFetchFlow resets state, updates status, and advances the queue.

-  PAT‑waiting behavior preserved: when an HTTPS remote is found and no token is provided, the flow stops with "PAT waiting".