### PR TITLE
Fix: Prevent context sub-menus from closing immediately on hover

### DIFF
--- a/Qml/View/Components/Base/ContextMenu.qml
+++ b/Qml/View/Components/Base/ContextMenu.qml
@@ -15,9 +15,6 @@ Popup {
      * ****************************************************************************************/
     property var menuModel: [] // Format: [{ text: "Checkout", icon: "\uf00c", action: function(){}, enabled: true }]
 
-    property var    pendingSubModel : null
-    property real   pendingSubY     : 0
-
     /* Object Properties
      * ****************************************************************************************/
     modal: false
@@ -57,28 +54,13 @@ Popup {
             border.width: 1
         }
 
-        contentItem: Item {
-            implicitWidth: subMenuColumn.implicitWidth
-            implicitHeight: subMenuColumn.implicitHeight
+        contentItem: Column {
+            spacing: 2
+            width: parent.width
 
-            MouseArea {
-                anchors.fill: parent
-                hoverEnabled: true
-                onEntered: {
-                    subMenuCloseTimer.stop()
-                    subMenuOpenTimer.stop()
-                }
-            }
-
-            Column {
-                id: subMenuColumn
-                width: parent.width
-                spacing: 2
-
-                Repeater {
-                    model: subMenuPopup.subModel
-                    delegate: menuDelegateComponent
-                }
+            Repeater {
+                model: subMenuPopup.subModel
+                delegate: menuDelegateComponent
             }
         }
     }
@@ -156,29 +138,13 @@ Popup {
                 hoverEnabled: isEnabled
                 onEntered: {
                     if (hasSub) {
-                        if (menuOption.parent === root.contentItem && subMenuPopup.opened) {
-                            root.pendingSubModel    = modelData.subItems;
-                            root.pendingSubY        = menuOption.mapToItem(root.contentItem, 0, 0).y - 6;
-                            subMenuOpenTimer.restart();
-                        } else {
-                            subMenuOpenTimer.stop();
-                            subMenuPopup.subModel   = modelData.subItems;
-                            subMenuPopup.y          = menuOption.mapToItem(root.contentItem, 0, 0).y - 6;
-                            subMenuPopup.open();
-                        }
+                        subMenuPopup.subModel = modelData.subItems
+                        subMenuPopup.y = menuOption.mapToItem(root.contentItem, 0, 0).y - 6
+                        subMenuPopup.open()
                     } else if (!isSep) {
-                        subMenuOpenTimer.stop();
-                        if (menuOption.parent === root.contentItem) {
-                            if (subMenuPopup.opened) {
-                                subMenuCloseTimer.restart();
-                            }
-                        }
-                        else{
-                            subMenuCloseTimer.stop();
-                        }
+                        subMenuPopup.close()
                     }
                 }
-
                 onClicked: {
                     if (isEnabled && !hasSub) {
                         modelData.action();
@@ -196,24 +162,6 @@ Popup {
         Repeater {
             model: root.menuModel
             delegate: menuDelegateComponent
-        }
-    }
-
-    Timer {
-        id: subMenuCloseTimer
-        interval: 150
-        onTriggered: subMenuPopup.close()
-    }
-
-    Timer {
-        id: subMenuOpenTimer
-        interval: 200
-        onTriggered: {
-            if (root.pendingSubModel) {
-                subMenuPopup.subModel   = root.pendingSubModel;
-                subMenuPopup.y          = root.pendingSubY;
-                subMenuPopup.open();
-            }
         }
     }
 }

--- a/Qml/View/Components/Base/ContextMenu.qml
+++ b/Qml/View/Components/Base/ContextMenu.qml
@@ -15,6 +15,9 @@ Popup {
      * ****************************************************************************************/
     property var menuModel: [] // Format: [{ text: "Checkout", icon: "\uf00c", action: function(){}, enabled: true }]
 
+    property var    pendingSubModel : null
+    property real   pendingSubY     : 0
+
     /* Object Properties
      * ****************************************************************************************/
     modal: false
@@ -188,5 +191,17 @@ Popup {
         id: subMenuCloseTimer
         interval: 150
         onTriggered: subMenuPopup.close()
+    }
+
+    Timer {
+        id: subMenuOpenTimer
+        interval: 200
+        onTriggered: {
+            if (root.pendingSubModel) {
+                subMenuPopup.subModel   = root.pendingSubModel;
+                subMenuPopup.y          = root.pendingSubY;
+                subMenuPopup.open();
+            }
+        }
     }
 }

--- a/Qml/View/Components/Base/ContextMenu.qml
+++ b/Qml/View/Components/Base/ContextMenu.qml
@@ -142,7 +142,9 @@ Popup {
                         subMenuPopup.y = menuOption.mapToItem(root.contentItem, 0, 0).y - 6
                         subMenuPopup.open()
                     } else if (!isSep) {
-                        subMenuPopup.close()
+                        if (subMenuPopup.opened) {
+                            subMenuCloseTimer.restart();
+                        }
                     }
                 }
                 onClicked: {
@@ -163,5 +165,11 @@ Popup {
             model: root.menuModel
             delegate: menuDelegateComponent
         }
+    }
+
+    Timer {
+        id: subMenuCloseTimer
+        interval: 150
+        onTriggered: subMenuPopup.close()
     }
 }

--- a/Qml/View/Components/Base/ContextMenu.qml
+++ b/Qml/View/Components/Base/ContextMenu.qml
@@ -156,10 +156,18 @@ Popup {
                 hoverEnabled: isEnabled
                 onEntered: {
                     if (hasSub) {
-                        subMenuPopup.subModel = modelData.subItems
-                        subMenuPopup.y = menuOption.mapToItem(root.contentItem, 0, 0).y - 6
-                        subMenuPopup.open()
+                        if (menuOption.parent === root.contentItem && subMenuPopup.opened) {
+                            root.pendingSubModel    = modelData.subItems;
+                            root.pendingSubY        = menuOption.mapToItem(root.contentItem, 0, 0).y - 6;
+                            subMenuOpenTimer.restart();
+                        } else {
+                            subMenuOpenTimer.stop();
+                            subMenuPopup.subModel   = modelData.subItems;
+                            subMenuPopup.y          = menuOption.mapToItem(root.contentItem, 0, 0).y - 6;
+                            subMenuPopup.open();
+                        }
                     } else if (!isSep) {
+                        subMenuOpenTimer.stop();
                         if (menuOption.parent === root.contentItem) {
                             if (subMenuPopup.opened) {
                                 subMenuCloseTimer.restart();
@@ -170,6 +178,7 @@ Popup {
                         }
                     }
                 }
+
                 onClicked: {
                     if (isEnabled && !hasSub) {
                         modelData.action();

--- a/Qml/View/Components/Base/ContextMenu.qml
+++ b/Qml/View/Components/Base/ContextMenu.qml
@@ -54,13 +54,25 @@ Popup {
             border.width: 1
         }
 
-        contentItem: Column {
-            spacing: 2
-            width: parent.width
+        contentItem: Item {
+            implicitWidth: subMenuColumn.implicitWidth
+            implicitHeight: subMenuColumn.implicitHeight
 
-            Repeater {
-                model: subMenuPopup.subModel
-                delegate: menuDelegateComponent
+            MouseArea {
+                anchors.fill: parent
+                hoverEnabled: true
+                onEntered: subMenuCloseTimer.stop()
+            }
+
+            Column {
+                id: subMenuColumn
+                width: parent.width
+                spacing: 2
+
+                Repeater {
+                    model: subMenuPopup.subModel
+                    delegate: menuDelegateComponent
+                }
             }
         }
     }

--- a/Qml/View/Components/Base/ContextMenu.qml
+++ b/Qml/View/Components/Base/ContextMenu.qml
@@ -33,12 +33,13 @@ Popup {
     }
 
     onClosed: {
-        subMenuPopup.close()
+        subMenuPopup.subModel = []
     }
 
     Popup {
         id: subMenuPopup
         property var subModel: []
+        visible: subMenuPopup.subModel.length > 0
         width: 200
         padding: 6
         x: root.width - 4
@@ -140,15 +141,14 @@ Popup {
                     if (hasSub) {
                         subMenuPopup.subModel = modelData.subItems
                         subMenuPopup.y = menuOption.mapToItem(root.contentItem, 0, 0).y - 6
-                        subMenuPopup.open()
-                    } else if (!isSep) {
-                        subMenuPopup.close()
+                    } else if (parent.parent === mainMenuColumn) {
+                        subMenuPopup.subModel = []
                     }
                 }
                 onClicked: {
                     if (isEnabled && !hasSub) {
                         modelData.action();
-                        subMenuPopup.close();
+                        subMenuPopup.subModel = []
                         root.close();
                     }
                 }
@@ -157,6 +157,7 @@ Popup {
     }
 
     contentItem: Column {
+        id: mainMenuColumn
         spacing: 2
         width: parent.width
         Repeater {

--- a/Qml/View/Components/Base/ContextMenu.qml
+++ b/Qml/View/Components/Base/ContextMenu.qml
@@ -64,7 +64,10 @@ Popup {
             MouseArea {
                 anchors.fill: parent
                 hoverEnabled: true
-                onEntered: subMenuCloseTimer.stop()
+                onEntered: {
+                    subMenuCloseTimer.stop()
+                    subMenuOpenTimer.stop()
+                }
             }
 
             Column {

--- a/Qml/View/Components/Base/ContextMenu.qml
+++ b/Qml/View/Components/Base/ContextMenu.qml
@@ -154,8 +154,13 @@ Popup {
                         subMenuPopup.y = menuOption.mapToItem(root.contentItem, 0, 0).y - 6
                         subMenuPopup.open()
                     } else if (!isSep) {
-                        if (subMenuPopup.opened) {
-                            subMenuCloseTimer.restart();
+                        if (menuOption.parent === root.contentItem) {
+                            if (subMenuPopup.opened) {
+                                subMenuCloseTimer.restart();
+                            }
+                        }
+                        else{
+                            subMenuCloseTimer.stop();
                         }
                     }
                 }


### PR DESCRIPTION
Description:

This fixes the bug where context sub-menus would vanish as soon as you tried to move your mouse towards them. I have successfully tested this with several sub-menus, and diagonal navigation between them now works smoothly.

The issue was that leaving the parent item triggered an instant close. I fixed this by adding some short timers to give the user a quick “grace period” for diagonal mouse movements:

- Added a 150ms delay before closing a sub-menu.
-  Added a 200ms delay before switching to a new sub-menu (so you don’t accidentally switch menus if you graze another item on your way there).
- Once your mouse enters the sub-menu itself, it stops the timers and keeps it open safely.

To test:
Right-click a commit, hover over an item with a sub-menu, and move your mouse diagonally into it. Also, try moving your mouse between several different main menu items that have sub-menus—they shouldn’t disappear or instantly overwrite each other prematurely anymore.