### PR TITLE
feat: implement Commit Amend functionality with UI polish

### DIFF
--- a/Qml/Pages/CommittingPage.qml
+++ b/Qml/Pages/CommittingPage.qml
@@ -160,6 +160,11 @@ Item {
 
         commitController        : root.commitController
         notificationController  : root.notificationController
+
+        onAmendSuccessful: {
+            changesFileLists.updateStatus()
+            commitTextArea.text = ""
+        }
     }
 
     Connections {

--- a/Qml/Pages/CommittingPage.qml
+++ b/Qml/Pages/CommittingPage.qml
@@ -328,6 +328,33 @@ Item {
 
                             readonly property bool commitEnabled: changesFileLists.stagedModel.length > 0 && commitTextArea.text !== ""
 
+                            onCommitEnabledChanged: {
+                                let items = []
+
+                                items.push({
+                                    text: commitEnabled ? "Commit Amend" : "Change commit message",
+                                    icon: Style.icons.penToSquare,
+                                    action: function() {
+                                        amendPopup.open();
+                                    }
+                                })
+
+                                if (commitEnabled) {
+                                    items.push({
+                                        text: "Commit && Push",
+                                        icon: Style.icons.arrowUp,
+                                        action: function() {
+                                            if(!root.commitAndUpdate())
+                                                return
+
+                                            root.pushAndUpdate()
+                                        }
+                                    })
+                                }
+
+                                commitDropMenu.menuModel = items
+                            }
+
                             Rectangle {
                                 id: commitBtn
                                 Layout.fillWidth: true
@@ -382,8 +409,7 @@ Item {
                                     anchors.bottom: parent.bottom
                                     width: 28
                                     hoverEnabled: true
-                                    cursorShape: parent.parent.commitEnabled ? Qt.PointingHandCursor : Qt.ArrowCursor
-                                    enabled: parent.parent.commitEnabled
+                                    cursorShape: Qt.PointingHandCursor
 
                                     Rectangle {
                                         anchors.fill: parent
@@ -412,20 +438,10 @@ Item {
                                     parent: commitPanel
                                     menuModel: [
                                         {
-                                            text: "Commit Amend",
+                                            text: parent.parent.commitEnabled ? "Commit Amend" : "Change commit message",
                                             icon: Style.icons.penToSquare,
                                             action: function() {
                                                 amendPopup.open();
-                                            }
-                                        },
-                                        {
-                                            text: "Commit && Push",
-                                            icon: Style.icons.arrowUp,
-                                            action: function() {
-                                                if(!root.commitAndUpdate())
-                                                    return
-
-                                                root.pushAndUpdate()
                                             }
                                         }
                                     ]

--- a/Qml/Pages/CommittingPage.qml
+++ b/Qml/Pages/CommittingPage.qml
@@ -1,4 +1,4 @@
-﻿import QtQuick
+import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
 
@@ -40,6 +40,7 @@ Item {
 
     property var                     pluginController:        null
 
+    property CommitAmendPopup        commitAmendPopup:        null
 
     property bool                    isFetching:             false
     property var                     activeFetchRemotes:     []
@@ -151,6 +152,14 @@ Item {
 
             changesFileLists.updateStatus()
         }
+    }
+
+    CommitAmendPopup {
+        id: amendPopup
+        anchors.centerIn: parent
+
+        commitController        : root.commitController
+        notificationController  : root.notificationController
     }
 
     Connections {
@@ -400,7 +409,9 @@ Item {
                                         {
                                             text: "Commit Amend",
                                             icon: Style.icons.penToSquare,
-                                            action: function() {root.commitAndUpdate(true)}
+                                            action: function() {
+                                                amendPopup.open();
+                                            }
                                         },
                                         {
                                             text: "Commit && Push",

--- a/Qml/Pages/CommittingPage.qml
+++ b/Qml/Pages/CommittingPage.qml
@@ -414,9 +414,10 @@ Item {
                                     cursorShape: Qt.PointingHandCursor
 
                                     Rectangle {
+                                        radius: 3
                                         anchors.fill: parent
-                                        radius: 4
-                                        color: commitCaretZone.containsMouse ? Qt.rgba(0,0,0,0.12) : "transparent"
+                                        color: committingButton.commitEnabled ?
+                                                   commitCaretZone.containsMouse ? Qt.rgba(0,0,0,0.12) : "transparent" : Style.colors.accent
                                     }
 
                                     Text {

--- a/Qml/Pages/CommittingPage.qml
+++ b/Qml/Pages/CommittingPage.qml
@@ -1,4 +1,4 @@
-import QtQuick
+﻿import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
 
@@ -39,8 +39,6 @@ Item {
     property UiSessionPopups         uiSessionPopups:         null
 
     property var                     pluginController:        null
-
-    property CommitAmendPopup        commitAmendPopup:        null
 
     property bool                    isFetching:             false
     property var                     activeFetchRemotes:     []
@@ -330,15 +328,17 @@ Item {
 
                             readonly property bool commitEnabled: changesFileLists.stagedModel.length > 0 && commitTextArea.text !== ""
 
-                            onCommitEnabledChanged: {
+                            Component.onCompleted: buildCommitMenu()
+
+                            onCommitEnabledChanged: buildCommitMenu()
+
+                            function buildCommitMenu() {
                                 let items = []
 
                                 items.push({
                                     text: commitEnabled ? "Commit Amend" : "Change commit message",
                                     icon: Style.icons.penToSquare,
-                                    action: function() {
-                                        amendPopup.open();
-                                    }
+                                    action: function() { amendPopup.open() }
                                 })
 
                                 if (commitEnabled) {
@@ -346,9 +346,7 @@ Item {
                                         text: "Commit && Push",
                                         icon: Style.icons.arrowUp,
                                         action: function() {
-                                            if(!root.commitAndUpdate())
-                                                return
-
+                                            if (!root.commitAndUpdate()) return
                                             root.pushAndUpdate()
                                         }
                                     })
@@ -414,8 +412,8 @@ Item {
                                     cursorShape: Qt.PointingHandCursor
 
                                     Rectangle {
-                                        radius: 3
                                         anchors.fill: parent
+                                        radius: 3
                                         color: committingButton.commitEnabled ?
                                                    commitCaretZone.containsMouse ? Qt.rgba(0,0,0,0.12) : "transparent" : Style.colors.accent
                                     }
@@ -439,15 +437,6 @@ Item {
                                 ContextMenu {
                                     id: commitDropMenu
                                     parent: commitPanel
-                                    menuModel: [
-                                        {
-                                            text: committingButton.commitEnabled ? "Commit Amend" : "Change commit message",
-                                            icon: Style.icons.penToSquare,
-                                            action: function() {
-                                                amendPopup.open();
-                                            }
-                                        }
-                                    ]
                                 }
                             }
 

--- a/Qml/Pages/CommittingPage.qml
+++ b/Qml/Pages/CommittingPage.qml
@@ -323,6 +323,7 @@ Item {
                         }
 
                         RowLayout {
+                            id: committingButton
                             Layout.fillWidth: true
                             spacing: 6
 
@@ -360,7 +361,7 @@ Item {
                                 Layout.fillWidth: true
                                 Layout.preferredHeight: 30
                                 radius: 4
-                                color: parent.commitEnabled ? Style.colors.accent : Style.colors.disabledButton
+                                color: committingButton.commitEnabled ? Style.colors.accent : Style.colors.disabledButton
 
                                 MouseArea {
                                     id: commitBtnMouse
@@ -369,8 +370,8 @@ Item {
                                     anchors.bottom: parent.bottom
                                     width: parent.width - 29
                                     hoverEnabled: true
-                                    cursorShape: parent.parent.commitEnabled ? Qt.PointingHandCursor : Qt.ArrowCursor
-                                    enabled: parent.parent.commitEnabled
+                                    cursorShape: committingButton.commitEnabled ? Qt.PointingHandCursor : Qt.ArrowCursor
+                                    enabled: committingButton.commitEnabled
 
                                     Rectangle {
                                         anchors.fill: parent
@@ -438,7 +439,7 @@ Item {
                                     parent: commitPanel
                                     menuModel: [
                                         {
-                                            text: parent.parent.commitEnabled ? "Commit Amend" : "Change commit message",
+                                            text: committingButton.commitEnabled ? "Commit Amend" : "Change commit message",
                                             icon: Style.icons.penToSquare,
                                             action: function() {
                                                 amendPopup.open();

--- a/Qml/Pages/CommittingPage.qml
+++ b/Qml/Pages/CommittingPage.qml
@@ -160,6 +160,7 @@ Item {
 
         commitController        : root.commitController
         notificationController  : root.notificationController
+        changeCommitMessage     : !committingButton.commitEnabled
 
         onAmendSuccessful: {
             changesFileLists.updateStatus()

--- a/Qml/UiCore/UiSessionPopups.qml
+++ b/Qml/UiCore/UiSessionPopups.qml
@@ -57,4 +57,7 @@ Item {
     property FetchSummaryPopup          fetchSummaryPopup:          FetchSummaryPopup {}
 
     property RepoForestPopup            repoForestPopup:            RepoForestPopup {}
+
+    property CommitAmendPopup commitAmendPopup: CommitAmendPopup{}
+
 }

--- a/Qml/View/MainWindow.qml
+++ b/Qml/View/MainWindow.qml
@@ -181,6 +181,8 @@ Rectangle {
                         }
                         if (item.hasOwnProperty("windowController")) {
                             item.windowController = Qt.binding(function() {return root.uiSession?.windowController})
+                        if (item.hasOwnProperty("commitAmendPopup")) {
+                            item.commitAmendPopup = Qt.binding(function() { return root.uiSession?.popups?.commitAmendPopup })
                         }
                         if (item.hasOwnProperty("pluginController")) {
                             item.pluginController = Qt.binding(function() { return root.uiSession?.pluginController })

--- a/Qml/View/MainWindow.qml
+++ b/Qml/View/MainWindow.qml
@@ -192,6 +192,7 @@ Rectangle {
                     onStatusChanged: {
                         if (status === Loader.Error)
                             console.error("[MainWindow] Failed to load page:", source)
+                        }
                     }
                 }
             }

--- a/Qml/View/Popups/CommitAmendPopup.qml
+++ b/Qml/View/Popups/CommitAmendPopup.qml
@@ -82,29 +82,36 @@ IPopup {
             anchors.horizontalCenter: parent.horizontalCenter
             topPadding: 10
 
-            Button {
-                id: confirmButton
-                width: root.width / 4
-                height: 40
-                hoverEnabled: true
-                text: "Amend"
+            Rectangle {
+                id: amendBtn
+                Layout.fillWidth: true
+                Layout.preferredHeight: 30
 
-                contentItem: Text {
-                    text: confirmButton.text
-                    font: confirmButton.font
-                    color: Style.colors.secondaryForeground
-                    horizontalAlignment: Text.AlignHCenter
-                    verticalAlignment: Text.AlignVCenter
-                }
+                radius: 4
 
-                background: Rectangle {
-                    radius: 3
-                    color: confirmButton.down ? Style.colors.accentHover : confirmButton.hovered ? Style.colors.accentHover : Style.colors.accent
-                }
+                readonly property bool canAmend: textArea.text.trim().length > 0
+                color: canAmend ? Style.colors.accent : Style.colors.disabledButton
 
-                MouseArea{
+                MouseArea {
+                    id: amendBtnMouse
                     anchors.fill: parent
-                    cursorShape: Qt.PointingHandCursor
+                    hoverEnabled: true
+                    cursorShape: parent.canAmend ? Qt.PointingHandCursor : Qt.ArrowCursor
+                    enabled: parent.canAmend
+
+                    Rectangle {
+                        anchors.fill: parent
+                        radius: 4
+                        color: amendBtnMouse.containsMouse ? Qt.rgba(0,0,0,0.12) : "transparent"
+                    }
+
+                    Text {
+                        anchors.centerIn: parent
+                        text: "Amend"
+                        color: Style.colors.secondaryForeground
+                        font.family: Style.fontTypes.roboto
+                        font.pixelSize: 12
+                    }
 
                     onClicked: {
                         let res = commitController.commit(textArea.text.trim(), true, false)

--- a/Qml/View/Popups/CommitAmendPopup.qml
+++ b/Qml/View/Popups/CommitAmendPopup.qml
@@ -100,7 +100,7 @@ IPopup {
                     cursorShape: Qt.PointingHandCursor
 
                     onClicked: {
-                        let res = commitController.commit(textArea.text, true, false)
+                        let res = commitController.commit(textArea.text.trim(), true, false)
 
                         if(res.success)
                             notificationController.success("Commit amended successfully", "Commit Amend", 3000)

--- a/Qml/View/Popups/CommitAmendPopup.qml
+++ b/Qml/View/Popups/CommitAmendPopup.qml
@@ -16,6 +16,7 @@ IPopup {
      * ****************************************************************************************/
     property NotificationController notificationController  : null
     property CommitController       commitController        : null
+    property bool                   changeCommitMessage     : false
 
 
     /* signals
@@ -121,7 +122,7 @@ IPopup {
                         let res = commitController.commit(textArea.text.trim(), true, false)
 
                         if(res.success){
-                            notificationController.success("Commit amended successfully", "Commit Amend", 3000)
+                            notificationController.success(root.changeCommitMessage ? "Commit Message Changes successfully" : "Commit amended successfully", "Commit Amend", 3000)
                             root.amendSuccessful()
                             root.close()
                         }

--- a/Qml/View/Popups/CommitAmendPopup.qml
+++ b/Qml/View/Popups/CommitAmendPopup.qml
@@ -76,11 +76,10 @@ IPopup {
             }
         }
 
-        Row {
+        RowLayout  {
             id: buttonsRow
-            spacing: 6
-            anchors.horizontalCenter: parent.horizontalCenter
-            topPadding: 10
+            width: parent.width
+            spacing: 10
 
             Rectangle {
                 id: amendBtn

--- a/Qml/View/Popups/CommitAmendPopup.qml
+++ b/Qml/View/Popups/CommitAmendPopup.qml
@@ -127,33 +127,34 @@ IPopup {
                 }
             }
 
-            Button {
-                id: cancelButton
-                width: root.width / 4
-                height: 40
-                hoverEnabled: true
-                text: "Cancel"
+            Rectangle {
+                id: cancelBtn
+                Layout.fillWidth: true
+                Layout.preferredHeight: 30
+                radius: 4
+                color: "transparent"
 
-                contentItem: Text {
-                    text: cancelButton.text
-                    font: cancelButton.font
-                    color: Style.colors.foreground
-                    horizontalAlignment: Text.AlignHCenter
-                    verticalAlignment: Text.AlignVCenter
-                }
-
-                background: Rectangle {
-                    radius: 3
-                    border.width: 1
-                    border.color: Style.colors.primaryBorder
-                    color: cancelButton.down ? Style.colors.surfaceMuted: cancelButton.hovered ? Style.colors.cardBackground : Style.colors.surfaceLight
-                }
-
-                MouseArea{
+                MouseArea {
+                    id: cancelBtnMouse
                     anchors.fill: parent
+                    hoverEnabled: true
                     cursorShape: Qt.PointingHandCursor
 
-                    onClicked: root.close()
+                    Rectangle {
+                        anchors.fill: parent
+                        radius: 4
+                        color: cancelBtnMouse.containsMouse ? Qt.rgba(255, 255, 255, 0.05) : Qt.rgba(255, 255, 255, 0.12)
+                    }
+
+                    Text {
+                        anchors.centerIn: parent
+                        text: "Cancel"
+                        color: Style.colors.secondaryForeground
+                        font.family: Style.fontTypes.roboto
+                        font.pixelSize: 12
+                    }
+
+                    onClicked: root.close();
                 }
             }
         }

--- a/Qml/View/Popups/CommitAmendPopup.qml
+++ b/Qml/View/Popups/CommitAmendPopup.qml
@@ -17,6 +17,7 @@ IPopup {
     property NotificationController notificationController  : null
     property CommitController       commitController        : null
 
+
     /* signals
      * ****************************************************************************************/
     signal amendSuccessful()
@@ -26,6 +27,10 @@ IPopup {
     width: parent.width / 2
     height: 300
     padding: 20
+
+    modal           : true
+    closePolicy     : Popup.NoAutoClose
+    anchors.centerIn: Overlay.overlay
 
     onOpened:{
         textArea.text = commitController.getLastCommitMessage()

--- a/Qml/View/Popups/CommitAmendPopup.qml
+++ b/Qml/View/Popups/CommitAmendPopup.qml
@@ -17,6 +17,10 @@ IPopup {
     property NotificationController notificationController  : null
     property CommitController       commitController        : null
 
+    /* signals
+     * ****************************************************************************************/
+    signal amendSuccessful()
+
     /* Object Properties
      * ****************************************************************************************/
     width: parent.width / 2
@@ -102,12 +106,13 @@ IPopup {
                     onClicked: {
                         let res = commitController.commit(textArea.text.trim(), true, false)
 
-                        if(res.success)
+                        if(res.success){
                             notificationController.success("Commit amended successfully", "Commit Amend", 3000)
+                            root.amendSuccessful()
+                            root.close()
+                        }
                         else
                             notificationController.error(res.errorMessage || "Amend failed", "Commit Amend Error", 5000)
-
-                        root.close()
                     }
                 }
             }

--- a/Qml/View/Popups/CommitAmendPopup.qml
+++ b/Qml/View/Popups/CommitAmendPopup.qml
@@ -1,0 +1,146 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+import GitEase
+import GitEase_Style
+import GitEase_Style_Impl
+
+/*! ***********************************************************************************************
+ * CommitAmendPopup
+ * ************************************************************************************************/
+IPopup {
+    id: root
+
+    /* Property Declarations
+     * ****************************************************************************************/
+    property NotificationController notificationController  : null
+    property CommitController       commitController        : null
+
+    /* Object Properties
+     * ****************************************************************************************/
+    width: parent.width / 2
+    height: 300
+    padding: 20
+
+    onOpened:{
+        textArea.text = commitController.getLastCommitMessage()
+    }
+
+    /* Children
+     * ****************************************************************************************/
+    background: Rectangle {
+        radius: 4
+        color: Style.colors.primaryBackground
+        border.width: 1
+        border.color: Style.colors.primaryBorder
+    }
+
+    contentItem: Column {
+        width: parent.width
+        spacing: 10
+
+        Label {
+            width: parent.width
+            color: Style.colors.descriptionText
+            text: "Amend Commit Message"
+            font.family: Style.fontTypes.roboto
+            font.pixelSize: 14
+            horizontalAlignment: Text.AlignHCenter
+        }
+
+        Label {
+            color: Style.colors.descriptionText
+            text: "Edit the message for your amended commit (Optional):"
+            font.pixelSize: 12
+        }
+
+        ScrollView {
+            width: parent.width
+            height: 150
+            anchors.margins: 5
+            TextArea {
+                id: textArea
+                color: Style.colors.foreground
+                font.family: Style.fontTypes.roboto
+                wrapMode: TextArea.Wrap
+                font.pixelSize: 12
+                Material.accent: Style.colors.accent
+            }
+        }
+
+        Row {
+            id: buttonsRow
+            spacing: 6
+            anchors.horizontalCenter: parent.horizontalCenter
+            topPadding: 10
+
+            Button {
+                id: confirmButton
+                width: root.width / 4
+                height: 40
+                hoverEnabled: true
+                text: "Amend"
+
+                contentItem: Text {
+                    text: confirmButton.text
+                    font: confirmButton.font
+                    color: Style.colors.secondaryForeground
+                    horizontalAlignment: Text.AlignHCenter
+                    verticalAlignment: Text.AlignVCenter
+                }
+
+                background: Rectangle {
+                    radius: 3
+                    color: confirmButton.down ? Style.colors.accentHover : confirmButton.hovered ? Style.colors.accentHover : Style.colors.accent
+                }
+
+                MouseArea{
+                    anchors.fill: parent
+                    cursorShape: Qt.PointingHandCursor
+
+                    onClicked: {
+                        let res = commitController.commit(textArea.text, true, false)
+
+                        if(res.success)
+                            notificationController.success("Commit amended successfully", "Commit Amend", 3000)
+                        else
+                            notificationController.error(res.errorMessage || "Amend failed", "Commit Amend Error", 5000)
+
+                        root.close()
+                    }
+                }
+            }
+
+            Button {
+                id: cancelButton
+                width: root.width / 4
+                height: 40
+                hoverEnabled: true
+                text: "Cancel"
+
+                contentItem: Text {
+                    text: cancelButton.text
+                    font: cancelButton.font
+                    color: Style.colors.foreground
+                    horizontalAlignment: Text.AlignHCenter
+                    verticalAlignment: Text.AlignVCenter
+                }
+
+                background: Rectangle {
+                    radius: 3
+                    border.width: 1
+                    border.color: Style.colors.primaryBorder
+                    color: cancelButton.down ? Style.colors.surfaceMuted: cancelButton.hovered ? Style.colors.cardBackground : Style.colors.surfaceLight
+                }
+
+                MouseArea{
+                    anchors.fill: parent
+                    cursorShape: Qt.PointingHandCursor
+
+                    onClicked: root.close()
+                }
+            }
+        }
+    }
+}

--- a/Qml/View/Popups/CommitAmendPopup.qml
+++ b/Qml/View/Popups/CommitAmendPopup.qml
@@ -29,6 +29,9 @@ IPopup {
 
     onOpened:{
         textArea.text = commitController.getLastCommitMessage()
+
+        textArea.forceActiveFocus()
+        textArea.cursorPosition = textArea.length
     }
 
     /* Children

--- a/Resources.cmake
+++ b/Resources.cmake
@@ -192,6 +192,7 @@ set(RESOURCES_POPUPS
     Qml/View/Popups/RepoForestPopup.qml
     Qml/View/Popups/ConflictPopup.qml
     Qml/View/Popups/MergeMethodPopup.qml
+    Qml/View/Popups/CommitAmendPopup.qml
 
     Qml/View/Popups/AddTagPopup.qml
     Qml/View/Popups/CalendarPopup.qml

--- a/Src/Git/GitCommit.cpp
+++ b/Src/Git/GitCommit.cpp
@@ -236,18 +236,38 @@ GitResult GitCommit::commit(const QString& message,
 
     QByteArray messageUtf8 = message.trimmed().toUtf8();
 
-    int result = git_commit_create(
-        &newCommitOid,                      // Output: new commit's SHA-1
-        m_currentRepo->repo,                // Repository to create in
-        "HEAD",                             // Update HEAD reference
-        author,                             // Who wrote the changes
-        author,                             // Who committed them
-        nullptr,                            // Default encoding (UTF-8)
-        messageUtf8.constData(),            // Commit message
-        tree,                               // Tree snapshot
-        parents.count,                      // Number of parents
-        (const git_commit**)parents.commits // Parent commits
+    int result = 0;
+    if (amend) {
+        if (!parents.amendedCommit) {
+            cleanupCommitResources(author, tree, parents);
+            return GitResult(false, QVariant(), "Cannot amend: no commits yet (unborn branch).");
+        }
+
+        result = git_commit_amend(
+            &newCommitOid,
+            parents.amendedCommit,              // The commit to amend
+            "HEAD",                             // Update HEAD reference
+            author,                             // Who wrote the changes
+            author,                             // Who committed them
+            nullptr,                            // Default encoding (UTF-8)
+            messageUtf8.constData(),            // Commit message
+            tree                                // Tree snapshot
         );
+    }
+    else{
+        result = git_commit_create(
+            &newCommitOid,                      // Output: new commit's SHA-1
+            m_currentRepo->repo,                // Repository to create in
+            "HEAD",                             // Update HEAD reference
+            author,                             // Who wrote the changes
+            author,                             // Who committed them
+            nullptr,                            // Default encoding (UTF-8)
+            messageUtf8.constData(),            // Commit message
+            tree,                               // Tree snapshot
+            parents.count,                      // Number of parents
+            (const git_commit**)parents.commits // Parent commits
+        );
+    }
 
     if (result != GIT_OK) {
         // Cleanup on failure

--- a/Src/Git/GitCommit.cpp
+++ b/Src/Git/GitCommit.cpp
@@ -556,3 +556,27 @@ QStringList GitCommit::getAllParents(git_commit *gitCommit)
 
     return parentHashes;
 }
+
+QString GitCommit::getLastCommitMessage()
+{
+    if (!m_currentRepo || !m_currentRepo->repo) {
+        return "";
+    }
+
+    git_reference* headRef = nullptr;
+    if (git_repository_head(&headRef, m_currentRepo->repo) != 0) {
+        return "";
+    }
+
+    git_commit* headCommit = nullptr;
+    int result = git_reference_peel((git_object**)&headCommit, headRef, GIT_OBJECT_COMMIT);
+    git_reference_free(headRef);
+
+    QString message = "";
+    if (result == 0 && headCommit) {
+        message = QString::fromUtf8(git_commit_message(headCommit));
+        git_commit_free(headCommit);
+    }
+
+    return message;
+}

--- a/Src/Git/GitCommit.h
+++ b/Src/Git/GitCommit.h
@@ -132,6 +132,12 @@ public:
      */
     void freeParentCommits(ParentCommits& parents);
 
+    /**
+     * \brief Retrieve the last commit message from the current repository
+     * \return The message of the last (HEAD) commit, or an empty string on error
+     */
+    Q_INVOKABLE QString getLastCommitMessage();
+
 
     Repository *currentRepo() const;
 


### PR DESCRIPTION
Overview
This PR introduces the "Amend Commit" feature, allowing users to modify their last commit message, alongside a polished and intuitive popup UI.

Changes Implemented

- Commit Amend Popup: Created CommitAmendPopup.qml to handle user input for amending the last commit.
- Main UI Integration: Added the amendSuccessful signal to trigger a status refresh in CommittingPage.qml immediately after a successful amend.

UX Enhancements: 

- The text area automatically gains focus and places the cursor at the end of the existing commit message upon opening.
- The "Amend" button features a distinct visual disabled state if the text area is empty.
- Added subtle hover effects to both the "Amend" and "Cancel" buttons.
- Modal Enforcement: Configured the popup to be a strict modal (NoAutoClose) centered on the application overlay, requiring explicit action to close.

 Testing
- Verified the last commit message loads correctly into the text area.
- Verified the popup cannot be bypassed by clicking outside (modal behavior).
- Confirmed the Amend button enables/disables correctly based on text input.
- Confirmed the main committing page updates its file status properly after a successful amend.
