### PR TITLE
Ge 320 uiux improvements for the fetchpull process in repo forest

### DIFF
--- a/Qml/Style/Icons.qml
+++ b/Qml/Style/Icons.qml
@@ -70,4 +70,7 @@ QtObject{
     property string arrowDownToLine:   "\uf33d"
 
     property string close:              "\uf00d" // close
+    property string play:              "\uf04b" // play
+    property string pause:             "\uf28b" // pause
+    property string stop:              "\uf04d" // stop
 }

--- a/Qml/UiCore/UiSessionPopups.qml
+++ b/Qml/UiCore/UiSessionPopups.qml
@@ -56,7 +56,9 @@ Item {
 
     property FetchSummaryPopup          fetchSummaryPopup:          FetchSummaryPopup {}
 
-    property RepoForestPopup            repoForestPopup:            RepoForestPopup {}
+    property RepoForestPopup            repoForestPopup:            RepoForestPopup {
+        userAuthenticationPopup: root.userAuthenticationPopup
+    }
 
     property CommitAmendPopup commitAmendPopup: CommitAmendPopup{}
 

--- a/Qml/View/Components/FileLists/ActionIconButton.qml
+++ b/Qml/View/Components/FileLists/ActionIconButton.qml
@@ -29,6 +29,7 @@ Rectangle {
     width: 20
     height: 20
     radius: 4
+    opacity: root.enabled ? 1.0 : 0.4
 
     property color hoverBackgroundColor: {
         if (backgroundColor == "transparent" || Qt.colorEqual(backgroundColor, "transparent")) {
@@ -67,8 +68,9 @@ Rectangle {
     MouseArea {
         id: mouse
         anchors.fill: parent
-        hoverEnabled: true
-        cursorShape: Qt.PointingHandCursor
+        enabled: root.enabled
+        hoverEnabled: root.enabled
+        cursorShape: root.enabled ? Qt.PointingHandCursor : Qt.ArrowCursor
         onClicked: root.clicked()
     }
 

--- a/Qml/View/Components/Remotes/RemoteView.qml
+++ b/Qml/View/Components/Remotes/RemoteView.qml
@@ -51,7 +51,9 @@ UtilitiesCard {
     icon: Style.icons.upload
 
     Connections {
+        id: userAuthenticationPopupConnection
         target: userAuthenticationPopup
+        enabled: false
 
         function onPasswordConfirm(password){
             if (root.authPurpose === "pull") {
@@ -88,6 +90,10 @@ UtilitiesCard {
         function onRejected() {
             root.authPurpose = "fetch"
             root.isFetching = root.activeFetchRemotes.length > 0
+        }
+
+        function onClosed() {
+            userAuthenticationPopupConnection.enabled = false
         }
     }
 
@@ -283,6 +289,7 @@ UtilitiesCard {
                                     case RepositoryController.GitProtocol.HTTP:
                                         root.isFetching = true
                                         root.authPurpose = "fetch"
+                                        userAuthenticationPopupConnection.enabled = true
                                         userAuthenticationPopup.open()
                                         break;
                                     }
@@ -317,6 +324,7 @@ UtilitiesCard {
                                     case RepositoryController.GitProtocol.HTTPS:
                                     case RepositoryController.GitProtocol.HTTP:
                                         root.authPurpose = "pull"
+                                        userAuthenticationPopupConnection.enabled = true
                                         userAuthenticationPopup.open()
                                         break
                                     }

--- a/Qml/View/Components/RepoForest/RepoForest.qml
+++ b/Qml/View/Components/RepoForest/RepoForest.qml
@@ -112,6 +112,14 @@ Rectangle {
             repoListView.focusOnIndex()
     }
 
+    onVisibleChanged: {
+        if (visible) {
+            root.reposModel = []
+            root.selectedIndexes = []
+            gitScanner.scan(root.rootPath)
+        }
+    }
+
     /* Signals
     * ****************************************************************************************/
     signal closeRequested()
@@ -583,12 +591,6 @@ Rectangle {
         function onClosed() {
             root._showUserAuthenticationPopup = false
         }
-    }
-
-    onRootPathChanged: {
-        root.reposModel = []
-        root.selectedIndexes = []
-        gitScanner.scan(root.rootPath)
     }
 
     ColumnLayout {

--- a/Qml/View/Components/RepoForest/RepoForest.qml
+++ b/Qml/View/Components/RepoForest/RepoForest.qml
@@ -36,6 +36,8 @@ Rectangle {
     property   int                    fetchFlowRemoteIndex:     0
     property   string                 fetchFlowCurrentRemote:   ""
 
+    property   var                    operationLogs:            []
+
 
     readonly property bool allSelected:     reposModel.length > 0 && selectedIndexes.length === reposModel.length
     readonly property bool noneSelected:    selectedIndexes.length === 0
@@ -123,6 +125,19 @@ Rectangle {
         root.reposModel = root.reposModel.slice()
     }
 
+    function logOperation(repoName, remoteName, operation, status, message) {
+        let entry = {
+            repoName: repoName,
+            remoteName: remoteName,
+            operation: operation,
+            status: status,
+            message: message,
+            timestamp: new Date().toLocaleTimeString(Qt.locale(), "hh:mm:ss")
+        }
+        root.operationLogs.push(entry)
+        root.operationLogs = root.operationLogs.slice()
+    }
+
     function enqueueOperation(operation, itemIndex, pat) {
         root.operationQueue.push({ operation: operation, index: itemIndex, pat: pat})
         root.operationQueue = root.operationQueue.slice()
@@ -155,10 +170,9 @@ Rectangle {
 
         let repoItem = root.reposModel[itemIndex]
 
-
-
         if(!repoItem.repo) {
             root.updateStatus(itemIndex, "Canceled")
+            root.logOperation(repoItem.name, "", "fetch", "Canceled", "Repository not available")
             processNextOperation()
             return
         }
@@ -169,12 +183,14 @@ Rectangle {
 
         if(!remotesRes.success) {
             root.updateStatus(itemIndex, "Canceled")
+            root.logOperation(repoItem.name, "", "fetch", "Canceled", "Failed to get remotes")
             processNextOperation()
             return
         }
 
         if (remotesRes.data.length === 0) {
             root.updateStatus(itemIndex, "Done")
+            root.logOperation(repoItem.name, "", "fetch", "Done", "No remotes to fetch")
             processNextOperation()
             return
         }
@@ -203,10 +219,12 @@ Rectangle {
         root.fetchFlowRemoteIndex += 1
         root.fetchFlowCurrentRemote = remote.name
 
+        root.logOperation(repoName, remote.name, "fetch", "Pending", "Starting fetch...")
+
         let remoteUrlRes = scanRemoteController.getRemoteUrl(remote.name)
         if(!remoteUrlRes.success) {
+            root.logOperation(repoName, remote.name, "fetch", "Canceled", "Failed to get remote URL")
             finishFetchFlow("Canceled")
-
             return
         }
 
@@ -215,6 +233,7 @@ Rectangle {
         if (protocol !== RepositoryController.GitProtocol.SSH && root.fetchFlowPat === "") {
             root.reposModel[root.fetchFlowItemIndex].pendingOperation = "fetch"
             root.reposModel = root.reposModel.slice()
+            root.logOperation(repoName, remote.name, "fetch", "Canceled", "PAT required for HTTPS")
             root.finishFetchFlow("PAT waiting")
             return
         }
@@ -228,6 +247,15 @@ Rectangle {
 
     function finishFetchFlow(status: string) {
         let idx = root.fetchFlowItemIndex
+        let repoName = root.reposModel[idx].name
+        if (status === "Done") {
+            root.logOperation(repoName, "", "fetch", "Done", "All remotes fetched successfully")
+        } else if (status === "Canceled") {
+            root.logOperation(repoName, root.fetchFlowCurrentRemote, "fetch", "Canceled", "Fetch canceled or failed")
+        } else if (status === "PAT waiting") {
+            root.logOperation(repoName, root.fetchFlowCurrentRemote, "fetch", "Canceled", "Waiting for PAT")
+        }
+
         root.fetchFlowActive        = false
         root.fetchFlowItemIndex     = -1
         root.fetchFlowPat           = ""
@@ -242,13 +270,11 @@ Rectangle {
     function executePull(itemIndex: int, pat: string) {
         root.updateStatus(itemIndex, "Pulling")
 
-        let repo = root.reposModel[itemIndex]
-
         let repoItem = root.reposModel[itemIndex]
 
-
-        if(!repoItem) {
+        if(!repoItem || !repoItem.repo) {
             root.updateStatus(itemIndex, "Canceled")
+            root.logOperation("Unknown", "", "pull", "Canceled", "Repository not available")
             processNextOperation()
             return
         }
@@ -258,12 +284,14 @@ Rectangle {
 
         if(!remotesRes.success) {
             root.updateStatus(itemIndex, "Canceled")
+            root.logOperation(repoItem.name, "", "pull", "Canceled", "Failed to get remotes")
             processNextOperation()
             return
         }
 
         if (remotesRes.data.length === 0) {
             root.updateStatus(itemIndex, "Done")
+            root.logOperation(repoItem.name, "", "pull", "Done", "No remotes to pull")
             processNextOperation()
             return
         }
@@ -273,6 +301,7 @@ Rectangle {
 
             if(!remoteUrlRes.success) {
                 root.updateStatus(itemIndex, "Canceled")
+                root.logOperation(repoItem.name, remote.name, "pull", "Canceled", "Failed to get remote URL")
                 processNextOperation()
                 return
             }
@@ -291,8 +320,10 @@ Rectangle {
                 let onPullFinished = (result) => {
                     if (result.success) {
                         root.updateStatus(itemIndex, "Done")
+                        root.logOperation(repoItem.name, remote.name, "pull", "Success", "Pull completed successfully")
                     } else {
                         root.updateStatus(itemIndex, "Canceled")
+                        root.logOperation(repoItem.name, remote.name, "pull", "Failed", result.error || "Pull failed")
                     }
                     scanRemoteController.pullFinished.disconnect(onPullFinished)
                     processNextOperation()
@@ -303,11 +334,30 @@ Rectangle {
                 let pullRes = scanRemoteController.pull(remote.name)
                 if(!pullRes.success) {
                     root.updateStatus(itemIndex, "Canceled")
+                    root.logOperation(repoItem.name, remote.name, "pull", "Canceled", "Failed to start pull")
                     scanRemoteController.pullFinished.disconnect(onPullFinished)
                     processNextOperation()
                 }
             } else {
-                // TODO
+                let onPullFinished = (result) => {
+                    if (result.success) {
+                        root.updateStatus(itemIndex, "Done")
+                        root.logOperation(repoItem.name, remote.name, "pull", "Success", "Pull completed successfully")
+                    } else {
+                        root.updateStatus(itemIndex, "Canceled")
+                        root.logOperation(repoItem.name, remote.name, "pull", "Failed", result.error || "Pull failed")
+                    }
+                    scanRemoteController.pullFinished.disconnect(onPullFinished)
+                    processNextOperation()
+                }
+                scanRemoteController.pullFinished.connect(onPullFinished)
+                let pullRes = scanRemoteController.pull(remote.name, "", pat)
+                if(!pullRes.success) {
+                    root.updateStatus(itemIndex, "Canceled")
+                    root.logOperation(repoItem.name, remote.name, "pull", "Canceled", "Failed to start pull")
+                    scanRemoteController.pullFinished.disconnect(onPullFinished)
+                    processNextOperation()
+                }
             }
         })
     }
@@ -352,10 +402,13 @@ Rectangle {
             if (result.remote !== root.fetchFlowCurrentRemote)
                 return
 
-            if (!result.success) {
-                finishFetchFlow("Canceled")
-            }else {
+            let repoName = root.reposModel[root.fetchFlowItemIndex].name
+            if (result.success) {
+                root.logOperation(repoName, result.remote, "fetch", "Success", "Fetch completed successfully")
                 fetchStartNextRemote()
+            } else {
+                root.logOperation(repoName, result.remote, "fetch", "Failed", result.error || "Fetch failed")
+                finishFetchFlow("Canceled")
             }
         }
 
@@ -733,12 +786,23 @@ Rectangle {
 
                     delegate: RepoItem {
                         isSelected: root.selectedIndexes.indexOf(index) !== -1
+                        isProcessing: root.isProcessingQueue
 
                         onClicked: (i) => root.toggleSelection(i)
                         onFetchRequested: (i, pat) => root.fetch(i, pat)
                         onPullRequested: (i, pat) => root.pull(i, pat)
                     }
                 }
+            }
+        }
+
+        RepoForestLogs {
+            Layout.fillWidth: true
+            visible: root.operationLogs.length > 0
+            operationLogs: root.operationLogs
+
+            onClearLogsRequested: {
+                root.operationLogs = []
             }
         }
     }

--- a/Qml/View/Components/RepoForest/RepoForest.qml
+++ b/Qml/View/Components/RepoForest/RepoForest.qml
@@ -41,6 +41,47 @@ Rectangle {
     readonly property bool noneSelected:    selectedIndexes.length === 0
     readonly property bool someSelected:    !allSelected && !noneSelected
 
+    readonly property int selectedCount:    root.selectedIndexes.length
+
+    readonly property int completedCount: {
+        let count = 0
+        root.selectedIndexes.forEach(idx => {
+            let status = root.reposModel[idx] ? root.reposModel[idx].status : ""
+            if (status === "Done" || status === "Canceled") {
+                count++
+            }
+        })
+        return count
+    }
+
+    readonly property int progressPercent: root.selectedCount > 0 ? Math.round((root.completedCount / root.selectedCount) * 100) : 0
+
+    readonly property int pendingFetchCount: {
+        let count = 0
+        root.operationQueue.forEach(op => {
+            if (op.operation === "fetch")
+                count++
+        })
+
+        if (root.fetchFlowActive)
+            count++
+
+        return count
+    }
+
+    readonly property int pendingPullCount: {
+        let count = 0
+        root.operationQueue.forEach(op => {
+            if (op.operation === "pull")
+                count++
+        })
+        root.selectedIndexes.forEach(idx => {
+            if (root.reposModel[idx] && root.reposModel[idx].status === "Pulling")
+                count++
+        })
+        return count
+    }
+
     /* Signals
     * ****************************************************************************************/
     signal closeRequested()
@@ -158,6 +199,7 @@ Rectangle {
         }
 
         let remote = root.fetchFlowRemotes[root.fetchFlowRemoteIndex]
+        let repoName = root.reposModel[root.fetchFlowItemIndex].name
         root.fetchFlowRemoteIndex += 1
         root.fetchFlowCurrentRemote = remote.name
 
@@ -171,6 +213,8 @@ Rectangle {
         let protocol = root.repositoryController.detectGitProtocol(remoteUrlRes.data.url)
 
         if (protocol !== RepositoryController.GitProtocol.SSH && root.fetchFlowPat === "") {
+            root.reposModel[root.fetchFlowItemIndex].pendingOperation = "fetch"
+            root.reposModel = root.reposModel.slice()
             root.finishFetchFlow("PAT waiting")
             return
         }
@@ -209,7 +253,8 @@ Rectangle {
             return
         }
 
-        let remotesRes =scanRemoteController.getRemotes()
+        scanRemoteController.currentRepo = repoItem.repo
+        let remotesRes = scanRemoteController.getRemotes()
 
         if(!remotesRes.success) {
             root.updateStatus(itemIndex, "Canceled")
@@ -223,8 +268,8 @@ Rectangle {
             return
         }
 
-        let remote = remotesRes.data.forEach(remote => {
-            let remoteUrlRes =scanRemoteController.getRemoteUrl(remote.name)
+        remotesRes.data.forEach(remote => {
+            let remoteUrlRes = scanRemoteController.getRemoteUrl(remote.name)
 
             if(!remoteUrlRes.success) {
                 root.updateStatus(itemIndex, "Canceled")
@@ -234,19 +279,31 @@ Rectangle {
 
             let protocol = root.repositoryController.detectGitProtocol(remoteUrlRes.data.url)
 
+            if (protocol !== RepositoryController.GitProtocol.SSH && pat === "") {
+                root.reposModel[itemIndex].pendingOperation = "pull"
+                root.reposModel = root.reposModel.slice()
+                root.updateStatus(itemIndex, "PAT waiting")
+                processNextOperation()
+                return
+            }
+
             if (protocol === RepositoryController.GitProtocol.SSH) {
                 let onPullFinished = (result) => {
-                    root.updateStatus(itemIndex, result.success ? "Done" : "Canceled")
-                   scanRemoteController.pullFinished.disconnect(onPullFinished)
+                    if (result.success) {
+                        root.updateStatus(itemIndex, "Done")
+                    } else {
+                        root.updateStatus(itemIndex, "Canceled")
+                    }
+                    scanRemoteController.pullFinished.disconnect(onPullFinished)
                     processNextOperation()
                 }
 
-               scanRemoteController.pullFinished.connect(onPullFinished)
+                scanRemoteController.pullFinished.connect(onPullFinished)
 
-                let pullRes =scanRemoteController.pull(remote.name)
+                let pullRes = scanRemoteController.pull(remote.name)
                 if(!pullRes.success) {
                     root.updateStatus(itemIndex, "Canceled")
-                   scanRemoteController.pullFinished.disconnect(onPullFinished)
+                    scanRemoteController.pullFinished.disconnect(onPullFinished)
                     processNextOperation()
                 }
             } else {
@@ -371,7 +428,7 @@ Rectangle {
     }
 
     ColumnLayout {
-        spacing: 8
+        spacing: 4
         anchors.fill: parent
         anchors.margins: 20
 
@@ -546,6 +603,82 @@ Rectangle {
                     }
                 }
                 onClicked: root.closeRequested()
+            }
+        }
+
+        Rectangle {
+            Layout.fillWidth: true
+            Layout.preferredHeight: 50
+            color: Style.colors.secondaryBackground
+            radius: 6
+            visible: root.selectedCount > 0
+
+            ColumnLayout {
+                anchors.fill: parent
+                anchors.margins: 8
+                anchors.leftMargin: 12
+                anchors.rightMargin: 12
+                spacing: 6
+
+                RowLayout {
+                    Layout.fillWidth: true
+                    spacing: 12
+
+                    Text {
+                        text: "Selected: " + root.selectedCount
+                        font.family: Style.fontTypes.roboto
+                        font.pixelSize: 11
+                        color: Style.colors.foreground
+                    }
+                    Text {
+                        text: "Pending Fetch: " + root.pendingFetchCount
+                        font.family: Style.fontTypes.roboto
+                        font.pixelSize: 11
+                        color: Style.colors.repoItemStatusFetchingText
+                    }
+                    Text {
+                        text: "Pending Pull: " + root.pendingPullCount
+                        font.family: Style.fontTypes.roboto
+                        font.pixelSize: 11
+                        color: Style.colors.repoItemStatusPullingText
+                    }
+
+                    Item {
+                        Layout.fillWidth: true
+                    }
+
+                    BusyIndicator {
+                        id: queueSpinner
+                        Layout.preferredWidth: 24
+                        Layout.preferredHeight: 24
+                        running: root.isProcessingQueue
+                        visible: root.isProcessingQueue
+                        Material.accent: Style.colors.accent
+                    }
+
+                    Text {
+                        text: root.progressPercent + "%"
+                        font.family: Style.fontTypes.roboto
+                        font.pixelSize: 12
+                        font.weight: Font.Bold
+                        color: Style.colors.accent
+                    }
+                }
+
+                Rectangle {
+                    Layout.fillWidth: true
+                    Layout.preferredHeight: 4
+                    radius: 2
+                    color: Style.colors.primaryBorder
+
+                    Rectangle {
+                        height: parent.height
+                        width: parent.width * (root.progressPercent / 100)
+                        radius: 2
+                        color: Style.colors.accent
+                        Behavior on width { NumberAnimation { duration: 200 } }
+                    }
+                }
             }
         }
 

--- a/Qml/View/Components/RepoForest/RepoForest.qml
+++ b/Qml/View/Components/RepoForest/RepoForest.qml
@@ -108,7 +108,8 @@ Rectangle {
     }
 
     onFetchFlowItemIndexChanged: {
-        repoListView.focusOnIndex()
+        if (autoScrollingCheckBox.checked)
+            repoListView.focusOnIndex()
     }
 
     /* Signals
@@ -630,6 +631,22 @@ Rectangle {
                 }
             }
 
+            CheckBox {
+                id: autoScrollingCheckBox
+                Layout.fillWidth: false
+                text: "Auto Scroll"
+
+                font.family: Style.fontTypes.roboto
+                font.pixelSize: 12
+
+                Material.accent: Style.colors.accent
+                Material.foreground: Style.colors.foreground
+
+                palette {
+                    text: Style.colors.foreground
+                }
+            }
+
             ToolButton {
                 id: fetchButton
                 Layout.preferredWidth: 26
@@ -1033,7 +1050,10 @@ Rectangle {
                 onPullRequested: (i) => root.pull(i)
             }
 
-            onCountChanged: repoListView.focusOnIndex()
+            onCountChanged: {
+                if (autoScrollingCheckBox.checked)
+                    repoListView.focusOnIndex()
+            }
 
             function focusOnIndex() {
                 if (root.fetchFlowItemIndex < 0 || root.fetchFlowItemIndex >= count)

--- a/Qml/View/Components/RepoForest/RepoForest.qml
+++ b/Qml/View/Components/RepoForest/RepoForest.qml
@@ -15,31 +15,39 @@ import GitEase_Style_Impl
 Rectangle {
     id: root
 
+    enum QueueState {
+        Ready,
+        Running,
+        Pause,
+        PauseRequested,
+        Stop
+    }
+
     /* Property Declarations
      * ****************************************************************************************/
-    property   RepositoryController   repositoryController
-    property   BranchController       branchController
-    property   RemoteController       remoteController
-    property   string                 rootPath
-    property   GitScanner             gitScanner
-    property   var                    reposModel:               []
-    property   var                    selectedIndexes:          []
-    property   bool                   isRunning:                false
-    property   var                    operationQueue:           []
-    property   bool                   isProcessingQueue:        false
-    property   var                    scannedRepositories:      []
-
-    property   bool                   fetchFlowActive:          false
-    property   int                    fetchFlowItemIndex:       -1
-    property   string                 fetchFlowPat:             ""
-    property   var                    fetchFlowRemotes:         []
-    property   int                    fetchFlowRemoteIndex:     0
-    property   string                 fetchFlowCurrentRemote:   ""
-
-    property   var                    operationLogs:            []
+    property   RepositoryController         repositoryController
+    property   BranchController             branchController
+    property   RemoteController             remoteController
     property   UserAuthenticationPopup      userAuthenticationPopup
+    property   string                       rootPath
+    property   GitScanner                   gitScanner
+    property   var                          reposModel:               []
+    property   var                          selectedIndexes:          []
+    property   bool                         isRunning:                false
+    property   var                          operationQueue:           []
+    property   int                          queueState:               RepoForest.QueueState.Ready
+    property   var                          scannedRepositories:      []
+
     property   string                       pat:                      ""
     property   string                       pendingOperation:         ""
+
+    property   bool                         fetchFlowActive:          false
+    property   int                          fetchFlowItemIndex:       -1
+    property   var                          fetchFlowRemotes:         []
+    property   int                          fetchFlowRemoteIndex:     0
+    property   string                       fetchFlowCurrentRemote:   ""
+
+    property   var                          operationLogs:            []
 
 
     readonly property bool allSelected:     reposModel.length > 0 && selectedIndexes.length === reposModel.length
@@ -154,18 +162,49 @@ Rectangle {
         root.operationQueue = root.operationQueue.slice()
         root.updateStatus(itemIndex, "Pending")
 
-        if (!root.isProcessingQueue) {
+        if (root.queueState === RepoForest.QueueState.Ready) {
             processNextOperation()
         }
     }
 
     function processNextOperation() {
         if (root.operationQueue.length === 0) {
-            root.isProcessingQueue = false
+            root.queueState = RepoForest.QueueState.Ready
             return
         }
 
-        root.isProcessingQueue = true
+        if (root.queueState === RepoForest.QueueState.PauseRequested) {
+            root.queueState = RepoForest.QueueState.Pause
+            return
+        }
+
+        if (root.queueState === RepoForest.QueueState.Pause) {
+            return
+        }
+
+        if (root.queueState === RepoForest.QueueState.Stop) {
+            let queue = root.operationQueue.slice()
+
+            root.logOperation("","", "Stop", "Info", "Queue Stop")
+
+            root.operationQueue = []
+            root.operationQueue = root.operationQueue.slice()
+            for (let i = 0; i < queue.length; i++) {
+                root.updateStatus(queue[i].index, "Stoped")
+            }
+
+            root.queueState = RepoForest.QueueState.Ready
+            root.fetchFlowActive = false
+            root.fetchFlowItemIndex = -1
+            root.fetchFlowRemotes = []
+            root.fetchFlowRemoteIndex = 0
+            root.fetchFlowCurrentRemote = ""
+            root._currentOperation = ""
+            root._patWaitingIndexs = []
+            return
+        }
+
+        root.queueState = RepoForest.QueueState.Running
         let item = root.operationQueue.shift()
         root.operationQueue = root.operationQueue.slice()
 
@@ -178,7 +217,22 @@ Rectangle {
         }
     }
 
-    function executeFetch(itemIndex: int, pat: string) {
+    function pauseQueue() {
+        root.queueState = RepoForest.QueueState.PauseRequested
+        root.logOperation("","", "pause", "Info", "Queue paused")
+    }
+
+    function resumeQueue() {
+        if (root.queueState === RepoForest.QueueState.Pause) {
+            root.logOperation("","", "resume", "Info", "Queue resumed")
+            root.queueState = RepoForest.QueueState.Ready
+            if (root.operationQueue.length > 0) {
+                processNextOperation()
+            }
+        }
+    }
+
+    function executeFetch(itemIndex: int) {
         root.updateStatus(itemIndex, "Fetching")
 
         let repoItem = root.reposModel[itemIndex]
@@ -577,7 +631,8 @@ Rectangle {
                 Layout.preferredWidth: 26
                 Layout.preferredHeight: 26
 
-                enabled: !root.noneSelected && !root.isProcessingQueue
+                enabled: !root.noneSelected && root.queueState === RepoForest.QueueState.Ready
+                visible: root.queueState === RepoForest.QueueState.Ready
                 hoverEnabled: true
 
                 contentItem: Text {
@@ -630,7 +685,8 @@ Rectangle {
                 Layout.preferredWidth: 26
                 Layout.preferredHeight: 26
 
-                enabled: !root.noneSelected && !root.isProcessingQueue
+                enabled: !root.noneSelected && root.queueState === RepoForest.QueueState.Ready
+                visible: root.queueState === RepoForest.QueueState.Ready
                 hoverEnabled: true
 
                 contentItem: Text {
@@ -676,6 +732,125 @@ Rectangle {
                 }
 
                 onClicked: root.pullSelectedIndexes()
+            }
+
+            ToolButton {
+                id: pauseResumeButton
+
+                property bool isQueuePaused: root.queueState === RepoForest.QueueState.Pause
+
+                Layout.preferredWidth: 26
+                Layout.preferredHeight: 26
+                visible: root.queueState === RepoForest.QueueState.Running || root.queueState === RepoForest.QueueState.Pause
+                enabled: (root.queueState === RepoForest.QueueState.Running || root.queueState === RepoForest.QueueState.Pause) && root.queueState !== RepoForest.QueueState.PauseRequested
+                hoverEnabled: true
+
+                contentItem: Text {
+                    anchors.centerIn: parent
+                    text: pauseResumeButton.isQueuePaused ? Style.icons.play : Style.icons.pause
+                    font.pixelSize: 15
+                    font.family: Style.fontTypes.font6ProSolid
+                    color: Style.colors.foreground
+                    horizontalAlignment: Text.AlignHCenter
+                    verticalAlignment: Text.AlignVCenter
+                }
+
+                background: Rectangle {
+                    radius: 5
+                    color: pauseResumeButton.down ? Style.colors.surfaceMuted :
+                           pauseResumeButton.hovered ? Style.colors.cardBackground : Style.colors.secondaryBackground
+                }
+
+                ToolTip {
+                    visible: pauseResumeButton.hovered
+                    delay: 100
+                    timeout: 2000
+
+                    x: (parent.width - width) / 2
+                    y: -height - 6
+
+                    padding: 6
+
+                    contentItem: Text {
+                        text: pauseResumeButton.isQueuePaused ? "Resume" : "Pause"
+                        font.family: Style.fontTypes.roboto
+                        font.pixelSize: 11
+                        color: "#ffffff"
+                    }
+
+                    background: Rectangle {
+                        radius: 6
+                        color: Qt.rgba(0, 0, 0, 0.85)
+                        border.color: Qt.rgba(1, 1, 1, 0.12)
+                        border.width: 1
+                    }
+                }
+
+                onClicked: {
+                    if (pauseResumeButton.isQueuePaused) {
+                        root.resumeQueue()
+                    } else {
+                        root.pauseQueue()
+                    }
+                }
+            }
+
+            ToolButton {
+                id: stopButton
+                Layout.preferredWidth: 26
+                Layout.preferredHeight: 26
+                visible: root.queueState === RepoForest.QueueState.Running || root.queueState === RepoForest.QueueState.Pause
+                enabled: (root.queueState === RepoForest.QueueState.Running || root.queueState === RepoForest.QueueState.Pause) && root.queueState !== RepoForest.QueueState.PauseRequested
+                hoverEnabled: true
+
+                contentItem: Text {
+                    anchors.centerIn: parent
+                    text: Style.icons.stop
+                    font.pixelSize: 15
+                    font.family: Style.fontTypes.font6ProSolid
+                    color: Style.colors.foreground
+                    horizontalAlignment: Text.AlignHCenter
+                    verticalAlignment: Text.AlignVCenter
+                }
+
+                background: Rectangle {
+                    radius: 5
+                    color: stopButton.down ? Style.colors.surfaceMuted :
+                           stopButton.hovered ? Style.colors.cardBackground : Style.colors.secondaryBackground
+                }
+
+                ToolTip {
+                    visible: stopButton.hovered
+                    delay: 100
+                    timeout: 2000
+
+                    x: (parent.width - width) / 2
+                    y: -height - 6
+
+                    padding: 6
+
+                    contentItem: Text {
+                        text: "Stop All"
+                        font.family: Style.fontTypes.roboto
+                        font.pixelSize: 11
+                        color: "#ffffff"
+                    }
+
+                    background: Rectangle {
+                        radius: 6
+                        color: Qt.rgba(0, 0, 0, 0.85)
+                        border.color: Qt.rgba(1, 1, 1, 0.12)
+                        border.width: 1
+                    }
+                }
+
+                onClicked: {
+                    let lastState = root.queueState
+                    root.queueState = RepoForest.QueueState.Stop
+                    if (lastState === RepoForest.QueueState.Pause) {
+                        processNextOperation()
+                    }
+                }
             }
 
             WindowsButton {
@@ -756,8 +931,8 @@ Rectangle {
                         id: queueSpinner
                         Layout.preferredWidth: 24
                         Layout.preferredHeight: 24
-                        running: root.isProcessingQueue
-                        visible: root.isProcessingQueue
+                        running: root.queueState !== RepoForest.QueueState.Ready && root.queueState !== RepoForest.QueueState.Pause
+                        visible: queueSpinner.running
                         Material.accent: Style.colors.accent
                     }
 
@@ -838,7 +1013,7 @@ Rectangle {
 
                     delegate: RepoItem {
                         isSelected: root.selectedIndexes.indexOf(index) !== -1
-                        isProcessing: root.isProcessingQueue
+                        isProcessing: root.queueState !== RepoForest.QueueState.Ready
 
                         onClicked: (i) => root.toggleSelection(i)
                         onFetchRequested: (i) => root.fetch(i)

--- a/Qml/View/Components/RepoForest/RepoForest.qml
+++ b/Qml/View/Components/RepoForest/RepoForest.qml
@@ -37,6 +37,7 @@ Rectangle {
     property   string                 fetchFlowCurrentRemote:   ""
 
     property   var                    operationLogs:            []
+    property   UserAuthenticationPopup      userAuthenticationPopup
 
 
     readonly property bool allSelected:     reposModel.length > 0 && selectedIndexes.length === reposModel.length

--- a/Qml/View/Components/RepoForest/RepoForest.qml
+++ b/Qml/View/Components/RepoForest/RepoForest.qml
@@ -612,6 +612,8 @@ Rectangle {
                 Layout.fillWidth: false
                 text: "Select All"
 
+                visible: root.queueState === RepoForest.QueueState.Ready
+
                 font.family: Style.fontTypes.roboto
                 font.pixelSize: 12
 

--- a/Qml/View/Components/RepoForest/RepoForest.qml
+++ b/Qml/View/Components/RepoForest/RepoForest.qml
@@ -301,6 +301,13 @@ Rectangle {
                 fetchStartNextRemote()
             }
         }
+
+        function onFetchProgress(progress) {
+            let idx = root.fetchFlowItemIndex
+
+            root.reposModel[idx].progress = progress
+            root.reposModel = root.reposModel.slice()
+        }
     }
 
     Connections {

--- a/Qml/View/Components/RepoForest/RepoForest.qml
+++ b/Qml/View/Components/RepoForest/RepoForest.qml
@@ -107,6 +107,10 @@ Rectangle {
         }
     }
 
+    onFetchFlowItemIndexChanged: {
+        repoListView.focusOnIndex()
+    }
+
     /* Signals
     * ****************************************************************************************/
     signal closeRequested()
@@ -997,29 +1001,47 @@ Rectangle {
             }
         }
 
-        ScrollView {
+        ListView {
+            id: repoListView
+
             Layout.fillWidth: true
             Layout.fillHeight: true
-            visible: root.reposModel && root.reposModel.length > 0 && !root.gitScanner.busy && !root.isRunning
             clip: true
+            spacing: 4
 
-            ColumnLayout {
-                width: parent.width
-                spacing: 4
+            visible: root.reposModel && root.reposModel.length > 0 && !root.gitScanner.busy && !root.isRunning
 
-                Repeater {
-                    id: repositoryRepeater
-                    model: root.reposModel
+            cacheBuffer: 800
+            reuseItems: true
 
-                    delegate: RepoItem {
-                        isSelected: root.selectedIndexes.indexOf(index) !== -1
-                        isProcessing: root.queueState !== RepoForest.QueueState.Ready
+            model: root.reposModel
 
-                        onClicked: (i) => root.toggleSelection(i)
-                        onFetchRequested: (i) => root.fetch(i)
-                        onPullRequested: (i) => root.pull(i)
-                    }
-                }
+            highlightMoveDuration: 500
+            preferredHighlightBegin: height / 2
+            preferredHighlightEnd: height / 2
+            highlightRangeMode: ListView.ApplyRange
+
+            delegate: RepoItem {
+                width: ListView.view.width
+                height: 70
+
+                isSelected: root.selectedIndexes.indexOf(index) !== -1
+                isProcessing: root.queueState !== RepoForest.QueueState.Ready
+
+                onClicked: (i) => root.toggleSelection(i)
+                onFetchRequested: (i) => root.fetch(i)
+                onPullRequested: (i) => root.pull(i)
+            }
+
+            onCountChanged: repoListView.focusOnIndex()
+
+            function focusOnIndex() {
+                if (root.fetchFlowItemIndex < 0 || root.fetchFlowItemIndex >= count)
+                    return
+
+                Qt.callLater(() => {
+                    positionViewAtIndex(root.fetchFlowItemIndex, ListView.Beginning)
+                })
             }
         }
 

--- a/Qml/View/Components/RepoForest/RepoForest.qml
+++ b/Qml/View/Components/RepoForest/RepoForest.qml
@@ -38,6 +38,8 @@ Rectangle {
 
     property   var                    operationLogs:            []
     property   UserAuthenticationPopup      userAuthenticationPopup
+    property   string                       pat:                      ""
+    property   string                       pendingOperation:         ""
 
 
     readonly property bool allSelected:     reposModel.length > 0 && selectedIndexes.length === reposModel.length
@@ -85,6 +87,18 @@ Rectangle {
         return count
     }
 
+    /* Private Properties
+     * ****************************************************************************************/
+    property string _currentOperation: ""
+    property var    _patWaitingIndexs: []
+    property bool   _showUserAuthenticationPopup: false
+
+    on_ShowUserAuthenticationPopupChanged: {
+        if (root._showUserAuthenticationPopup && root.pat === "") {
+            root.userAuthenticationPopup.open()
+        }
+    }
+
     /* Signals
     * ****************************************************************************************/
     signal closeRequested()
@@ -119,10 +133,6 @@ Rectangle {
     function updateStatus(itemIndex: int, status: string) {
         root.reposModel[itemIndex].status = status
 
-        if (status === "Canceled" || status === "Done") {
-            repositoryController.closeRepository(root.reposModel[itemIndex].repo)
-        }
-
         root.reposModel = root.reposModel.slice()
     }
 
@@ -139,8 +149,8 @@ Rectangle {
         root.operationLogs = root.operationLogs.slice()
     }
 
-    function enqueueOperation(operation, itemIndex, pat) {
-        root.operationQueue.push({ operation: operation, index: itemIndex, pat: pat})
+    function enqueueOperation(operation, itemIndex) {
+        root.operationQueue.push({ operation: operation, index: itemIndex})
         root.operationQueue = root.operationQueue.slice()
         root.updateStatus(itemIndex, "Pending")
 
@@ -160,9 +170,11 @@ Rectangle {
         root.operationQueue = root.operationQueue.slice()
 
         if (item.operation === "fetch") {
-            executeFetch(item.index, item.pat)
+            root._currentOperation = item.operation
+            executeFetch(item.index)
         } else if (item.operation === "pull") {
-            executePull(item.index, item.pat)
+            root._currentOperation = item.operation
+            executePull(item.index)
         }
     }
 
@@ -198,7 +210,6 @@ Rectangle {
 
         root.fetchFlowActive        = true
         root.fetchFlowItemIndex     = itemIndex
-        root.fetchFlowPat           = pat
         root.fetchFlowRemotes       = remotesRes.data
         root.fetchFlowRemoteIndex   = 0
         root.fetchFlowCurrentRemote = ""
@@ -220,7 +231,7 @@ Rectangle {
         root.fetchFlowRemoteIndex += 1
         root.fetchFlowCurrentRemote = remote.name
 
-        root.logOperation(repoName, remote.name, "fetch", "Pending", "Starting fetch...")
+        root.logOperation(repoName, remote.name, "fetch", "Fetching", "Starting fetch...")
 
         let remoteUrlRes = scanRemoteController.getRemoteUrl(remote.name)
         if(!remoteUrlRes.success) {
@@ -231,18 +242,24 @@ Rectangle {
 
         let protocol = root.repositoryController.detectGitProtocol(remoteUrlRes.data.url)
 
-        if (protocol !== RepositoryController.GitProtocol.SSH && root.fetchFlowPat === "") {
-            root.reposModel[root.fetchFlowItemIndex].pendingOperation = "fetch"
-            root.reposModel = root.reposModel.slice()
-            root.logOperation(repoName, remote.name, "fetch", "Canceled", "PAT required for HTTPS")
-            root.finishFetchFlow("PAT waiting")
-            return
+        if (protocol !== RepositoryController.GitProtocol.SSH) {
+            if (root.pat === "") {
+                root._patWaitingIndexs.push(root.fetchFlowItemIndex)
+
+                root._showUserAuthenticationPopup = true
+                root.finishFetchFlow("PAT waiting")
+                return
+            } else if (root.pat === "skip") {
+                root.logOperation(repoName, remote.name, "fetch", "Canceled", "HTTPS Skipped")
+                root.finishFetchFlow("Skipped")
+                return
+            }
         }
 
         if (protocol === RepositoryController.GitProtocol.SSH) {
             scanRemoteController.fetch(remote.name)
         } else {
-            scanRemoteController.fetchWithToken(remote.name, root.fetchFlowPat)
+            scanRemoteController.fetchWithToken(remote.name, root.pat)
         }
     }
 
@@ -259,7 +276,6 @@ Rectangle {
 
         root.fetchFlowActive        = false
         root.fetchFlowItemIndex     = -1
-        root.fetchFlowPat           = ""
         root.fetchFlowRemotes       = []
         root.fetchFlowRemoteIndex   = 0
         root.fetchFlowCurrentRemote = ""
@@ -363,23 +379,23 @@ Rectangle {
         })
     }
 
-    function fetch(itemIndex: int, pat: string) {
-        enqueueOperation("fetch", itemIndex, pat)
+    function fetch(itemIndex: int) {
+        enqueueOperation("fetch", itemIndex)
     }
 
-    function pull(itemIndex: int, pat: string) {
-        enqueueOperation("pull", itemIndex, pat)
+    function pull(itemIndex: int) {
+        enqueueOperation("pull", itemIndex)
     }
 
     function fetchSelectedIndexes() {
         root.selectedIndexes.forEach(index => {
-            root.fetch(index, "")
+            root.fetch(index)
         })
     }
 
     function pullSelectedIndexes() {
         root.selectedIndexes.forEach(index => {
-            root.pull(index, "")
+            root.pull(index)
         })
     }
 
@@ -472,6 +488,41 @@ Rectangle {
                 root.reposModel = root.reposModel.slice()
                 root.isRunning = false
             }
+        }
+    }
+
+    Connections {
+        target: root.userAuthenticationPopup
+
+        function onPasswordConfirm(password){
+            root.pat = password
+
+            root._patWaitingIndexs.forEach(index => {
+                if (root._currentOperation === "fetch") {
+                    root.fetch(index)
+                } else if (root._currentOperation === "pull"){
+                    root.pull(index)
+                }
+            })
+
+            root._patWaitingIndexs = []
+        }
+
+        function onRejected() {
+            root.pat = "skip"
+
+            root._patWaitingIndexs.forEach(index => {
+                root.updateStatus(index, "Skipped")
+                let repoName = root.reposModel[index].name || ""
+                if (repoName !== "")
+                    root.logOperation(repoName, "", "fetch", "Canceled", "HTTPS Skipped")
+            })
+
+            root._patWaitingIndexs = []
+        }
+
+        function onClosed() {
+            root._showUserAuthenticationPopup = false
         }
     }
 
@@ -790,8 +841,8 @@ Rectangle {
                         isProcessing: root.isProcessingQueue
 
                         onClicked: (i) => root.toggleSelection(i)
-                        onFetchRequested: (i, pat) => root.fetch(i, pat)
-                        onPullRequested: (i, pat) => root.pull(i, pat)
+                        onFetchRequested: (i) => root.fetch(i)
+                        onPullRequested: (i) => root.pull(i)
                     }
                 }
             }

--- a/Qml/View/Components/RepoForest/RepoForestLogs.qml
+++ b/Qml/View/Components/RepoForest/RepoForestLogs.qml
@@ -106,6 +106,8 @@ ColumnLayout {
                 model: root.operationLogs
                 spacing: 4
 
+                highlightMoveDuration: 150
+
                 delegate: RowLayout {
                     width: ListView.width
                     spacing: 6
@@ -159,6 +161,12 @@ ColumnLayout {
                             return Style.colors.foreground
                         }
                         elide: Text.ElideRight
+                    }
+                }
+
+                onCountChanged: {
+                    if (count > 0) {
+                        positionViewAtIndex(count - 1, ListView.End)
                     }
                 }
             }

--- a/Qml/View/Components/RepoForest/RepoForestLogs.qml
+++ b/Qml/View/Components/RepoForest/RepoForestLogs.qml
@@ -1,0 +1,167 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+import GitEase
+import GitEase_Style
+import GitEase_Style_Impl
+
+/*! ***********************************************************************************************
+ * RepoForestLogs
+ * ************************************************************************************************/
+ColumnLayout {
+    id: root
+
+    /* Property Declarations
+     * ****************************************************************************************/
+    property var  operationLogs:        []
+    property bool showOperationLogs:    false
+
+    /* Object Properties
+     * ****************************************************************************************/
+    spacing: 8
+
+    /* Signals
+    * ****************************************************************************************/
+    signal clearLogsRequested()
+
+    /* Children
+    * ****************************************************************************************/
+    RowLayout {
+        Layout.fillWidth: true
+        spacing: 8
+
+        Text {
+            Layout.fillWidth: true
+            text: "Operation Log"
+            font.family: Style.fontTypes.roboto
+            font.pixelSize: 12
+            font.bold: true
+            color: Style.colors.foreground
+        }
+
+        ToolButton {
+            Layout.preferredWidth: 22
+            Layout.preferredHeight: 22
+            hoverEnabled: true
+            contentItem: Text {
+                anchors.centerIn: parent
+                text: root.showOperationLogs ? Style.icons.caretDown : Style.icons.caretUp
+                font.pixelSize: 14
+                font.family: Style.fontTypes.font6ProSolid
+                color: Style.colors.foreground
+                horizontalAlignment: Text.AlignHCenter
+                verticalAlignment: Text.AlignVCenter
+            }
+            background: Rectangle {
+                radius: 5
+                color: parent.hovered ? Style.colors.cardBackground : "transparent"
+            }
+            onClicked: root.showOperationLogs = !root.showOperationLogs
+        }
+
+        ToolButton {
+            Layout.preferredWidth: 22
+            Layout.preferredHeight: 22
+            hoverEnabled: true
+            contentItem: Text {
+                anchors.centerIn: parent
+                text: Style.icons.trash
+                font.pixelSize: 12
+                font.family: Style.fontTypes.font6ProSolid
+                color: Style.colors.windowsClose
+                horizontalAlignment: Text.AlignHCenter
+                verticalAlignment: Text.AlignVCenter
+            }
+            background: Rectangle {
+                radius: 5
+                color: parent.hovered ? Style.colors.cardBackground : "transparent"
+            }
+            onClicked: {
+                root.clearLogsRequested()
+                root.showOperationLogs = false
+            }
+        }
+    }
+
+    Rectangle {
+        Layout.fillWidth: true
+        Layout.preferredHeight: root.showOperationLogs ? 150 : 0
+        radius: 3
+        color: Style.colors.secondaryBackground
+        border.color: Style.colors.primaryBorder
+        clip: true
+
+        Behavior on Layout.preferredHeight {
+            NumberAnimation { duration: 300 }
+        }
+
+        ScrollView {
+            anchors.fill: parent
+            anchors.margins: 4
+            clip: true
+
+            ListView {
+                width: parent.width
+                model: root.operationLogs
+                spacing: 4
+
+                delegate: RowLayout {
+                    width: ListView.width
+                    spacing: 6
+
+                    Text {
+                        Layout.preferredWidth: 60
+                        text: modelData.timestamp
+                        font.family: Style.fontTypes.roboto
+                        font.pixelSize: 11
+                        color: Style.colors.mutedText
+                    }
+
+                    Text {
+                        Layout.preferredWidth: 120
+                        text: modelData.repoName
+                        font.family: Style.fontTypes.roboto
+                        font.pixelSize: 11
+                        font.bold: true
+                        color: Style.colors.foreground
+                        elide: Text.ElideRight
+                    }
+
+                    Text {
+                        Layout.preferredWidth: 80
+                        text: "[" + modelData.operation.toUpperCase() + "]"
+                        font.family: Style.fontTypes.roboto
+                        font.pixelSize: 11
+                        color: modelData.operation === "fetch" ? Style.colors.repoItemStatusFetchingText : Style.colors.repoItemStatusPullingText
+                    }
+
+                    Text {
+                        Layout.preferredWidth: 80
+                        text: modelData.remoteName ? ("@" + modelData.remoteName) : ""
+                        font.family: Style.fontTypes.roboto
+                        font.pixelSize: 11
+                        color: Style.colors.mutedText
+                    }
+
+                    Text {
+                        Layout.fillWidth: true
+                        text: modelData.message
+                        font.family: Style.fontTypes.roboto
+                        font.pixelSize: 11
+                        color: {
+                            if (modelData.status === "Success" || modelData.status === "Done")
+                                return Style.colors.repoItemStatusDoneText
+
+                            if (modelData.status === "Failed" || modelData.status === "Canceled")
+                                return Style.colors.repoItemStatusCanceledText
+
+                            return Style.colors.foreground
+                        }
+                        elide: Text.ElideRight
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Qml/View/Components/RepoForest/RepoItem.qml
+++ b/Qml/View/Components/RepoForest/RepoItem.qml
@@ -28,8 +28,6 @@ Rectangle {
 
     /* Object Properties
      * ****************************************************************************************/
-    Layout.fillWidth: true
-    Layout.preferredHeight: 70
     color: {
         if (msa.hovered) {
                 return Qt.darker(Style.colors.surfaceLight, 1.05)

--- a/Qml/View/Components/RepoForest/RepoItem.qml
+++ b/Qml/View/Components/RepoForest/RepoItem.qml
@@ -83,6 +83,9 @@ Rectangle {
 
                 Rectangle {
                     id: status
+
+                    property int progress: root.modelData.progress || -1
+
                     property color statusTextColor: {
                         switch(root.modelData.status) {
                             case "Canceled":
@@ -129,11 +132,31 @@ Rectangle {
                         }
                     }
 
+                    property color progressFillColor: Qt.darker(statusBgColor, 2.5)
+
                     Layout.alignment: Qt.AlignVCenter
                     Layout.preferredWidth: statusText.contentWidth + 30
                     Layout.preferredHeight: 20
                     radius: 5
                     color: status.statusBgColor
+
+                    Rectangle {
+                        id: progressFill
+                        anchors.left: status.left
+                        anchors.top: status.top
+                        anchors.bottom: status.bottom
+                        implicitWidth: status.width * (status.progress / 100)
+                        color: status.progressFillColor
+                        radius: status.radius
+                        opacity: 0.25
+
+                        Behavior on width {
+                            NumberAnimation {
+                                duration: 250
+                                easing.type: Easing.InOutQuad
+                            }
+                        }
+                    }
 
                     RowLayout {
                         anchors.centerIn: parent
@@ -150,7 +173,8 @@ Rectangle {
                         Text {
                             id: statusText
                             Layout.alignment: Qt.AlignVCenter
-                            text: root.modelData.status
+                            text: (status.progress > 0 && status.progress <= 100) ?
+                                      `${root.modelData.status} ${status.progress} %` : root.modelData.status
                             font.family: Style.fontTypes.roboto
                             font.pixelSize: 12
                             font.weight: 300

--- a/Qml/View/Components/RepoForest/RepoItem.qml
+++ b/Qml/View/Components/RepoForest/RepoItem.qml
@@ -149,6 +149,7 @@ Rectangle {
                         color: status.progressFillColor
                         radius: status.radius
                         opacity: 0.25
+                        visible: !(status.progress === 100)
 
                         Behavior on width {
                             NumberAnimation {

--- a/Qml/View/Components/RepoForest/RepoItem.qml
+++ b/Qml/View/Components/RepoForest/RepoItem.qml
@@ -167,7 +167,7 @@ Rectangle {
                         Text {
                             id: statusText
                             Layout.alignment: Qt.AlignVCenter
-                            text: (status.progress > 0 && status.progress <= 100) ?
+                            text: (status.progress > 0 && status.progress <= 99) ?
                                       `${root.modelData.status} ${status.progress} %` : root.modelData.status
                             font.family: Style.fontTypes.roboto
                             font.pixelSize: 12

--- a/Qml/View/Components/RepoForest/RepoItem.qml
+++ b/Qml/View/Components/RepoForest/RepoItem.qml
@@ -19,20 +19,17 @@ Rectangle {
     required property       var     modelData
     property                bool    isSelected: false
     property                bool    isProcessing: false
-    readonly property       bool    patNeeded:  root.modelData.status === "PAT waiting"
-    property                string  pat:        ""
-    readonly property       string  pendingOperation: root.modelData.pendingOperation || ""
 
     /* Signals
      * ****************************************************************************************/
     signal clicked(index: int)
-    signal fetchRequested(index: int, pat: string)
-    signal pullRequested(index: int, pat: string)
+    signal fetchRequested(index: int)
+    signal pullRequested(index: int)
 
     /* Object Properties
      * ****************************************************************************************/
     Layout.fillWidth: true
-    Layout.preferredHeight: root.patNeeded ? 120 : 70
+    Layout.preferredHeight: 70
     color: {
         if (msa.hovered) {
                 return Qt.darker(Style.colors.surfaceLight, 1.05)
@@ -104,10 +101,8 @@ Rectangle {
                                 return Style.colors.repoItemStatusDirtyText
                             case "Conflict":
                                 return Style.colors.repoItemStatusConflictText
-                            case "PAT waiting":
-                                return Style.colors.repoItemStatusPATText
                             default:
-                                return Style.colors.repoItemStatusPendingText
+                                return Style.colors.repoItemStatusCanceledText
                         }
                     }
 
@@ -127,10 +122,8 @@ Rectangle {
                                 return Style.colors.repoItemStatusDirtyBg
                             case "Conflict":
                                 return Style.colors.repoItemStatusConflictBg
-                            case "PAT waiting":
-                                return Style.colors.repoItemStatusPATBg
                             default:
-                                return Style.colors.repoItemStatusPendingBg
+                                return Style.colors.repoItemStatusCanceledBg
                         }
                     }
 
@@ -187,24 +180,22 @@ Rectangle {
                 }
 
                 ActionIconButton {
-                    visible: !root.patNeeded || root.pat.length > 0
                     enabled: !root.isProcessing
                     iconText: Style.icons.arrowDown
                     tooltip: "Pull"
                     backgroundColor: Qt.darker(Style.colors.surfaceLight, 1.4)
                     textColor: Style.colors.foreground
-                    onClicked: root.pullRequested(root.index, root.pat)
+                    onClicked: root.pullRequested(root.index)
                 }
 
                 ActionIconButton {
-                    visible: !root.patNeeded || root.pat.length > 0
                     enabled: !root.isProcessing
                     Layout.rightMargin: 10
                     iconText: Style.icons.download
                     tooltip: "Fetch"
                     backgroundColor: Qt.darker(Style.colors.surfaceLight, 1.4)
                     textColor: Style.colors.foreground
-                    onClicked: root.fetchRequested(root.index, root.pat)
+                    onClicked: root.fetchRequested(root.index)
                 }
             }
 
@@ -279,65 +270,6 @@ Rectangle {
                     color: Style.colors.mutedText
                     font.weight: 400
                     font.letterSpacing: 0
-                }
-            }
-
-            // PAT
-            RowLayout {
-                Layout.fillWidth: true
-                Layout.topMargin: 10
-                spacing: 15
-
-                visible: root.patNeeded
-
-                FormInputField {
-                    id: textField
-                    field.implicitHeight: 30
-                    Layout.fillWidth: true
-                    Layout.rightMargin: 10
-                    placeholderText: "Personal Access Token"
-                    icon: "\uF023"
-                    echoMode: TextInput.Password
-                }
-
-                Button {
-                    id: confirmButton
-                    implicitWidth: 60
-                    Layout.preferredHeight: 25
-                    Layout.rightMargin: 10
-                    hoverEnabled: true
-                    visible: textField.field.text.length > 0
-
-                    topInset: 0
-                    bottomInset: 0
-                    leftPadding: 0
-                    rightPadding: 0
-                    topPadding: 0
-                    bottomPadding: 0
-
-                    contentItem: Text {
-                        text: "Confirm"
-                        font: confirmButton.font
-                        color: Style.colors.secondaryForeground
-                        horizontalAlignment: Text.AlignHCenter
-                        verticalAlignment: Text.AlignVCenter
-                    }
-
-                    background: Rectangle {
-                        radius: 3
-                        color: confirmButton.down ? Style.colors.accentHover : confirmButton.hovered ? Style.colors.accentHover : Style.colors.accent
-                    }
-
-                    onClicked: {
-                        root.pat = textField.text
-                        confirmButton.visible = false
-                        textField.enabled = false
-                        if (root.pendingOperation === "fetch") {
-                            root.fetchRequested(root.index, root.pat)
-                        } else if (root.pendingOperation === "pull") {
-                            root.pullRequested(root.index, root.pat)
-                        }
-                    }
                 }
             }
         }

--- a/Qml/View/Components/RepoForest/RepoItem.qml
+++ b/Qml/View/Components/RepoForest/RepoItem.qml
@@ -21,6 +21,7 @@ Rectangle {
     property                bool    isProcessing: false
     readonly property       bool    patNeeded:  root.modelData.status === "PAT waiting"
     property                string  pat:        ""
+    readonly property       string  pendingOperation: root.modelData.pendingOperation || ""
 
     /* Signals
      * ****************************************************************************************/
@@ -331,6 +332,11 @@ Rectangle {
                         root.pat = textField.text
                         confirmButton.visible = false
                         textField.enabled = false
+                        if (root.pendingOperation === "fetch") {
+                            root.fetchRequested(root.index, root.pat)
+                        } else if (root.pendingOperation === "pull") {
+                            root.pullRequested(root.index, root.pat)
+                        }
                     }
                 }
             }

--- a/Qml/View/Components/RepoForest/RepoItem.qml
+++ b/Qml/View/Components/RepoForest/RepoItem.qml
@@ -18,6 +18,7 @@ Rectangle {
     required property       int     index
     required property       var     modelData
     property                bool    isSelected: false
+    property                bool    isProcessing: false
     readonly property       bool    patNeeded:  root.modelData.status === "PAT waiting"
     property                string  pat:        ""
 
@@ -186,6 +187,7 @@ Rectangle {
 
                 ActionIconButton {
                     visible: !root.patNeeded || root.pat.length > 0
+                    enabled: !root.isProcessing
                     iconText: Style.icons.arrowDown
                     tooltip: "Pull"
                     backgroundColor: Qt.darker(Style.colors.surfaceLight, 1.4)
@@ -195,6 +197,7 @@ Rectangle {
 
                 ActionIconButton {
                     visible: !root.patNeeded || root.pat.length > 0
+                    enabled: !root.isProcessing
                     Layout.rightMargin: 10
                     iconText: Style.icons.download
                     tooltip: "Fetch"
@@ -340,6 +343,7 @@ Rectangle {
     }
 
     TapHandler {
+        enabled: !root.isProcessing
         onTapped: root.clicked(root.index)
     }
 }

--- a/Qml/View/Popups/RepoForestPopup.qml
+++ b/Qml/View/Popups/RepoForestPopup.qml
@@ -15,11 +15,12 @@ IPopup {
 
     /* Property Declarations
      * ****************************************************************************************/
-    property   RepositoryController   repositoryController
-    property   BranchController       branchController
-    property   RemoteController       remoteController
-    property   string                 rootPath
-    property   GitScanner             gitScanner:               GitScanner{}
+    property   RepositoryController         repositoryController
+    property   BranchController             branchController
+    property   RemoteController             remoteController
+    property   UserAuthenticationPopup      userAuthenticationPopup
+    property   string                       rootPath
+    property   GitScanner                   gitScanner:               GitScanner{}
 
     /* Object Properties
      * ****************************************************************************************/
@@ -34,6 +35,7 @@ IPopup {
         repositoryController: root.repositoryController
         branchController: root.branchController
         remoteController: root.remoteController
+        userAuthenticationPopup: root.userAuthenticationPopup
         rootPath: root.rootPath
         gitScanner: root.gitScanner
 

--- a/Qml/View/Popups/RepoForestPopup.qml
+++ b/Qml/View/Popups/RepoForestPopup.qml
@@ -48,10 +48,13 @@ IPopup {
     /* Functions
      * ****************************************************************************************/
     function resetRepoForest() {
+        repoForest.reposModel = []
+        repoForest.pat = ""
+        repoForest.pendingOperation = ""
         repoForest.selectedIndexes = []
         repoForest.isRunning = false
         repoForest.operationQueue = []
-        repoForest.isProcessingQueue = false
+        repoForest.queueState = RepoForest.QueueState.Ready
         gitScanner.stop()
     }
 }

--- a/Resources.cmake
+++ b/Resources.cmake
@@ -150,6 +150,7 @@ set(RESOURCES_COMPONENTS
 
     # Repo Forest
     Qml/View/Components/RepoForest/RepoForest.qml
+    Qml/View/Components/RepoForest/RepoForestLogs.qml
     Qml/View/Components/RepoForest/RepoItem.qml
 
     # Conflict Components

--- a/Src/Git/GitRemote.cpp
+++ b/Src/Git/GitRemote.cpp
@@ -1000,7 +1000,26 @@ GitResult GitRemote::fetchInternal(const QString& remoteName, std::unique_ptr<IG
         auth.get()
     };
 
+    auto progressCallback = [](const git_indexer_progress *stats, void *p) -> int {
+        auto *data = static_cast<GitRepository::GitPayload*>(p);
+
+        if (stats->total_objects > 0) {
+            int percent = static_cast<int>(
+                (100.0 * stats->received_objects) / stats->total_objects
+                );
+
+            QMetaObject::invokeMethod(
+                data->parentThread,
+                "fetchProgress",
+                Qt::QueuedConnection,
+                Q_ARG(int, percent)
+                );
+        }
+        return 0;
+    };
+
     opts.callbacks.payload = &payload;
+    opts.callbacks.transfer_progress = progressCallback;
     auth->applyFetch(opts);
 
     QHash<QString, QString> beforeTrackingTips = getRemoteTrackingTipsSnapshot(remoteName);

--- a/Src/Git/GitRemote.h
+++ b/Src/Git/GitRemote.h
@@ -268,6 +268,7 @@ private:
                                      std::unique_ptr<IGitAuth> auth);
 
 signals:
+    void fetchProgress(int progress);
     void pullFinished(QVariantMap result);
     void pushFinished(QVariantMap result);
     void pushInProgressChanged();


### PR DESCRIPTION
+ Progress bar & per‑repo progress
Show an overall progress bar (e.g., “Fetching 3/10 repositories”) and per‑repo progress (“Fetching n% repo X”).

+ Play / Stop / Resume controls
Add a toolbar with buttons to pause the queue, resume, or stop all operations. The queue could be paused mid‑flow

+ Batch token entry before start
+ Disable action buttons during operations

+ Ensure the main Fetch/Pull buttons are disabled while isProcessingQueue is true .
+ Add a visual “spinner” or animated icon.

+ Operation log / detailed status
Show a collapsible log area that lists each remote’s fetch/pull result in real time (success/failure messages).