### PR TITLE
339 new rebase

### DIFF
--- a/Qml/Pages/UtilitiesPage.qml
+++ b/Qml/Pages/UtilitiesPage.qml
@@ -144,15 +144,7 @@ Item {
                 commitController        : root.commitController
                 statusController        : root.statusController
                 notificationController  : root.notificationController
-
-                conflictPopup: ConflictPopup {
-                    currentOperation: ConflictPopup.OperationType.Rebase
-
-                    rebaseController        : root.rebaseController
-                    conflictController      : root.conflictController
-                    notificationController  : root.notificationController
-                    statusController        : root.statusController
-                }
+                conflictController      : root.conflictController
             }
 
             // ── Plugin docks ─────────────────────────────────────────────────

--- a/Qml/Pages/UtilitiesPage.qml
+++ b/Qml/Pages/UtilitiesPage.qml
@@ -141,6 +141,8 @@ Item {
                 height: 390
                 branchController        : root.branchController
                 rebaseController        : root.rebaseController
+                commitController        : root.commitController
+                statusController        : root.statusController
                 notificationController  : root.notificationController
 
                 conflictPopup: ConflictPopup {

--- a/Qml/Style/Colors.qml
+++ b/Qml/Style/Colors.qml
@@ -139,4 +139,11 @@ QtObject{
     property color conflictSeparatorBg:     "transparent"
     property color conflictMarkerText:      "#333333"
     property color lineNumberColor:         "#808080"
+
+    // Interactive rebase status colors
+    property color rebaseStatusPending:    mutedText
+    property color rebaseStatusInProgress: "#E67E00"       // warm orange
+    property color rebaseStatusRebased:    "#1B7B3A"       // dark green
+    property color rebaseStatusConflict:   "#C0392B"       // deep red
+    property color rebaseStatusSkipped:    mutedText       // dimmed
 }

--- a/Qml/Style/Style.qml
+++ b/Qml/Style/Style.qml
@@ -143,6 +143,13 @@ QtObject {
         conflictMarkerText:     "#E0E0E0"  // Brighter text for headers
         hintText:               "#a0a0a0"
         lineNumberColor:        "#a0a0a0"
+
+        // Interactive rebase status colors
+        property color rebaseStatusPending:    secondaryText
+        property color rebaseStatusInProgress: "#FFA500"        // bright orange
+        property color rebaseStatusRebased:    "#2ECC40"        // bright green
+        property color rebaseStatusConflict:   "#FF4136"        // bright red
+        property color rebaseStatusSkipped:    mutedText        // dimmed
     }
 
     property           string       currentTheme:               "Modern Light"

--- a/Qml/View/Components/Docks/CommitGraphDock.qml
+++ b/Qml/View/Components/Docks/CommitGraphDock.qml
@@ -455,6 +455,8 @@ DetachablePanel {
         statusController: root.statusController
         commitController: root.commitController
         rebaseController: root.rebaseController
+        conflictController: root.conflictController
+        notificationController: root.notificationController
     }
 
     /* Functions

--- a/Qml/View/Components/Docks/CommitGraphDock.qml
+++ b/Qml/View/Components/Docks/CommitGraphDock.qml
@@ -946,7 +946,7 @@ DetachablePanel {
             var res = root.mergeController.mergeBranchIntoCurrent(source, noFF)
 
             if (root.mergeController.hasMergeConflicts()) {
-                mergeConflictPopup.open()
+                mergeConflictPopup.show()
 
                 root.notificationController.warning("Merge conflicts detected.", "Merge", 4000)
 

--- a/Qml/View/Components/Docks/CommitGraphDock.qml
+++ b/Qml/View/Components/Docks/CommitGraphDock.qml
@@ -455,7 +455,6 @@ DetachablePanel {
         statusController: root.statusController
         commitController: root.commitController
         rebaseController: root.rebaseController
-        conflictPopup   : rebaseConflictPopup
     }
 
     /* Functions

--- a/Qml/View/Components/Docks/CommitGraphDock.qml
+++ b/Qml/View/Components/Docks/CommitGraphDock.qml
@@ -450,6 +450,14 @@ DetachablePanel {
         }
     }
 
+    CommitPlanPopup {
+        id: commitPlanPopup
+        statusController: root.statusController
+        commitController: root.commitController
+        rebaseController: root.rebaseController
+        conflictPopup   : rebaseConflictPopup
+    }
+
     /* Functions
      * ****************************************************************************************/
     function emptyStateDetailsText() {

--- a/Qml/View/Components/Docks/CommitGraphDock.qml
+++ b/Qml/View/Components/Docks/CommitGraphDock.qml
@@ -423,16 +423,6 @@ DetachablePanel {
     MergeMethodPopup { id: mergeMethodPopup }
 
     ConflictPopup {
-        id: rebaseConflictPopup
-        currentOperation        : ConflictPopup.OperationType.Rebase
-        rebaseController        : root.rebaseController
-        conflictController      : root.conflictController
-        notificationController  : root.notificationController
-        statusController        : root.statusController
-        // onOperationCompleted    : reloadAll()        //TODO
-    }
-
-    ConflictPopup {
         id: cherryPickConflictPopup
         currentOperation        : ConflictPopup.OperationType.CherryPick
         cherryPickController    : root.cherryPickController

--- a/Qml/View/Components/Docks/CommitGraphDock.qml
+++ b/Qml/View/Components/Docks/CommitGraphDock.qml
@@ -961,9 +961,19 @@ DetachablePanel {
     }
 
     function executeRebase(commitHash) {
-        var res = rebaseController.rebase(commitHash);
+        var res = rebaseController.previewRebasePlan("", commitHash, "");
 
-        handleGitControllerResult(res, "Rebase completed", rebaseConflictPopup, "Rebase");
+        if (!res || !res.success) {
+            notificationController.error(res ? res.errorMessage : "Could not prepare rebase plan", "Rebase", 5000);
+            return;
+        }
+
+        if (!res.data || !res.data.commits || res.data.commits.length === 0) {
+            notificationController.info("There are no commits to replay for this rebase.", "Rebase", 4000);
+            return;
+        }
+
+        commitPlanPopup.showPlan(res.data);
     }
 
     function executeCherryPickSelected() {

--- a/Qml/View/Components/Docks/FileChangesDock.qml
+++ b/Qml/View/Components/Docks/FileChangesDock.qml
@@ -64,6 +64,7 @@ DetachablePanel {
         anchors.fill: parent
         color: Style.colors.primaryBackground
         visible: root.files && root.files.length > 0
+        clip: true
 
         ColumnLayout {
             anchors.fill: parent

--- a/Qml/View/Components/Docks/RebaseDock.qml
+++ b/Qml/View/Components/Docks/RebaseDock.qml
@@ -20,7 +20,7 @@ UtilitiesCard {
     property CommitController       commitController:       null
     property StatusController       statusController:       null
     property NotificationController notificationController: null
-    property ConflictPopup          conflictPopup:          null
+    property ConflictController     conflictController:     null
 
     /* Object Properties
      * ****************************************************************************************/
@@ -190,7 +190,8 @@ UtilitiesCard {
         statusController: root.statusController
         commitController: root.commitController
         rebaseController: root.rebaseController
-        conflictPopup   : root.conflictPopup
+        conflictController: root.conflictController
+        notificationController: root.notificationController
     }
 
     /* Functions

--- a/Qml/View/Components/Docks/RebaseDock.qml
+++ b/Qml/View/Components/Docks/RebaseDock.qml
@@ -185,6 +185,14 @@ UtilitiesCard {
         id: branchModel
     }
 
+    CommitPlanPopup {
+        id: commitPlanPopup
+        statusController: root.statusController
+        commitController: root.commitController
+        rebaseController: root.rebaseController
+        conflictPopup   : root.conflictPopup
+    }
+
     /* Functions
      * ****************************************************************************************/
 

--- a/Qml/View/Components/Docks/RebaseDock.qml
+++ b/Qml/View/Components/Docks/RebaseDock.qml
@@ -223,55 +223,57 @@ UtilitiesCard {
         }
     }
 
-    // Perform the rebase
-    function startRebase(upstream, onto, advanced, currentIndexBranchCombo) {
-        if (!rebaseController)
+    function previewRebase(upstream, onto, advanced, currentIndexBranchCombo) {
+        if (!validateInputs(upstream, onto, advanced, currentIndexBranchCombo))
             return
 
+        upstream    = upstream.trim()
+        onto        = advanced ? onto.trim() : ""
+
+        var branchValue = currentBranchValue(currentIndexBranchCombo)
+        var res = rebaseController.previewRebasePlan(onto, upstream, branchValue)
+
+        if (!res || !res.success) {
+            notificationController.error(res ? res.errorMessage : "Could not prepare rebase plan", "Rebase", 5000)
+            return
+        }
+
+        if (!res.data || !res.data.commits || res.data.commits.length === 0) {
+            notificationController.info("There are no commits to replay for this rebase.", "Rebase", 4000)
+            return
+        }
+
+        commitPlanPopup.showPlan(res.data)
+    }
+
+    function validateInputs(upstream, onto, advanced, currentIndexBranchCombo) {
         upstream = upstream.trim()
         if (upstream.length === 0) {
-            if (notificationController)
-                notificationController.error("Upstream is required.", "Rebase", 4000)
-            return
+            notificationController.error("Upstream is required.", "Rebase", 4000)
+            return false
         }
 
-        if(!branchModel.count > 0)
-            return
-
-        var branchValue = branchModel.get(currentIndexBranchCombo).value
-
-        var res
-        if (advanced) {
-
-            onto = onto.trim()
-            if (onto.length === 0) {
-                if (notificationController)
-                    notificationController.error("Onto is required in advanced mode.", "Rebase", 4000)
-                return
-            }
-
-            res = rebaseController.rebaseOnto(onto, upstream, branchValue)
-        }
-        else {
-            res = rebaseController.rebase(upstream, branchValue)
+        if (branchModel.count <= 0) {
+            notificationController.error("No local branch is available to rebase.", "Rebase", 4000)
+            return false
         }
 
-        if (res && res.success) {
-            if (notificationController)
-                notificationController.success("Rebase completed successfully", "Rebase", 3000)
-            return
+        if (currentBranchValue(currentIndexBranchCombo).length === 0)
+            return false
+
+        if (advanced && onto.trim().length === 0) {
+            notificationController.error("Onto is required in advanced mode.", "Rebase", 4000)
+            return false
         }
 
-        if (res && res.data && (res.data.status === "conflict" || res.data.hasConflicts)) {
-            if (conflictPopup)
-                conflictPopup.show()
-            if (notificationController)
-                notificationController.warning("Rebase conflicts detected. Please resolve them.", "Rebase", 4000)
-            return
-        }
+        return true
+    }
 
-        if (notificationController)
-            notificationController.error(res?.errorMessage || "Rebase failed", "Rebase", 5000)
+    function currentBranchValue(currentIndexBranchCombo) {
+        if (branchModel.count <= 0 || currentIndexBranchCombo < 0 || currentIndexBranchCombo >= branchModel.count)
+            return ""
+
+        return branchModel.get(currentIndexBranchCombo).value
     }
 
     onBranchControllerChanged: refreshBranches()

--- a/Qml/View/Components/Docks/RebaseDock.qml
+++ b/Qml/View/Components/Docks/RebaseDock.qml
@@ -177,7 +177,7 @@ UtilitiesCard {
                 }
             }
 
-            onClicked: startRebase(upstreamInput.text, ontoInput.text, advancedToggle.checked, branchCombo.currentIndex)
+            onClicked: previewRebase(upstreamInput.text, ontoInput.text, advancedToggle.checked, branchCombo.currentIndex)
         }
     }
 

--- a/Qml/View/Components/Docks/RebaseDock.qml
+++ b/Qml/View/Components/Docks/RebaseDock.qml
@@ -17,6 +17,8 @@ UtilitiesCard {
      * ****************************************************************************************/
     property BranchController       branchController:       null
     property RebaseController       rebaseController:       null
+    property CommitController       commitController:       null
+    property StatusController       statusController:       null
     property NotificationController notificationController: null
     property ConflictPopup          conflictPopup:          null
 

--- a/Qml/View/Popups/CommitPlanPopup.qml
+++ b/Qml/View/Popups/CommitPlanPopup.qml
@@ -649,7 +649,8 @@ IPopup {
                 author      : commit.author     || "",
                 authorDate  : commit.authorDate || "",
                 parentHash  : commit.parentHash || "",
-                isMerge     : commit.isMerge    || false
+                isMerge     : commit.isMerge    || false,
+                status      : commitStatus.pending
             })
         }
 

--- a/Qml/View/Popups/CommitPlanPopup.qml
+++ b/Qml/View/Popups/CommitPlanPopup.qml
@@ -630,4 +630,43 @@ IPopup {
         }
         return result
     }
+
+    function beginRebase() {
+        if (root.currentRebaseState === rebaseState.running)
+            return;
+
+        root.currentRebaseState = rebaseState.running;
+
+        var ops         = operations();
+        ops.reverse();
+
+        var onto        = planData.onto     || "";
+        var upstream    = planData.upstream || "";
+        var branch      = planData.branch   || "";
+
+        rebaseController.startInteractiveRebase(onto, upstream, branch, ops);
+    }
+
+    function setCommitStatus(hash, status) {
+        for (var i = 0; i < commitModel.count; i++) {
+            if (commitModel.get(i).hash === hash) {
+                commitModel.setProperty(i, "status", status);
+                break;
+            }
+        }
+    }
+
+    function scrollToCommit(hash) {
+        var idx = findCommitIndex(hash);
+        if (idx >= 0)
+            commitList.positionViewAtIndex(idx, ListView.Contain);
+    }
+
+    function findCommitIndex(hash) {
+        for (var i = 0; i < commitModel.count; i++)
+            if (commitModel.get(i).hash === hash)
+                return i;
+
+        return -1;
+    }
 }

--- a/Qml/View/Popups/CommitPlanPopup.qml
+++ b/Qml/View/Popups/CommitPlanPopup.qml
@@ -26,19 +26,19 @@ IPopup {
         function colorOf(status){
             switch (status) {
                 case inProgress:
-                    return "#FFA500"
+                    return Style.colors.rebaseStatusInProgress
 
                 case rebased:
-                    return "#2ECC40"
+                    return Style.colors.rebaseStatusRebased
 
                 case conflict:
-                    return "#FF4136"
+                    return Style.colors.rebaseStatusConflict
 
                 case skipped:
-                    return Style.colors.mutedText
+                    return Style.colors.rebaseStatusSkipped
 
                 default:
-                    return Style.colors.mutedText
+                    return Style.colors.rebaseStatusPending
             }
         }
     }

--- a/Qml/View/Popups/CommitPlanPopup.qml
+++ b/Qml/View/Popups/CommitPlanPopup.qml
@@ -111,6 +111,49 @@ IPopup {
                         anchors.fill: parent
                         spacing: 0
 
+                        // Column header
+                        Rectangle {
+                            Layout.fillWidth: true
+                            Layout.preferredHeight: 30
+                            color: Style.colors.primaryBackground
+
+                            RowLayout {
+                                anchors.fill: parent
+                                anchors.leftMargin: 10
+                                anchors.rightMargin: 10
+                                spacing: 8
+
+                                Text {
+                                    text: "Action"
+                                    Layout.preferredWidth: 78
+                                    font.bold: true
+                                    color: Style.colors.foreground
+                                    font.pixelSize: 11
+                                }
+
+                                Text {
+                                    text: "Commit"
+                                    Layout.fillWidth: true
+                                    font.bold: true; color: Style.colors.foreground
+                                    font.pixelSize: 11
+                                }
+
+                                Text {
+                                    text: "Author"
+                                    Layout.preferredWidth: 130
+                                    font.bold: true; color: Style.colors.foreground
+                                    font.pixelSize: 11
+                                }
+
+                                Text {
+                                    text: "Date"
+                                    Layout.preferredWidth: 130
+                                    font.bold: true; color: Style.colors.foreground
+                                    font.pixelSize: 11
+                                }
+                            }
+                        }
+
                         ListView {
                             id: commitList
                             Layout.fillWidth: true
@@ -146,8 +189,7 @@ IPopup {
                                         id: actionCombo
                                         Layout.preferredWidth: 78
                                         Layout.preferredHeight: 26
-                                        model: root.planData.supportedActions
-                                        currentIndex: actionCombo.currentText === "skip" ? 1 : 0
+                                        model: root.planData.supportedActions || []
                                         font.pixelSize: 11
                                         onActivated: commitModel.setProperty(index, "action", currentText)
                                     }

--- a/Qml/View/Popups/CommitPlanPopup.qml
+++ b/Qml/View/Popups/CommitPlanPopup.qml
@@ -31,6 +31,10 @@ IPopup {
     width   : Math.min(1180 , Overlay.overlay   ? Overlay.overlay.width - 80    : 1180)
     height  : Math.min(760  , Overlay.overlay   ? Overlay.overlay.height - 80   : 760)
 
+    modal           : true
+    closePolicy     : Popup.NoAutoClose
+    anchors.centerIn: Overlay.overlay
+
     /* Children
      * ****************************************************************************************/
     contentItem: Rectangle {

--- a/Qml/View/Popups/CommitPlanPopup.qml
+++ b/Qml/View/Popups/CommitPlanPopup.qml
@@ -49,6 +49,49 @@ IPopup {
             anchors.margins: 16
             spacing: 12
 
+            RowLayout {
+                Layout.fillWidth: true
+                spacing: 12
+
+                ColumnLayout {
+                    Layout.fillWidth: true
+                    spacing: 4
+
+                    Text {
+                        text: "Interactive Rebase Plan"
+                        color: Style.colors.foreground
+                        font.family: Style.fontTypes.roboto
+                        font.pixelSize: 18
+                        font.bold: true
+                    }
+
+                    Text {
+                        text: planSummary()
+                        color: Style.colors.mutedText
+                        font.family: Style.fontTypes.roboto
+                        font.pixelSize: 12
+                        elide: Text.ElideRight
+                        Layout.fillWidth: true
+                    }
+                }
+
+                Rectangle {
+                    Layout.preferredWidth: 120
+                    Layout.preferredHeight: 32
+                    color: Style.colors.surfaceMuted
+                    border.color: Style.colors.primaryBorder
+                    radius: 16
+
+                    Text {
+                        anchors.centerIn: parent
+                        text: pickedCount() + " pick / " + skippedCount() + " skip"
+                        color: Style.colors.secondaryText
+                        font.family: Style.fontTypes.roboto
+                        font.pixelSize: 11
+                    }
+                }
+            }
+
             // Main content: vertical split
             SplitView {
                 Layout.fillWidth: true
@@ -226,6 +269,16 @@ IPopup {
         id: commitModel
     }
 
+    function planSummary() {
+        var upstream    = planData.upstream || ""
+        var onto        = planData.onto || ""
+        var branch      = planData.branch || "current branch"
+
+        return onto.length > 0
+               ? branch + " after " + upstream + " onto " + onto
+               : branch + " onto " + upstream
+    }
+
     function pickedCount() {
         var count = 0
         for (var i = 0; i < commitModel.count; i++) {
@@ -233,6 +286,10 @@ IPopup {
                 count++
         }
         return count
+    }
+
+    function skippedCount() {
+        return commitModel.count - pickedCount()
     }
 
     function showPlan(data) {

--- a/Qml/View/Popups/CommitPlanPopup.qml
+++ b/Qml/View/Popups/CommitPlanPopup.qml
@@ -224,8 +224,84 @@ IPopup {
                                         Layout.preferredHeight: 26
                                         model: root.planData.supportedActions || []
                                         font.pixelSize: 11
+
+                                        background: Rectangle {
+                                            color: Style.colors.secondaryBackground
+                                            border.color: Style.colors.primaryBorder
+                                            border.width: 1
+                                            radius: 4
+                                        }
+
+                                        contentItem: Text {
+                                            text: actionCombo.displayText
+                                            color: Style.colors.foreground
+                                            font.pixelSize: 11
+                                            verticalAlignment: Text.AlignVCenter
+                                            leftPadding: 8
+                                            rightPadding: actionCombo.indicator.width + 8
+                                            elide: Text.ElideRight
+                                        }
+
+                                        indicator: Canvas {
+                                            id: comboIndicator
+                                            x: actionCombo.width - width - 8
+                                            y: (actionCombo.height - height) / 2
+                                            width: 10
+                                            height: 6
+                                            contextType: "2d"
+
+                                            onPaint: {
+                                                context.reset()
+                                                context.moveTo(0, 0)
+                                                context.lineTo(width, 0)
+                                                context.lineTo(width / 2, height)
+                                                context.closePath()
+                                                context.fillStyle = Style.colors.foreground
+                                                context.fill()
+                                            }
+                                        }
+
+                                        popup: Popup {
+                                            y: actionCombo.height
+                                            width: actionCombo.width
+                                            implicitHeight: contentItem.implicitHeight
+                                            padding: 1
+
+                                            contentItem: ListView {
+                                                clip: true
+                                                implicitHeight: contentHeight
+                                                model: actionCombo.popup.visible ? actionCombo.delegateModel : null
+                                                currentIndex: actionCombo.highlightedIndex
+                                            }
+
+                                            background: Rectangle {
+                                                color: Style.colors.secondaryBackground
+                                                border.color: Style.colors.primaryBorder
+                                                border.width: 1
+                                                radius: 4
+                                            }
+                                        }
+
+                                        delegate: ItemDelegate {
+                                            width: actionCombo.width
+                                            contentItem: Text {
+                                                text: modelData
+                                                color: Style.colors.foreground
+                                                font.pixelSize: 11
+                                                verticalAlignment: Text.AlignVCenter
+                                                elide: Text.ElideRight
+                                            }
+
+                                            background: Rectangle {
+                                                color: highlighted
+                                                       ? Style.colors.hoverTitle
+                                                       : Style.colors.secondaryBackground
+                                            }
+                                        }
+
                                         onActivated: commitModel.setProperty(index, "action", currentText)
                                     }
+
 
                                     // Commit info (short hash + message)
                                     RowLayout {

--- a/Qml/View/Popups/CommitPlanPopup.qml
+++ b/Qml/View/Popups/CommitPlanPopup.qml
@@ -580,6 +580,32 @@ IPopup {
         }
     }
 
+    Connections {
+        target: root.conflictPopup
+
+        function onInteractiveActionRequested(action) {
+            switch (action) {
+
+            case ConflictPopup.InteractiveAction.Continue:
+                root.rebaseController.interactiveContinue()
+                break
+
+            case ConflictPopup.InteractiveAction.Skip:
+                root.rebaseController.interactiveSkip()
+                break
+
+            case ConflictPopup.InteractiveAction.Abort:
+                root.rebaseController.interactiveAbort()
+                break
+
+            default:
+                return
+            }
+
+            root.conflictPopup.close()
+        }
+    }
+
     function planSummary() {
         var upstream    = planData.upstream || ""
         var onto        = planData.onto || ""

--- a/Qml/View/Popups/CommitPlanPopup.qml
+++ b/Qml/View/Popups/CommitPlanPopup.qml
@@ -43,6 +43,15 @@ IPopup {
         }
     }
 
+    QtObject {
+        id: rebaseState
+
+        readonly property string idle      : "Start Rebase"
+        readonly property string running   : "Rebasing..."
+        readonly property string completed : "Close"
+        readonly property string failed    : "Start Rebase"
+    }
+
     /* Property Declarations
      * ****************************************************************************************/
     property StatusController statusController: null

--- a/Qml/View/Popups/CommitPlanPopup.qml
+++ b/Qml/View/Popups/CommitPlanPopup.qml
@@ -423,7 +423,13 @@ IPopup {
                         border.color: Style.colors.accent
                         radius: 6
                     }
-                    onClicked: root.close()
+
+                    MouseArea {
+                        anchors.fill: parent
+                        cursorShape: Qt.PointingHandCursor
+
+                        onClicked: root.close()
+                    }
                 }
 
                 Button {
@@ -439,9 +445,15 @@ IPopup {
                                : Style.colors.disabledButton
                         radius: 6
                     }
-                    onClicked: {
-                        root.accepted(root.operations())
-                        root.close()
+
+                    MouseArea {
+                        anchors.fill: parent
+                        cursorShape: Qt.PointingHandCursor
+
+                        onClicked: {
+                            root.accepted(root.operations())
+                            root.close()
+                        }
                     }
                 }
             }

--- a/Qml/View/Popups/CommitPlanPopup.qml
+++ b/Qml/View/Popups/CommitPlanPopup.qml
@@ -250,21 +250,8 @@ IPopup {
                                     anchors.rightMargin: 8
                                     spacing: 8
 
-                                    readonly property color actionColor: {
-                                        const a = actionCombo.currentText
-                                        switch (a){
-                                            case "pick":
-                                                return Style.colors.foreground
-
-                                            case "skip":
-                                                return Style.colors.mutedText
-
-                                            default:
-                                                return Style.colors.accent
-                                        }
-                                    }
-
-                                    readonly property bool isDimmed: actionCombo.currentText === "skip"
+                                    readonly property bool isDimmed     : action === actionType.skip
+                                    readonly property color actionColor : actionType.colorOf(action)
 
                                     // Action combo (pick / skip)
                                     ComboBox {

--- a/Qml/View/Popups/CommitPlanPopup.qml
+++ b/Qml/View/Popups/CommitPlanPopup.qml
@@ -98,6 +98,22 @@ IPopup {
                 Layout.fillHeight: true
                 orientation: Qt.Vertical
 
+                handle: Rectangle {
+                    implicitWidth: 6
+                    implicitHeight: 6
+                    color: SplitHandle.pressed ? Style.colors.resizeHandlePressed
+                         : SplitHandle.hovered ? Style.colors.resizeHandle
+                         : "transparent"
+
+                    Rectangle {
+                        anchors.centerIn: parent
+                        width: parent.width
+                        height: 2
+                        radius: 1
+                        color: SplitHandle.pressed ? Style.colors.accent : Style.colors.primaryBorder
+                    }
+                }
+
                 // Top: commit list (full width)
                 Rectangle {
                     SplitView.preferredHeight: 300
@@ -265,6 +281,22 @@ IPopup {
                 // Bottom: file changes + diff view side‑by‑side
                 SplitView {
                     orientation: Qt.Horizontal
+
+                    handle: Rectangle {
+                        implicitWidth: 6
+                        implicitHeight: 6
+                        color: SplitHandle.pressed ? Style.colors.resizeHandlePressed
+                             : SplitHandle.hovered ? Style.colors.resizeHandle
+                             : "transparent"
+
+                        Rectangle {
+                            anchors.centerIn: parent
+                            width: 2
+                            height: parent.height
+                            radius: 1
+                            color: SplitHandle.pressed ? Style.colors.accent : Style.colors.primaryBorder
+                        }
+                    }
 
                     FileChangesDock {
                         id: fileChangesDock

--- a/Qml/View/Popups/CommitPlanPopup.qml
+++ b/Qml/View/Popups/CommitPlanPopup.qml
@@ -284,6 +284,7 @@ IPopup {
 
                                         delegate: ItemDelegate {
                                             width: actionCombo.width
+                                            hoverEnabled: true
                                             contentItem: Text {
                                                 text: modelData
                                                 color: Style.colors.foreground
@@ -293,7 +294,7 @@ IPopup {
                                             }
 
                                             background: Rectangle {
-                                                color: highlighted
+                                                color: hovered
                                                        ? Style.colors.hoverTitle
                                                        : Style.colors.secondaryBackground
                                             }

--- a/Qml/View/Popups/CommitPlanPopup.qml
+++ b/Qml/View/Popups/CommitPlanPopup.qml
@@ -74,11 +74,16 @@ IPopup {
 
     /* Property Declarations
      * ****************************************************************************************/
-    property StatusController statusController: null
-    property CommitController commitController: null
+    property StatusController   statusController: null
+    property CommitController   commitController: null
+    property RebaseController   rebaseController: null
+    property ConflictPopup      conflictPopup   : null
+
 
     property var    planData            : ({})
     property string selectedCommitHash  : ""
+
+    property string currentRebaseState  : rebaseState.idle
 
     /* Signals
      * ****************************************************************************************/

--- a/Qml/View/Popups/CommitPlanPopup.qml
+++ b/Qml/View/Popups/CommitPlanPopup.qml
@@ -14,6 +14,35 @@ import GitEase_Style_Impl
 IPopup {
     id: root
 
+    QtObject {
+        id: commitStatus
+
+        readonly property string pending   : "Pending"
+        readonly property string inProgress: "In Progress"
+        readonly property string rebased   : "Rebased"
+        readonly property string skipped   : "Skipped"
+        readonly property string conflict  : "Conflict"
+
+        function colorOf(status){
+            switch (status) {
+                case inProgress:
+                    return "#FFA500"
+
+                case rebased:
+                    return "#2ECC40"
+
+                case conflict:
+                    return "#FF4136"
+
+                case skipped:
+                    return Style.colors.mutedText
+
+                default:
+                    return Style.colors.mutedText
+            }
+        }
+    }
+
     /* Property Declarations
      * ****************************************************************************************/
     property StatusController statusController: null

--- a/Qml/View/Popups/CommitPlanPopup.qml
+++ b/Qml/View/Popups/CommitPlanPopup.qml
@@ -179,10 +179,27 @@ IPopup {
                                 }
 
                                 RowLayout {
+                                    id: layout
                                     anchors.fill: parent
                                     anchors.leftMargin: 8
                                     anchors.rightMargin: 8
                                     spacing: 8
+
+                                    readonly property color actionColor: {
+                                        const a = actionCombo.currentText
+                                        switch (a){
+                                            case "pick":
+                                                return Style.colors.foreground
+
+                                            case "skip":
+                                                return Style.colors.mutedText
+
+                                            default:
+                                                return Style.colors.accent
+                                        }
+                                    }
+
+                                    readonly property bool isDimmed: actionCombo.currentText === "skip"
 
                                     // Action combo (pick / skip)
                                     ComboBox {
@@ -201,7 +218,7 @@ IPopup {
 
                                         Text {
                                             text: shortHash
-                                            color: actionCombo.currentText === "skip" ? Style.colors.mutedText : Style.colors.accent
+                                            color: Style.colors.accent
                                             font.family: Style.fontTypes.roboto
                                             font.pixelSize: 11
                                             Layout.alignment: Qt.AlignVCenter
@@ -209,7 +226,8 @@ IPopup {
 
                                         Text {
                                             text: summary
-                                            color: actionCombo.currentText === "skip" ? Style.colors.mutedText : Style.colors.foreground
+                                            color: layout.actionColor
+                                            opacity: layout.isDimmed ? 0.5 : 1.0
                                             font.pixelSize: 12
                                             elide: Text.ElideRight
                                             Layout.fillWidth: true
@@ -220,7 +238,8 @@ IPopup {
                                     // Author
                                     Text {
                                         text: author
-                                        color: actionCombo.currentText === "skip" ? Style.colors.mutedText : Style.colors.foreground
+                                        color: layout.actionColor
+                                        opacity: layout.isDimmed ? 0.5 : 1.0
                                         font.pixelSize: 11
                                         elide: Text.ElideRight
                                         Layout.preferredWidth: 130
@@ -230,7 +249,8 @@ IPopup {
                                     // Date
                                     Text {
                                         text: authorDate ? Qt.formatDateTime(new Date(authorDate), "yyyy-MM-dd hh:mm") : ""
-                                        color: actionCombo.currentText === "skip" ? Style.colors.mutedText : Style.colors.secondaryText
+                                        color: layout.actionColor
+                                        opacity: layout.isDimmed ? 0.5 : 1.0
                                         font.pixelSize: 10
                                         elide: Text.ElideRight
                                         Layout.preferredWidth: 130

--- a/Qml/View/Popups/CommitPlanPopup.qml
+++ b/Qml/View/Popups/CommitPlanPopup.qml
@@ -537,6 +537,49 @@ IPopup {
         id: commitModel
     }
 
+    Connections {
+        target: root.rebaseController
+
+        function onRebaseOperationStarted(hash) {
+            setCommitStatus(hash, commitStatus.inProgress);
+
+            scrollToCommit(hash);
+
+            var idx = findCommitIndex(hash);
+            if (idx >= 0)
+                commitList.currentIndex = idx;
+        }
+
+        function onRebaseOperationCompleted(hash) {
+            setCommitStatus(hash, commitStatus.rebased);
+        }
+
+        function onRebaseOperationSkipped(hash) {
+            setCommitStatus(hash, commitStatus.skipped);
+        }
+
+        function onRebaseConflict(hash) {
+            setCommitStatus(hash, commitStatus.conflict);
+
+            scrollToCommit(hash);
+
+            root.conflictPopup.interactiveMode  = true;
+            root.conflictPopup.currentOperation = ConflictPopup.OperationType.Rebase;
+            root.conflictPopup.show();
+        }
+
+        function onRebaseFinished(success) {
+            root.currentRebaseState = success ? rebaseState.completed : rebaseState.failed;
+        }
+
+        function onRebaseAborted() {
+            root.currentRebaseState = rebaseState.idle;
+
+            for (var i = 0; i < commitModel.count; i++)
+                commitModel.setProperty(i, "status", commitStatus.pending);
+        }
+    }
+
     function planSummary() {
         var upstream    = planData.upstream || ""
         var onto        = planData.onto || ""

--- a/Qml/View/Popups/CommitPlanPopup.qml
+++ b/Qml/View/Popups/CommitPlanPopup.qml
@@ -75,20 +75,11 @@ IPopup {
                     }
                 }
 
-                Rectangle {
-                    Layout.preferredWidth: 120
-                    Layout.preferredHeight: 32
-                    color: Style.colors.surfaceMuted
-                    border.color: Style.colors.primaryBorder
-                    radius: 16
-
-                    Text {
-                        anchors.centerIn: parent
-                        text: pickedCount() + " pick / " + skippedCount() + " skip"
-                        color: Style.colors.secondaryText
-                        font.family: Style.fontTypes.roboto
-                        font.pixelSize: 11
-                    }
+                Text {
+                    text: pickedCount() + " pick / " + skippedCount() + " skip"
+                    color: Style.colors.secondaryText
+                    font.family: Style.fontTypes.roboto
+                    font.pixelSize: 11
                 }
             }
 

--- a/Qml/View/Popups/CommitPlanPopup.qml
+++ b/Qml/View/Popups/CommitPlanPopup.qml
@@ -52,6 +52,26 @@ IPopup {
         readonly property string failed    : "Start Rebase"
     }
 
+    QtObject {
+        id: actionType
+
+        readonly property string pick: "pick"
+        readonly property string skip: "skip"
+
+        function colorOf(action) {
+            switch (action) {
+            case pick:
+                return Style.colors.foreground
+
+            case skip:
+                return Style.colors.mutedText
+
+            default:
+                return Style.colors.accent
+            }
+        }
+    }
+
     /* Property Declarations
      * ****************************************************************************************/
     property StatusController statusController: null

--- a/Qml/View/Popups/CommitPlanPopup.qml
+++ b/Qml/View/Popups/CommitPlanPopup.qml
@@ -77,7 +77,8 @@ IPopup {
     property StatusController   statusController: null
     property CommitController   commitController: null
     property RebaseController   rebaseController: null
-    property ConflictPopup      conflictPopup   : null
+    property ConflictController conflictController: null
+    property NotificationController notificationController: null
 
 
     property var    planData            : ({})
@@ -544,6 +545,17 @@ IPopup {
         id: commitModel
     }
 
+    ConflictPopup {
+        id : rebaseConflictPopup
+
+        currentOperation: ConflictPopup.OperationType.Rebase
+
+        rebaseController        : root.rebaseController
+        conflictController      : root.conflictController
+        notificationController  : root.notificationController
+        statusController        : root.statusController
+    }
+
     Connections {
         target: root.rebaseController
 
@@ -570,9 +582,8 @@ IPopup {
 
             scrollToCommit(hash);
 
-            root.conflictPopup.interactiveMode  = true;
-            root.conflictPopup.currentOperation = ConflictPopup.OperationType.Rebase;
-            root.conflictPopup.show();
+            rebaseConflictPopup.interactiveMode  = true;
+            rebaseConflictPopup.show();
         }
 
         function onRebaseFinished(success) {
@@ -588,7 +599,7 @@ IPopup {
     }
 
     Connections {
-        target: root.conflictPopup
+        target: rebaseConflictPopup
 
         function onInteractiveActionRequested(action) {
             switch (action) {
@@ -609,7 +620,7 @@ IPopup {
                 return
             }
 
-            root.conflictPopup.close()
+            rebaseConflictPopup.close()
         }
     }
 

--- a/Qml/View/Popups/CommitPlanPopup.qml
+++ b/Qml/View/Popups/CommitPlanPopup.qml
@@ -273,6 +273,7 @@ IPopup {
                                         Layout.preferredHeight: 26
                                         model: root.planData.supportedActions || []
                                         font.pixelSize: 11
+                                        enabled: root.currentRebaseState !== rebaseState.running
 
                                         background: Rectangle {
                                             color: Style.colors.secondaryBackground
@@ -355,7 +356,13 @@ IPopup {
                                             }
                                         }
 
-                                        onActivated: commitModel.setProperty(index, "action", currentText)
+                                        Component.onCompleted: {
+                                            currentIndex = model.indexOf(commitModel.get(index).action)
+                                        }
+
+                                        onActivated: function(i) {
+                                            commitModel.setProperty(index, "action", model[i])
+                                        }
 
                                         MouseArea {
                                             anchors.fill: parent

--- a/Qml/View/Popups/CommitPlanPopup.qml
+++ b/Qml/View/Popups/CommitPlanPopup.qml
@@ -721,7 +721,11 @@ IPopup {
         var upstream    = planData.upstream || "";
         var branch      = planData.branch   || "";
 
-        rebaseController.startInteractiveRebase(onto, upstream, branch, ops);
+        var res = rebaseController.startInteractiveRebase(onto, upstream, branch, ops);
+        if (!res.success) {
+            root.currentRebaseState = rebaseState.failed;
+            notificationController.error(res.errorMessage || "Rebased failed", "Rebase", 5000);
+        }
     }
 
     function setCommitStatus(hash, status) {

--- a/Qml/View/Popups/CommitPlanPopup.qml
+++ b/Qml/View/Popups/CommitPlanPopup.qml
@@ -298,9 +298,21 @@ IPopup {
                                                        ? Style.colors.hoverTitle
                                                        : Style.colors.secondaryBackground
                                             }
+
+                                            MouseArea {
+                                                anchors.fill: parent
+                                                cursorShape: Qt.PointingHandCursor
+                                                acceptedButtons: Qt.NoButton
+                                            }
                                         }
 
                                         onActivated: commitModel.setProperty(index, "action", currentText)
+
+                                        MouseArea {
+                                            anchors.fill: parent
+                                            cursorShape: Qt.PointingHandCursor
+                                            acceptedButtons: Qt.NoButton
+                                        }
                                     }
 
 

--- a/Qml/View/Popups/CommitPlanPopup.qml
+++ b/Qml/View/Popups/CommitPlanPopup.qml
@@ -487,15 +487,20 @@ IPopup {
                         anchors.fill: parent
                         cursorShape: Qt.PointingHandCursor
 
-                        onClicked: root.close()
+                        onClicked: {
+                            root.rebaseController.interactiveAbort()
+                            root.close()
+                        }
                     }
                 }
 
                 Button {
                     id: startButton
-                    text: "Start Rebase"
+                    text: root.currentRebaseState
                     Layout.preferredWidth: 130
-                    enabled: commitModel.count > 0 && pickedCount() > 0
+                    enabled: commitModel.count > 0  &&
+                             root.currentRebaseState !== rebaseState.running
+
                     Material.foreground: Style.colors.textButton
                     background: Rectangle {
                         implicitHeight: 34
@@ -507,11 +512,20 @@ IPopup {
 
                     MouseArea {
                         anchors.fill: parent
-                        cursorShape: Qt.PointingHandCursor
+                        cursorShape: startButton.enabled ? Qt.PointingHandCursor : Qt.ForbiddenCursor
 
                         onClicked: {
-                            root.accepted(root.operations())
-                            root.close()
+                            if (root.currentRebaseState === rebaseState.completed) {
+                                root.close();
+
+                            }
+                            else if (root.currentRebaseState === rebaseState.idle || root.currentRebaseState === rebaseState.failed) {
+                                if (root.currentRebaseState === rebaseState.failed) {
+                                    for (var i = 0; i < commitModel.count; i++)
+                                        commitModel.setProperty(i, "status", commitStatus.pending);
+                                }
+                                beginRebase();
+                            }
                         }
                     }
                 }

--- a/Qml/View/Popups/CommitPlanPopup.qml
+++ b/Qml/View/Popups/CommitPlanPopup.qml
@@ -221,6 +221,14 @@ IPopup {
                                     font.bold: true; color: Style.colors.foreground
                                     font.pixelSize: 11
                                 }
+
+                                Text {
+                                    text: (root.currentRebaseState !== rebaseState.idle) ? "Status" : ""
+                                    Layout.preferredWidth: (root.currentRebaseState !== rebaseState.idle) ? 80 : 0
+                                    font.bold: true
+                                    color: Style.colors.foreground
+                                    font.pixelSize: 11
+                                }
                             }
                         }
 
@@ -400,6 +408,16 @@ IPopup {
                                         font.pixelSize: 10
                                         elide: Text.ElideRight
                                         Layout.preferredWidth: 130
+                                        Layout.alignment: Qt.AlignVCenter
+                                    }
+
+                                    Text {
+                                        text: status
+                                        color: commitStatus.colorOf(status)
+                                        font.pixelSize: 10
+                                        elide: Text.ElideRight
+                                        Layout.preferredWidth: (root.currentRebaseState !== rebaseState.idle) ? 80 : 0
+                                        visible: root.currentRebaseState !== rebaseState.idle
                                         Layout.alignment: Qt.AlignVCenter
                                     }
                                 }

--- a/Qml/View/Popups/CommitPlanPopup.qml
+++ b/Qml/View/Popups/CommitPlanPopup.qml
@@ -1,0 +1,304 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+import GitEase
+import GitEase_Style
+import GitEase_Style_Impl
+
+/*! ***********************************************************************************************
+ * CommitPlanPopup
+ * Shows a previewable commits todo list with commit file changes and diff view.
+ * ************************************************************************************************/
+
+IPopup {
+    id: root
+
+    /* Property Declarations
+     * ****************************************************************************************/
+    property StatusController statusController: null
+    property CommitController commitController: null
+
+    property var    planData            : ({})
+    property string selectedCommitHash  : ""
+
+    /* Signals
+     * ****************************************************************************************/
+    signal accepted(var operations)
+
+    /* Object Properties
+     * ****************************************************************************************/
+    width   : Math.min(1180 , Overlay.overlay   ? Overlay.overlay.width - 80    : 1180)
+    height  : Math.min(760  , Overlay.overlay   ? Overlay.overlay.height - 80   : 760)
+
+    /* Children
+     * ****************************************************************************************/
+    contentItem: Rectangle {
+        color: Style.colors.primaryBackground
+        radius: 12
+        clip: true
+        border.color: Style.colors.primaryBorder
+        border.width: 1
+
+        ColumnLayout {
+            anchors.fill: parent
+            anchors.margins: 16
+            spacing: 12
+
+            // Main content: vertical split
+            SplitView {
+                Layout.fillWidth: true
+                Layout.fillHeight: true
+                orientation: Qt.Vertical
+
+                // Top: commit list (full width)
+                Rectangle {
+                    SplitView.preferredHeight: 300
+                    SplitView.minimumHeight: 150
+                    color: Style.colors.secondaryBackground
+                    border.color: Style.colors.primaryBorder
+                    radius: 8
+                    clip: true
+
+                    ColumnLayout {
+                        anchors.fill: parent
+                        spacing: 0
+
+                        ListView {
+                            id: commitList
+                            Layout.fillWidth: true
+                            Layout.fillHeight: true
+                            clip: true
+                            model: commitModel
+                            currentIndex: commitModel.count > 0 ? 0 : -1
+
+                            delegate: Rectangle {
+                                width: ListView.view.width
+                                height: 32
+                                color: ListView.isCurrentItem ? Qt.rgba(0.533, 0.694, 0.875, 0.38)
+                                      : commitMouse.containsMouse ? Style.colors.hoverTitle
+                                      : Style.colors.secondaryBackground
+
+                                MouseArea {
+                                    id: commitMouse
+                                    anchors.fill: parent
+                                    hoverEnabled: true
+                                    acceptedButtons: Qt.LeftButton
+                                    onClicked: selectCommit(index)
+                                    cursorShape: Qt.PointingHandCursor
+                                }
+
+                                RowLayout {
+                                    anchors.fill: parent
+                                    anchors.leftMargin: 8
+                                    anchors.rightMargin: 8
+                                    spacing: 8
+
+                                    // Action combo (pick / skip)
+                                    ComboBox {
+                                        id: actionCombo
+                                        Layout.preferredWidth: 78
+                                        Layout.preferredHeight: 26
+                                        model: root.planData.supportedActions
+                                        currentIndex: actionCombo.currentText === "skip" ? 1 : 0
+                                        font.pixelSize: 11
+                                        onActivated: commitModel.setProperty(index, "action", currentText)
+                                    }
+
+                                    // Commit info (short hash + message)
+                                    RowLayout {
+                                        Layout.fillWidth: true
+                                        spacing: 6
+
+                                        Text {
+                                            text: shortHash
+                                            color: actionCombo.currentText === "skip" ? Style.colors.mutedText : Style.colors.accent
+                                            font.family: Style.fontTypes.roboto
+                                            font.pixelSize: 11
+                                            Layout.alignment: Qt.AlignVCenter
+                                        }
+
+                                        Text {
+                                            text: summary
+                                            color: actionCombo.currentText === "skip" ? Style.colors.mutedText : Style.colors.foreground
+                                            font.pixelSize: 12
+                                            elide: Text.ElideRight
+                                            Layout.fillWidth: true
+                                            Layout.alignment: Qt.AlignVCenter
+                                        }
+                                    }
+
+                                    // Author
+                                    Text {
+                                        text: author
+                                        color: actionCombo.currentText === "skip" ? Style.colors.mutedText : Style.colors.foreground
+                                        font.pixelSize: 11
+                                        elide: Text.ElideRight
+                                        Layout.preferredWidth: 130
+                                        Layout.alignment: Qt.AlignVCenter
+                                    }
+
+                                    // Date
+                                    Text {
+                                        text: authorDate ? Qt.formatDateTime(new Date(authorDate), "yyyy-MM-dd hh:mm") : ""
+                                        color: actionCombo.currentText === "skip" ? Style.colors.mutedText : Style.colors.secondaryText
+                                        font.pixelSize: 10
+                                        elide: Text.ElideRight
+                                        Layout.preferredWidth: 130
+                                        Layout.alignment: Qt.AlignVCenter
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+
+                // Bottom: file changes + diff view side‑by‑side
+                SplitView {
+                    orientation: Qt.Horizontal
+
+                    FileChangesDock {
+                        id: fileChangesDock
+
+                        SplitView.preferredWidth: 500
+
+                        statusController: root.statusController
+
+                        onFileSelected: function(filePath) { root.loadDiff(filePath) }
+                    }
+
+                    DiffView {
+                        id: diffView
+                        readOnly: true
+                    }
+                }
+            }
+
+            // Bottom action bar
+            RowLayout {
+                Layout.fillWidth: true
+                spacing: 10
+
+                Item {
+                    Layout.fillWidth: true
+                }
+
+                Button {
+                    text: "Cancel"
+                    flat: true
+                    Layout.preferredWidth: 100
+                    Material.foreground: hovered ? Style.colors.secondaryForeground : Style.colors.foreground
+                    background: Rectangle {
+                        color: parent.hovered ? Style.colors.accent : Style.colors.secondaryBackground
+                        border.color: Style.colors.accent
+                        radius: 6
+                    }
+                    onClicked: root.close()
+                }
+
+                Button {
+                    id: startButton
+                    text: "Start Rebase"
+                    Layout.preferredWidth: 130
+                    enabled: commitModel.count > 0 && pickedCount() > 0
+                    Material.foreground: Style.colors.textButton
+                    background: Rectangle {
+                        implicitHeight: 34
+                        color: startButton.enabled
+                               ? (startButton.hovered ? Style.colors.accentHover : Style.colors.accent)
+                               : Style.colors.disabledButton
+                        radius: 6
+                    }
+                    onClicked: {
+                        root.accepted(root.operations())
+                        root.close()
+                    }
+                }
+            }
+        }
+    }
+
+    ListModel {
+        id: commitModel
+    }
+
+    function pickedCount() {
+        var count = 0
+        for (var i = 0; i < commitModel.count; i++) {
+            if (commitModel.get(i).action !== "skip")
+                count++
+        }
+        return count
+    }
+
+    function showPlan(data) {
+        commitModel.clear()
+
+        root.planData           = data || {}
+        diffView.diffData       = null
+        fileChangesDock.files   = []
+        root.selectedCommitHash = ""
+
+        var commits = root.planData.commits || []
+        for (var i = 0; i < commits.length; i++) {
+            var commit = commits[i]
+            commitModel.append({
+                action      : commit.action     || "pick",
+                hash        : commit.hash       || "",
+                shortHash   : commit.shortHash  || "",
+                summary     : commit.summary    || "",
+                message     : commit.message    || "",
+                author      : commit.author     || "",
+                authorDate  : commit.authorDate || "",
+                parentHash  : commit.parentHash || "",
+                isMerge     : commit.isMerge    || false
+            })
+        }
+
+        if (commitModel.count > 0)
+            selectCommit(0)
+
+        root.open()
+    }
+
+    function selectCommit(index) {
+        if (index < 0 || index >= commitModel.count)
+            return
+
+        commitList.currentIndex     = index
+        var commit                  = commitModel.get(index)
+        root.selectedCommitHash     = commit.hash
+        diffView.diffData           = null
+        fileChangesDock.commitHash  = commit.hash
+    }
+
+    function loadDiff(filePath) {
+        if (!root.selectedCommitHash || !filePath)
+            return
+
+        var parentHash = root.commitController.getParentHash(root.selectedCommitHash)
+        var selected = commitModel.get(commitList.currentIndex)
+        if (!parentHash && selected && selected.parentHash)
+            parentHash = selected.parentHash
+
+        if (!parentHash)
+            return
+
+        var diffRes = root.statusController.getDiff(parentHash, root.selectedCommitHash, filePath)
+        if (diffRes && diffRes.success)
+            diffView.diffData = diffRes.data
+    }
+
+    function operations() {
+        var result = []
+        for (var i = 0; i < commitModel.count; i++) {
+            var commit = commitModel.get(i)
+            result.push({
+                action  : commit.action,
+                hash    : commit.hash,
+                summary : commit.summary
+            })
+        }
+        return result
+    }
+}

--- a/Qml/View/Popups/ConflictPopup.qml
+++ b/Qml/View/Popups/ConflictPopup.qml
@@ -15,6 +15,13 @@ import "qrc:/GitEase/Qml/Core/Scripts/ConflictPopupUtils.js" as ConflictUtils
 Window {
     id: root
 
+    enum InteractiveAction {
+        None,
+        Continue,
+        Skip,
+        Abort
+    }
+
     /* Property Declarations
      * ****************************************************************************************/
     property MergeController        mergeController         : null

--- a/Qml/View/Popups/ConflictPopup.qml
+++ b/Qml/View/Popups/ConflictPopup.qml
@@ -68,9 +68,12 @@ Window {
         }
     }
 
+    property bool interactiveMode: false
+
     /* Signals
      * ****************************************************************************************/
     signal operationCompleted();
+    signal interactiveActionRequested(int action)
 
     /* Object Properties
      * ****************************************************************************************/

--- a/Qml/View/Popups/ConflictPopup.qml
+++ b/Qml/View/Popups/ConflictPopup.qml
@@ -547,6 +547,11 @@ Window {
     }
 
     function continueOperation() {
+        if (interactiveMode) {
+            interactiveActionRequested(ConflictPopup.InteractiveAction.Continue);
+            return;
+        }
+
         let res = currentController.continueOp()
 
         if (res.success) {
@@ -570,6 +575,11 @@ Window {
     }
 
     function skipOperation() {
+        if (interactiveMode) {
+            interactiveActionRequested(ConflictPopup.InteractiveAction.Skip);
+            return;
+        }
+
         let res = currentController.skipOp()
 
         if (res.success) {
@@ -593,6 +603,11 @@ Window {
     }
 
     function abortOperation() {
+        if (interactiveMode) {
+            interactiveActionRequested(ConflictPopup.InteractiveAction.Abort);
+            return;
+        }
+
         let res = currentController.abortOp()
 
         if (res.success) {

--- a/Qml/View/Popups/ConflictPopup.qml
+++ b/Qml/View/Popups/ConflictPopup.qml
@@ -77,15 +77,29 @@ Window {
 
     /* Object Properties
      * ****************************************************************************************/
+    modality: Qt.ApplicationModal
+    color: "transparent"
+
     width: 800
     height: 650
 
-    modality: Qt.ApplicationModal
-    color: "transparent"
+    onWidthChanged: {
+        if (visible && width != 800)
+            width = 800
+    }
+    onHeightChanged: {
+        if (visible && height != 650)
+            height = 650
+    }
 
     onVisibleChanged: {
         if(!visible)
             return
+
+        Qt.callLater(function() {
+            x = (Screen.width - width) / 2
+            y = (Screen.height - height) / 2
+        })
 
         if (!notificationController) {
             console.error("ConflictPopup: missing required controllers")

--- a/Resources.cmake
+++ b/Resources.cmake
@@ -197,6 +197,8 @@ set(RESOURCES_POPUPS
     Qml/View/Popups/AddTagPopup.qml
     Qml/View/Popups/CalendarPopup.qml
 
+    Qml/View/Popups/CommitPlanPopup.qml
+
 )
 
 

--- a/Src/Git/GitRebase.cpp
+++ b/Src/Git/GitRebase.cpp
@@ -79,7 +79,7 @@ GitResult GitRebase::previewRebasePlan(const QString& onto,
                          QString("Failed to prepare rebase plan: %1").arg(GitUtils::getLastError()));
     }
 
-    git_revwalk_sorting(walk, GIT_SORT_TOPOLOGICAL | GIT_SORT_TIME);
+    git_revwalk_sorting(walk, GIT_SORT_TOPOLOGICAL | GIT_SORT_REVERSE);
     git_revwalk_push(walk, git_object_id(branchObject));
     git_revwalk_hide(walk, git_object_id(upstreamObject));
 
@@ -123,7 +123,7 @@ GitResult GitRebase::previewRebasePlan(const QString& onto,
         item["parentHash"]      = parentHashes.isEmpty() ? QString() : parentHashes.first();
         item["isMerge"]         = parentCount > 1;
 
-        commits.prepend(item);
+        commits.append(item);
         git_commit_free(commit);
     }
 

--- a/Src/Git/GitRebase.cpp
+++ b/Src/Git/GitRebase.cpp
@@ -11,6 +11,7 @@
 #include <git2/revparse.h>
 #include <git2/revwalk.h>
 #include <git2/signature.h>
+#include <git2/reset.h>
 
 #include <QVariantList>
 #include <git2/branch.h>
@@ -1107,7 +1108,7 @@ void GitRebase::interactiveContinue()
         return;
     }
 
-    git_repository_state_cleanup(m_currentRepo->repo)
+    git_repository_state_cleanup(m_currentRepo->repo);
 
     git_commit_free(originalCommit);
     emit rebaseOperationCompleted(m_currentOpHash);
@@ -1131,45 +1132,41 @@ void GitRebase::interactiveSkip()
 
 void GitRebase::interactiveAbort()
 {
-    if (!m_interactiveInProgress)
+    if (!m_interactiveInProgress || !m_currentRepo || !m_currentRepo->repo)
         return;
 
-    // If we were mid‑cherry‑pick, abort it first
     if (m_isCherryPickActive) {
         abortCherryPick();
-    }
-    else if (m_currentRepo && m_currentRepo->repo) {
+    } else {
         git_repository_state_cleanup(m_currentRepo->repo);
     }
 
-    // Reset to the original HEAD
+    git_object* targetObj = nullptr;
+
     if (m_originalHeadRef) {
-        git_object* target = nullptr;
-        if (git_reference_peel(&target, m_originalHeadRef, GIT_OBJ_COMMIT) == GIT_OK) {
-            git_checkout_options opts = GIT_CHECKOUT_OPTIONS_INIT;
-            opts.checkout_strategy = GIT_CHECKOUT_SAFE | GIT_CHECKOUT_RECREATE_MISSING;
-
-            git_checkout_tree(m_currentRepo->repo, target, &opts);
-
-            git_repository_set_head(m_currentRepo->repo, git_reference_name(m_originalHeadRef));
-
-            git_object_free(target);
-        }
+        git_reference_peel(&targetObj, m_originalHeadRef, GIT_OBJ_COMMIT);
+    } else if (m_originalHeadDetached) {
+        git_commit_lookup((git_commit**)&targetObj, m_currentRepo->repo, &m_originalHeadOid);
     }
-    else if (m_originalHeadDetached) {
-        // Reset to the original detached commit
-        git_commit* target = nullptr;
-        if (git_commit_lookup(&target, m_currentRepo->repo, &m_originalHeadOid) == GIT_OK) {
-            resetToCommit(target);
-            git_commit_free(target);
+
+    if (targetObj) {
+        git_checkout_options opts = GIT_CHECKOUT_OPTIONS_INIT;
+        opts.checkout_strategy = GIT_CHECKOUT_FORCE; // Ensure all rebase remnants are wiped
+
+        git_reset(m_currentRepo->repo, targetObj, GIT_RESET_HARD, &opts);
+
+        if (m_originalHeadRef) {
+            git_repository_set_head(m_currentRepo->repo, git_reference_name(m_originalHeadRef));
         }
+
+        git_object_free(targetObj);
     }
 
     git_repository_state_cleanup(m_currentRepo->repo);
-
     cleanupInteractiveState();
     emit rebaseAborted();
 }
+
 
 git_commit* GitRebase::lookupCommit(const QString& hash) const
 {

--- a/Src/Git/GitRebase.cpp
+++ b/Src/Git/GitRebase.cpp
@@ -1104,3 +1104,10 @@ git_commit* GitRebase::lookupCommit(const QString& hash) const
 
     return commit;
 }
+
+int GitRebase::cherryPickCommit(git_commit* commit)
+{
+    git_cherrypick_options opts = GIT_CHERRYPICK_OPTIONS_INIT;
+    opts.checkout_opts.checkout_strategy = GIT_CHECKOUT_SAFE | GIT_CHECKOUT_RECREATE_MISSING;
+    return git_cherrypick(m_currentRepo->repo, commit, &opts);
+}

--- a/Src/Git/GitRebase.cpp
+++ b/Src/Git/GitRebase.cpp
@@ -898,3 +898,103 @@ void GitRebase::startInteractiveRebase(const QString& onto,
     m_currentPlanIndex = 0;
     QTimer::singleShot(0, this, &GitRebase::processNextOperation);
 }
+
+void GitRebase::processNextOperation()
+{
+    if (!m_interactiveInProgress)
+        return;
+
+    // If we've processed everything, finish the rebase
+    if (m_currentPlanIndex >= m_interactivePlan.size()) {
+        // If we started on a branch, move it to the new HEAD
+        if (m_originalHeadRef) {
+            git_oid headOid;
+            if (git_reference_name_to_id(&headOid, m_currentRepo->repo, "HEAD") == GIT_OK) {
+                git_reference* newRef = nullptr;
+                int err = git_reference_set_target(&newRef, m_originalHeadRef, &headOid, "rebase completed");
+                if (err == GIT_OK) {
+                    git_reference_free(m_originalHeadRef);
+                    m_originalHeadRef = newRef;
+                }
+            }
+        }
+        cleanupInteractiveState();
+        emit rebaseFinished(true);
+        return;
+    }
+
+    // Get the next plan entry
+    QVariantMap op = m_interactivePlan[m_currentPlanIndex].toMap();
+    QString action = op.value("action").toString().toLower();
+    QString hash   = op.value("hash").toString();
+
+    // Handle skip
+    if (action == "skip") {
+        emit rebaseOperationSkipped(hash);
+        m_currentPlanIndex++;
+        QTimer::singleShot(0, this, &GitRebase::processNextOperation);
+        return;
+    }
+
+    if (action == "pick") {
+        emit rebaseOperationStarted(hash);
+        m_currentOpHash = hash;
+
+        git_commit* commit = lookupCommit(hash);
+        if (!commit) {
+            cleanupInteractiveState();
+            emit rebaseFinished(false);
+            return;
+        }
+
+        int cpResult = cherryPickCommit(commit);
+        if (cpResult == GIT_OK) {
+            // Check whether the cherry-pick actually left conflicts in the index
+            bool hasConflicts = false;
+
+            git_index* index = nullptr;
+            if (git_repository_index(&index, m_currentRepo->repo) == GIT_OK) {
+                hasConflicts = git_index_has_conflicts(index);
+                git_index_free(index);
+            }
+
+            if (hasConflicts) {
+                // Treat as a conflict – do not try to commit
+                git_commit_free(commit);
+                m_isCherryPickActive = true;
+                emit rebaseConflict(hash);
+                return;
+            }
+
+            // Proceed with commit
+            if (!commitCherryPick(commit)) {
+                git_commit_free(commit);
+                abortCherryPick();
+                git_repository_state_cleanup(m_currentRepo->repo);
+                cleanupInteractiveState();
+                emit rebaseFinished(false);
+                return;
+            }
+
+            git_repository_state_cleanup(m_currentRepo->repo);
+            git_commit_free(commit);
+            emit rebaseOperationCompleted(hash);
+            m_currentPlanIndex++;
+            m_isCherryPickActive = false;
+            QTimer::singleShot(0, this, &GitRebase::processNextOperation);
+        } else if (cpResult == GIT_EMERGECONFLICT) {
+            git_commit_free(commit);
+            m_isCherryPickActive = true;
+            emit rebaseConflict(hash);
+        } else {
+            git_commit_free(commit);
+            abortCherryPick();
+            git_repository_state_cleanup(m_currentRepo->repo);
+            cleanupInteractiveState();
+            emit rebaseFinished(false);
+        }
+        return;
+    }
+    m_currentPlanIndex++;
+    QTimer::singleShot(0, this, &GitRebase::processNextOperation);
+}

--- a/Src/Git/GitRebase.cpp
+++ b/Src/Git/GitRebase.cpp
@@ -1039,3 +1039,55 @@ void GitRebase::interactiveSkip()
     m_isCherryPickActive = false;
     QTimer::singleShot(0, this, &GitRebase::processNextOperation);
 }
+
+void GitRebase::interactiveAbort()
+{
+    if (!m_interactiveInProgress)
+        return;
+
+    // If we were mid‑cherry‑pick, abort it first
+    if (m_isCherryPickActive) {
+        abortCherryPick();
+    }
+
+    // Reset to the original HEAD
+    if (m_originalHeadRef) {
+        git_object* target = nullptr;
+        if (git_reference_peel(&target, m_originalHeadRef, GIT_OBJ_COMMIT) == GIT_OK) {
+            // Checkout the tree first
+            git_checkout_options opts = GIT_CHECKOUT_OPTIONS_INIT;
+            opts.checkout_strategy = GIT_CHECKOUT_SAFE | GIT_CHECKOUT_RECREATE_MISSING;
+            git_checkout_tree(m_currentRepo->repo, target, &opts);
+            // Then reset HEAD to the original ref
+            git_repository_set_head(m_currentRepo->repo, git_reference_name(m_originalHeadRef));
+            git_object_free(target);
+        }
+    } else {
+        if (m_originalHeadDetached) {
+            // Reset to the original detached commit
+            git_commit* target = nullptr;
+            if (git_commit_lookup(&target, m_currentRepo->repo, &m_originalHeadOid) == GIT_OK) {
+                resetToCommit(target);
+                git_commit_free(target);
+            }
+        } else if (m_originalHeadRef) {
+            // Reset to the original branch
+            git_object* target = nullptr;
+            if (git_reference_peel(&target, m_originalHeadRef, GIT_OBJ_COMMIT) == GIT_OK) {
+                resetToCommit(reinterpret_cast<git_commit*>(target));
+                git_object_free(target);
+            }
+            // Checkout the branch and update HEAD
+            git_checkout_options opts = GIT_CHECKOUT_OPTIONS_INIT;
+            opts.checkout_strategy = GIT_CHECKOUT_SAFE | GIT_CHECKOUT_RECREATE_MISSING;
+            if (git_reference_peel(&target, m_originalHeadRef, GIT_OBJ_COMMIT) == GIT_OK) {
+                git_checkout_tree(m_currentRepo->repo, target, &opts);
+                git_object_free(target);
+            }
+            git_repository_set_head(m_currentRepo->repo, git_reference_name(m_originalHeadRef));
+        }
+    }
+
+    cleanupInteractiveState();
+    emit rebaseAborted();
+}

--- a/Src/Git/GitRebase.cpp
+++ b/Src/Git/GitRebase.cpp
@@ -746,24 +746,24 @@ QString GitRebase::getCurrentBranchName()
     return branchName;  // "main", "master", or Detached HEAD if detached
 }
 
-void GitRebase::startInteractiveRebase(const QString& onto,
+GitResult GitRebase::startInteractiveRebase(const QString& onto,
                                        const QString& upstream,
                                        const QString& branch,
                                        const QVariantList& operations)
 {
     if (m_interactiveInProgress) {
         emit rebaseFinished(false);
-        return;
+        return GitResult(false, {}, "An interactive rebase is already in progress.");
     }
 
     if (!m_currentRepo || !m_currentRepo->repo) {
         emit rebaseFinished(false);
-        return;
+        return GitResult(false, {}, "Repository not found.");
     }
 
     if (isRebaseInProgress()) {
         emit rebaseFinished(false);
-        return;
+                return GitResult(false, {}, "A rebase is already in progress. Abort or continue it first.");
     }
 
     // Check for uncommitted changes
@@ -776,7 +776,7 @@ void GitRebase::startInteractiveRebase(const QString& onto,
         if (count > 0) {
             cleanupInteractiveState();
             emit rebaseFinished(false);
-            return;
+            return GitResult(false, {}, "Working directory is not clean. Commit or stash changes first.");
         }
     }
 
@@ -805,7 +805,7 @@ void GitRebase::startInteractiveRebase(const QString& onto,
             // Should not happen, but if it does, abort
             cleanupInteractiveState();
             emit rebaseFinished(false);
-            return;
+            return GitResult(false, {}, "Could not read HEAD.");
         }
     } else {
         m_originalHeadDetached = false;
@@ -821,7 +821,7 @@ void GitRebase::startInteractiveRebase(const QString& onto,
             if (!checkoutRes.success()) {
                 cleanupInteractiveState();
                 emit rebaseFinished(false);
-                return;
+                return GitResult(false, {}, checkoutRes.errorMessage());
             }
         }
         actualBranch.clear(); // after checkout we use HEAD
@@ -832,7 +832,7 @@ void GitRebase::startInteractiveRebase(const QString& onto,
     if (baseRef.isEmpty()) {
         cleanupInteractiveState();
         emit rebaseFinished(false);
-        return;
+        return GitResult(false, {}, "No base reference provided.");
     }
 
     git_object* baseObj = nullptr;
@@ -840,7 +840,7 @@ void GitRebase::startInteractiveRebase(const QString& onto,
     if (result != GIT_OK || !baseObj) {
         cleanupInteractiveState();
         emit rebaseFinished(false);
-        return;
+        return GitResult(false, {}, QString("Invalid base reference '%1'.").arg(baseRef));
     }
 
     // It must be a commit
@@ -848,7 +848,7 @@ void GitRebase::startInteractiveRebase(const QString& onto,
         git_object_free(baseObj);
         cleanupInteractiveState();
         emit rebaseFinished(false);
-        return;
+        return GitResult(false, {}, "Base reference does not point to a commit.");
     }
 
     m_newBaseCommit = reinterpret_cast<git_commit*>(baseObj); // we own it now
@@ -860,7 +860,7 @@ void GitRebase::startInteractiveRebase(const QString& onto,
     if (result != GIT_OK) {
         cleanupInteractiveState();
         emit rebaseFinished(false);
-        return;
+        return GitResult(false, {}, "Failed to checkout the base commit.");
     }
 
     // Set HEAD to the new base commit (detached)
@@ -868,19 +868,24 @@ void GitRebase::startInteractiveRebase(const QString& onto,
     if (result != GIT_OK) {
         cleanupInteractiveState();
         emit rebaseFinished(false);
-        return;
+        return GitResult(false, {}, "Failed to detach HEAD.");
     }
 
     // Create default committer signature
     git_signature* sig = nullptr;
-    if (git_signature_default(&sig, m_currentRepo->repo) == GIT_OK) {
-        m_defaultSignature = sig;
+    if (git_signature_default(&sig, m_currentRepo->repo) != GIT_OK) {
+        cleanupInteractiveState();
+        emit rebaseFinished(false);
+        return GitResult(false, {}, "Could not read Git user identity (user.name / user.email).");
     }
+    m_defaultSignature = sig;
 
     // Kick off processing
     m_interactiveInProgress = true;
     m_currentPlanIndex = 0;
     QTimer::singleShot(0, this, &GitRebase::processNextOperation);
+
+    return GitResult(true);
 }
 
 void GitRebase::processNextOperation()

--- a/Src/Git/GitRebase.cpp
+++ b/Src/Git/GitRebase.cpp
@@ -85,7 +85,7 @@ GitResult GitRebase::previewRebasePlan(const QString& onto,
                          QString("Failed to prepare rebase plan: %1").arg(GitUtils::getLastError()));
     }
 
-    git_revwalk_sorting(walk, GIT_SORT_TOPOLOGICAL | GIT_SORT_REVERSE);
+    git_revwalk_sorting(walk, GIT_SORT_TOPOLOGICAL | GIT_SORT_TIME);
     git_revwalk_push(walk, git_object_id(branchObject));
     git_revwalk_hide(walk, git_object_id(upstreamObject));
 

--- a/Src/Git/GitRebase.cpp
+++ b/Src/Git/GitRebase.cpp
@@ -1217,3 +1217,25 @@ bool GitRebase::resetToCommit(git_commit* target)
         return false;
     return git_repository_set_head_detached(m_currentRepo->repo, git_commit_id(target)) == GIT_OK;
 }
+
+void GitRebase::cleanupInteractiveState()
+{
+    if (m_newBaseCommit) {
+        git_commit_free(m_newBaseCommit);
+        m_newBaseCommit = nullptr;
+    }
+    if (m_originalHeadRef) {
+        git_reference_free(m_originalHeadRef);
+        m_originalHeadRef = nullptr;
+    }
+    m_interactiveInProgress = false;
+    m_isCherryPickActive = false;
+    m_interactivePlan.clear();
+    m_currentPlanIndex = 0;
+    m_currentOpHash.clear();
+
+    if (m_defaultSignature) {
+        git_signature_free(m_defaultSignature);
+        m_defaultSignature = nullptr;
+    }
+}

--- a/Src/Git/GitRebase.cpp
+++ b/Src/Git/GitRebase.cpp
@@ -3,10 +3,13 @@
 #include "GitUtils.h"
 
 #include <git2/annotated_commit.h>
+#include <git2/commit.h>
 #include <git2/checkout.h>
 #include <git2/index.h>
 #include <git2/rebase.h>
 #include <git2/repository.h>
+#include <git2/revparse.h>
+#include <git2/revwalk.h>
 #include <git2/signature.h>
 
 #include <QVariantList>
@@ -124,6 +127,115 @@ GitResult GitRebase::rebaseOnto(const QString& onto,
     }
 
     return rebaseResult;
+}
+
+GitResult GitRebase::previewRebasePlan(const QString& onto,
+                                       const QString& upstream,
+                                       const QString& branch)
+{
+    Q_UNUSED(onto)
+
+    if (!m_currentRepo || !m_currentRepo->repo) {
+        return GitResult(false, QVariant(), "Repository not found.");
+    }
+
+    if (upstream.trimmed().isEmpty()) {
+        return GitResult(false, QVariant(), "Upstream reference is required.");
+    }
+
+    git_object* upstreamObject = nullptr;
+    int result = git_revparse_single(&upstreamObject,
+                                     m_currentRepo->repo,
+                                     upstream.trimmed().toUtf8().constData());
+    if (result != GIT_OK || !upstreamObject) {
+        return GitResult(false, QVariant(),
+                         QString("Invalid upstream '%1'.").arg(upstream));
+    }
+
+    QString branchSpec = branch.trimmed();
+    if (branchSpec.isEmpty()) {
+        branchSpec = "HEAD";
+    }
+
+    git_object* branchObject = nullptr;
+    result = git_revparse_single(&branchObject,
+                                 m_currentRepo->repo,
+                                 branchSpec.toUtf8().constData());
+    if (result != GIT_OK || !branchObject) {
+        git_object_free(upstreamObject);
+        return GitResult(false, QVariant(),
+                         QString("Invalid branch '%1'.").arg(branchSpec));
+    }
+
+    git_revwalk* walk = nullptr;
+    result = git_revwalk_new(&walk, m_currentRepo->repo);
+    if (result != GIT_OK || !walk) {
+        git_object_free(branchObject);
+        git_object_free(upstreamObject);
+        return GitResult(false, QVariant(),
+                         QString("Failed to prepare rebase plan: %1").arg(GitUtils::getLastError()));
+    }
+
+    git_revwalk_sorting(walk, GIT_SORT_TOPOLOGICAL | GIT_SORT_TIME);
+    git_revwalk_push(walk, git_object_id(branchObject));
+    git_revwalk_hide(walk, git_object_id(upstreamObject));
+
+    QVariantList commits;
+    git_oid oid;
+    while (git_revwalk_next(&oid, walk) == GIT_OK) {
+        git_commit* commit = nullptr;
+        if (git_commit_lookup(&commit, m_currentRepo->repo, &oid) != GIT_OK || !commit) {
+            continue;
+        }
+
+        char hash[GIT_OID_HEXSZ + 1] = {0};
+        git_oid_tostr(hash, sizeof(hash), git_commit_id(commit));
+
+        QStringList parentHashes;
+        const unsigned int parentCount = git_commit_parentcount(commit);
+        for (unsigned int i = 0; i < parentCount; ++i) {
+            const git_oid* parentOid = git_commit_parent_id(commit, i);
+            if (!parentOid) {
+                continue;
+            }
+
+            char parentHash[GIT_OID_HEXSZ + 1] = {0};
+            git_oid_tostr(parentHash, sizeof(parentHash), parentOid);
+            parentHashes.append(QString::fromUtf8(parentHash));
+        }
+
+        const git_signature* author = git_commit_author(commit);
+        const QString message       = QString::fromUtf8(git_commit_message(commit));
+
+        QVariantMap item;
+        item["action"]          = "pick";
+        item["hash"]            = QString::fromUtf8(hash);
+        item["shortHash"]       = QString::fromUtf8(hash).left(7);
+        item["summary"]         = message.split('\n').first();
+        item["message"]         = message;
+        item["author"]          = author && author->name ? QString::fromUtf8(author->name) : QString();
+        item["authorEmail"]     = author && author->email ? QString::fromUtf8(author->email) : QString();
+        item["authorDate"]      = author ? QDateTime::fromSecsSinceEpoch(author->when.time).toString(Qt::ISODate) : QString();
+        item["parentHashes"]    = parentHashes;
+        item["parentHash"]      = parentHashes.isEmpty() ? QString() : parentHashes.first();
+        item["isMerge"]         = parentCount > 1;
+
+        commits.prepend(item);
+        git_commit_free(commit);
+    }
+
+    git_revwalk_free(walk);
+    git_object_free(branchObject);
+    git_object_free(upstreamObject);
+
+    QVariantMap data;
+    data["commits"]             = commits;
+    data["upstream"]            = upstream.trimmed();
+    data["onto"]                = onto.trimmed();
+    data["branch"]              = branch.trimmed();
+    data["supportedActions"]    = QStringList{"pick", "skip"};
+
+    return GitResult(true, data);
 }
 
 GitResult GitRebase::continueOp()

--- a/Src/Git/GitRebase.cpp
+++ b/Src/Git/GitRebase.cpp
@@ -15,6 +15,12 @@
 #include <QVariantList>
 #include <git2/branch.h>
 
+#include <QDateTime>
+#include <QStringList>
+#include <QVariantMap>
+#include <QTimer>
+#include <git2/cherrypick.h>
+
 GitRebase::GitRebase(QObject* parent)
     : IGitController{parent}
 {

--- a/Src/Git/GitRebase.cpp
+++ b/Src/Git/GitRebase.cpp
@@ -1207,3 +1207,13 @@ void GitRebase::abortCherryPick()
         git_index_free(index);
     }
 }
+
+bool GitRebase::resetToCommit(git_commit* target)
+{
+    git_checkout_options opts = GIT_CHECKOUT_OPTIONS_INIT;
+    opts.checkout_strategy = GIT_CHECKOUT_FORCE | GIT_CHECKOUT_RECREATE_MISSING;
+    int result = git_checkout_tree(m_currentRepo->repo, reinterpret_cast<git_object*>(target), &opts);
+    if (result != GIT_OK)
+        return false;
+    return git_repository_set_head_detached(m_currentRepo->repo, git_commit_id(target)) == GIT_OK;
+}

--- a/Src/Git/GitRebase.cpp
+++ b/Src/Git/GitRebase.cpp
@@ -1107,6 +1107,8 @@ void GitRebase::interactiveContinue()
         return;
     }
 
+    git_repository_state_cleanup(m_currentRepo->repo)
+
     git_commit_free(originalCommit);
     emit rebaseOperationCompleted(m_currentOpHash);
     m_currentPlanIndex++;

--- a/Src/Git/GitRebase.cpp
+++ b/Src/Git/GitRebase.cpp
@@ -1111,3 +1111,79 @@ int GitRebase::cherryPickCommit(git_commit* commit)
     opts.checkout_opts.checkout_strategy = GIT_CHECKOUT_SAFE | GIT_CHECKOUT_RECREATE_MISSING;
     return git_cherrypick(m_currentRepo->repo, commit, &opts);
 }
+
+bool GitRebase::commitCherryPick(git_commit* originalCommit)
+{
+    git_oid headOid;
+    if (git_reference_name_to_id(&headOid, m_currentRepo->repo, "HEAD") != GIT_OK) {
+        qWarning() << "commitCherryPick: failed to get HEAD OID";
+        return false;
+    }
+
+    git_commit* parent = nullptr;
+    if (git_commit_lookup(&parent, m_currentRepo->repo, &headOid) != GIT_OK) {
+        qWarning() << "commitCherryPick: failed to lookup parent commit";
+        return false;
+    }
+
+    const git_signature* author = git_commit_author(originalCommit);
+    const char* message = git_commit_message(originalCommit);
+
+    git_index* index = nullptr;
+    if (git_repository_index(&index, m_currentRepo->repo) != GIT_OK) {
+        qWarning() << "commitCherryPick: failed to get repository index";
+        git_commit_free(parent);
+        return false;
+    }
+
+    if (git_index_has_conflicts(index)) {
+        git_index_free(index);
+        git_commit_free(parent);
+        return false;
+    }
+
+    git_oid treeOid;
+    if (git_index_write_tree(&treeOid, index) != GIT_OK) {
+        const git_error *err = git_error_last();
+        qWarning() << "commitCherryPick: failed to write tree:" << (err ? err->message : "unknown");
+        git_index_free(index);
+        git_commit_free(parent);
+        return false;
+    }
+
+    git_tree* tree = nullptr;
+    if (git_tree_lookup(&tree, m_currentRepo->repo, &treeOid) != GIT_OK) {
+        qWarning() << "commitCherryPick: failed to lookup tree";
+        git_index_free(index);
+        git_commit_free(parent);
+        return false;
+    }
+
+    const git_commit* parents[1] = { parent };
+
+    git_oid newCommitOid;
+    int result = git_commit_create(
+        &newCommitOid,
+        m_currentRepo->repo,
+        "HEAD",
+        author,
+        m_defaultSignature,
+        "UTF-8",
+        message,
+        tree,
+        1,
+        parents
+        );
+
+    git_tree_free(tree);
+    git_index_free(index);
+    git_commit_free(parent);
+
+    if (result != GIT_OK) {
+        const git_error *err = git_error_last();
+        qWarning() << "commitCherryPick: git_commit_create failed:" << (err ? err->message : "unknown");
+        return false;
+    }
+
+    return true;
+}

--- a/Src/Git/GitRebase.cpp
+++ b/Src/Git/GitRebase.cpp
@@ -42,107 +42,205 @@ GitResult GitRebase::previewRebasePlan(const QString& onto,
                                        const QString& upstream,
                                        const QString& branch)
 {
-    Q_UNUSED(onto)
-
-    if (!m_currentRepo || !m_currentRepo->repo) {
+    if (!m_currentRepo || !m_currentRepo->repo)
         return GitResult(false, QVariant(), "Repository not found.");
-    }
 
-    if (upstream.trimmed().isEmpty()) {
+    if (upstream.trimmed().isEmpty())
         return GitResult(false, QVariant(), "Upstream reference is required.");
-    }
 
-    git_object* upstreamObject = nullptr;
-    int result = git_revparse_single(&upstreamObject,
-                                     m_currentRepo->repo,
-                                     upstream.trimmed().toUtf8().constData());
-    if (result != GIT_OK || !upstreamObject) {
+    git_repository* repo = m_currentRepo->repo;
+
+    git_object* upstreamObject  = nullptr;
+    git_object* ontoObject      = nullptr;
+    git_object* branchObject    = nullptr;
+    git_revwalk* walk           = nullptr;
+
+    // Resolve upstream
+    if (git_revparse_single(&upstreamObject, repo,
+                            upstream.trimmed().toUtf8().constData()) != GIT_OK)
+    {
         return GitResult(false, QVariant(),
                          QString("Invalid upstream '%1'.").arg(upstream));
     }
 
-    QString branchSpec = branch.trimmed();
-    if (branchSpec.isEmpty()) {
-        branchSpec = "HEAD";
+    // Resolve onto (fallback = upstream)
+    QString ontoSpec = onto.trimmed();
+    if (ontoSpec.isEmpty()) {
+        ontoObject = upstreamObject;
+    } else {
+        if (git_revparse_single(&ontoObject, repo,
+                                ontoSpec.toUtf8().constData()) != GIT_OK)
+        {
+            git_object_free(upstreamObject);
+            return GitResult(false, QVariant(),
+                             QString("Invalid onto '%1'.").arg(ontoSpec));
+        }
     }
 
-    git_object* branchObject = nullptr;
-    result = git_revparse_single(&branchObject,
-                                 m_currentRepo->repo,
-                                 branchSpec.toUtf8().constData());
-    if (result != GIT_OK || !branchObject) {
+    // Resolve branch (default HEAD)
+    QString branchSpec = branch.trimmed().isEmpty() ? "HEAD" : branch.trimmed();
+    if (git_revparse_single(&branchObject, repo,
+                            branchSpec.toUtf8().constData()) != GIT_OK)
+    {
+        if (ontoObject != upstreamObject)
+            git_object_free(ontoObject);
         git_object_free(upstreamObject);
+
         return GitResult(false, QVariant(),
                          QString("Invalid branch '%1'.").arg(branchSpec));
     }
 
-    git_revwalk* walk = nullptr;
-    result = git_revwalk_new(&walk, m_currentRepo->repo);
-    if (result != GIT_OK || !walk) {
-        git_object_free(branchObject);
+    // STEP 1: Collect patch-ids from ONTO history
+    QSet<QByteArray> upstreamPatchIds;
+
+    git_revwalk* upstreamWalk = nullptr;
+    git_revwalk_new(&upstreamWalk, repo);
+    git_revwalk_sorting(upstreamWalk, GIT_SORT_TOPOLOGICAL);
+    git_revwalk_push(upstreamWalk, git_object_id(ontoObject));
+
+    git_oid upstreamOid;
+    while (git_revwalk_next(&upstreamOid, upstreamWalk) == GIT_OK)
+    {
+        git_commit* commit = nullptr;
+        if (git_commit_lookup(&commit, repo, &upstreamOid) != GIT_OK)
+            continue;
+
+        // Skip root commits and merges (like Git does)
+        if (git_commit_parentcount(commit) == 1)
+        {
+            git_commit* parent = nullptr;
+            git_commit_parent(&parent, commit, 0);
+
+            git_tree* tree = nullptr;
+            git_tree* parentTree = nullptr;
+            git_commit_tree(&tree, commit);
+            git_commit_tree(&parentTree, parent);
+
+            git_diff* diff = nullptr;
+            git_diff_tree_to_tree(&diff, repo, parentTree, tree, nullptr);
+
+            git_oid patchId;
+            if (git_diff_patchid(&patchId, diff, nullptr) == GIT_OK)
+            {
+                upstreamPatchIds.insert(
+                    QByteArray(reinterpret_cast<char*>(patchId.id),
+                               GIT_OID_RAWSZ));
+            }
+
+            git_diff_free(diff);
+            git_tree_free(tree);
+            git_tree_free(parentTree);
+            git_commit_free(parent);
+        }
+
+        git_commit_free(commit);
+    }
+
+    git_revwalk_free(upstreamWalk);
+
+    // STEP 2: Walk upstream..branch commits
+    if (git_revwalk_new(&walk, repo) != GIT_OK)
+    {
+        if (ontoObject != upstreamObject)
+            git_object_free(ontoObject);
         git_object_free(upstreamObject);
+        git_object_free(branchObject);
+
         return GitResult(false, QVariant(),
-                         QString("Failed to prepare rebase plan: %1").arg(GitUtils::getLastError()));
+                         "Failed to prepare rebase plan.");
     }
 
     git_revwalk_sorting(walk, GIT_SORT_TOPOLOGICAL | GIT_SORT_TIME);
-    git_revwalk_push(walk, git_object_id(branchObject));
-    git_revwalk_hide(walk, git_object_id(upstreamObject));
+
+    QString range = QString("%1..%2")
+                        .arg(upstream.trimmed())
+                        .arg(branchSpec);
+
+    git_revwalk_push_range(walk, range.toUtf8().constData());
 
     QVariantList commits;
     git_oid oid;
-    while (git_revwalk_next(&oid, walk) == GIT_OK) {
+
+    while (git_revwalk_next(&oid, walk) == GIT_OK)
+    {
         git_commit* commit = nullptr;
-        if (git_commit_lookup(&commit, m_currentRepo->repo, &oid) != GIT_OK || !commit) {
+        if (git_commit_lookup(&commit, repo, &oid) != GIT_OK)
             continue;
-        }
 
         char hash[GIT_OID_HEXSZ + 1] = {0};
-        git_oid_tostr(hash, sizeof(hash), git_commit_id(commit));
-
-        QStringList parentHashes;
-        const unsigned int parentCount = git_commit_parentcount(commit);
-        for (unsigned int i = 0; i < parentCount; ++i) {
-            const git_oid* parentOid = git_commit_parent_id(commit, i);
-            if (!parentOid) {
-                continue;
-            }
-
-            char parentHash[GIT_OID_HEXSZ + 1] = {0};
-            git_oid_tostr(parentHash, sizeof(parentHash), parentOid);
-            parentHashes.append(QString::fromUtf8(parentHash));
-        }
+        git_oid_tostr(hash, sizeof(hash), &oid);
 
         const git_signature* author = git_commit_author(commit);
-        const QString message       = QString::fromUtf8(git_commit_message(commit));
+        QString message = QString::fromUtf8(git_commit_message(commit));
+
+        bool alreadyApplied = false;
+
+        // Only compute patch-id for non-merge commits
+        if (git_commit_parentcount(commit) == 1)
+        {
+            git_commit* parent = nullptr;
+            git_commit_parent(&parent, commit, 0);
+
+            git_tree* tree = nullptr;
+            git_tree* parentTree = nullptr;
+            git_commit_tree(&tree, commit);
+            git_commit_tree(&parentTree, parent);
+
+            git_diff* diff = nullptr;
+            git_diff_tree_to_tree(&diff, repo, parentTree, tree, nullptr);
+
+            git_oid patchId;
+            if (git_diff_patchid(&patchId, diff, nullptr) == GIT_OK)
+            {
+                QByteArray id(reinterpret_cast<char*>(patchId.id),
+                              GIT_OID_RAWSZ);
+
+                if (upstreamPatchIds.contains(id))
+                    alreadyApplied = true;
+            }
+
+            git_diff_free(diff);
+            git_tree_free(tree);
+            git_tree_free(parentTree);
+            git_commit_free(parent);
+        }
 
         QVariantMap item;
-        item["action"]          = "pick";
-        item["hash"]            = QString::fromUtf8(hash);
-        item["shortHash"]       = QString::fromUtf8(hash).left(7);
-        item["summary"]         = message.split('\n').first();
-        item["message"]         = message;
-        item["author"]          = author && author->name ? QString::fromUtf8(author->name) : QString();
-        item["authorEmail"]     = author && author->email ? QString::fromUtf8(author->email) : QString();
-        item["authorDate"]      = author ? QDateTime::fromSecsSinceEpoch(author->when.time).toString(Qt::ISODate) : QString();
-        item["parentHashes"]    = parentHashes;
-        item["parentHash"]      = parentHashes.isEmpty() ? QString() : parentHashes.first();
-        item["isMerge"]         = parentCount > 1;
+        item["action"]      = alreadyApplied ? "skip" : "pick";
+        item["hash"]        = QString::fromUtf8(hash);
+        item["shortHash"]   = QString::fromUtf8(hash).left(7);
+        item["summary"]     = message.split('\n').first();
+        item["message"]     = message;
+        item["author"]      = author && author->name
+                             ? QString::fromUtf8(author->name) : QString();
+
+        item["authorEmail"] = author && author->email
+                                  ? QString::fromUtf8(author->email) : QString();
+
+        item["authorDate"]  = author
+                                 ? QDateTime::fromSecsSinceEpoch(
+                                       author->when.time).toString(Qt::ISODate)
+                                 : QString();
+
+        item["isMerge"]     = git_commit_parentcount(commit) > 1;
 
         commits.append(item);
         git_commit_free(commit);
     }
 
+    // Cleanup
     git_revwalk_free(walk);
     git_object_free(branchObject);
+    if (ontoObject != upstreamObject)
+        git_object_free(ontoObject);
     git_object_free(upstreamObject);
 
     QVariantMap data;
-    data["commits"]             = commits;
-    data["upstream"]            = upstream.trimmed();
-    data["onto"]                = onto.trimmed();
-    data["branch"]              = branch.trimmed();
-    data["supportedActions"]    = QStringList{"pick", "skip"};
+    data["commits"] = commits;
+    data["upstream"] = upstream.trimmed();
+    data["onto"] = onto.trimmed();
+    data["branch"] = branchSpec;
+    data["supportedActions"] = QStringList{ "pick", "skip" };
 
     return GitResult(true, data);
 }

--- a/Src/Git/GitRebase.cpp
+++ b/Src/Git/GitRebase.cpp
@@ -29,104 +29,7 @@ GitResult GitRebase::rebaseOnto(const QString& onto,
                                 const QString& upstream,
                                 QString branch)
 {
-    if (!m_currentRepo || !m_currentRepo->repo) {
-        return GitResult(false, QVariant(), "Repository not found.");
-    }
-
-    if (upstream.trimmed().isEmpty()) {
-        return GitResult(false, QVariant(), "Upstream reference is required.");
-    }
-
-    if (isRebaseInProgress()) {
-        return GitResult(false, QVariant(),
-                         "A rebase is already in progress. Continue or abort it first.");
-    }
-
-    QString originalBranch = branch;
-    bool hasBranch = !branch.trimmed().isEmpty();
-
-    // If a branch is provided, ensure it is checked out
-    if (hasBranch) {
-        QString currentBranch = getCurrentBranchName();
-        if (currentBranch != originalBranch) {
-            GitResult checkoutResult = checkoutBranch(branch);
-            if (!checkoutResult.success()) {
-                return checkoutResult;
-            }
-        }
-        // After checkout, we want to use the current HEAD, so we clear 'branch'
-        // to prevent creating a separate annotated commit for it.
-        branch = QString();
-    }
-
-    git_rebase* rebase = nullptr;
-    git_annotated_commit* branchCommit = nullptr;
-    git_annotated_commit* ontoCommit = nullptr;
-    git_annotated_commit* upstreamCommit = nullptr;
-
-    int result = git_annotated_commit_from_revspec(
-        &upstreamCommit, m_currentRepo->repo, upstream.trimmed().toUtf8().constData());
-    if (result != GIT_OK) {
-        return GitResult(false, QVariant(),
-                         QString("Invalid upstream '%1'.").arg(upstream));
-    }
-
-    if (!branch.trimmed().isEmpty()) {
-        result = git_annotated_commit_from_revspec(
-            &branchCommit, m_currentRepo->repo, branch.trimmed().toUtf8().constData());
-        if (result != GIT_OK) {
-            git_annotated_commit_free(upstreamCommit);
-            return GitResult(false, QVariant(),
-                             QString("Invalid branch '%1'.").arg(branch));
-        }
-    }
-
-    if (!onto.trimmed().isEmpty()) {
-        result = git_annotated_commit_from_revspec(
-            &ontoCommit, m_currentRepo->repo, onto.trimmed().toUtf8().constData());
-        if (result != GIT_OK) {
-            git_annotated_commit_free(branchCommit);
-            git_annotated_commit_free(upstreamCommit);
-            return GitResult(false, QVariant(),
-                             QString("Invalid onto '%1'.").arg(onto));
-        }
-    }
-
-    git_rebase_options rebaseOpts = GIT_REBASE_OPTIONS_INIT;
-    rebaseOpts.checkout_options.checkout_strategy = GIT_CHECKOUT_SAFE | GIT_CHECKOUT_RECREATE_MISSING;
-
-    result = git_rebase_init(&rebase,
-                             m_currentRepo->repo,
-                             branchCommit,
-                             upstreamCommit,
-                             ontoCommit,
-                             &rebaseOpts);
-
-    git_annotated_commit_free(branchCommit);
-    git_annotated_commit_free(upstreamCommit);
-    git_annotated_commit_free(ontoCommit);
-
-    if (result != GIT_OK) {
-        return GitResult(false, QVariant(),
-                         QString("Failed to start rebase: %1").arg(GitUtils::getLastError()));
-    }
-
-    GitResult rebaseResult = runRebase(rebase, false);
-    git_rebase_free(rebase);
-
-    if (rebaseResult.success()) {
-        QString command = "git rebase";
-        if (!onto.trimmed().isEmpty()) {
-            command += " --onto " + quoteCommandArg(onto);
-        }
-        command += " " + quoteCommandArg(upstream);
-        if (hasBranch) {
-            command += " " + quoteCommandArg(originalBranch);
-        }
-        emitGitCommand(command);
-    }
-
-    return rebaseResult;
+    return startRebase(onto, upstream, branch, {});
 }
 
 GitResult GitRebase::previewRebasePlan(const QString& onto,
@@ -258,6 +161,114 @@ GitResult GitRebase::rebaseWithPlan(const QString& onto,
     }
 
     return startRebase(onto, upstream, branch, skippedCommits);
+}
+
+GitResult GitRebase::startRebase(const QString& onto,
+                                 const QString& upstream,
+                                 QString branch,
+                                 const QSet<QString>& skippedCommits)
+{
+    if (!m_currentRepo || !m_currentRepo->repo) {
+        return GitResult(false, QVariant(), "Repository not found.");
+    }
+
+    if (upstream.trimmed().isEmpty()) {
+        return GitResult(false, QVariant(), "Upstream reference is required.");
+    }
+
+    if (isRebaseInProgress()) {
+        return GitResult(false, QVariant(),
+                         "A rebase is already in progress. Continue or abort it first.");
+    }
+
+    QString originalBranch  = branch;
+    bool hasBranch          = !branch.trimmed().isEmpty();
+
+    // If a branch is provided, ensure it is checked out
+    if (hasBranch) {
+        QString currentBranch = getCurrentBranchName();
+        if (currentBranch != originalBranch) {
+            GitResult checkoutResult = checkoutBranch(branch);
+            if (!checkoutResult.success()) {
+                return checkoutResult;
+            }
+        }
+        // After checkout, we want to use the current HEAD, so we clear 'branch'
+        // to prevent creating a separate annotated commit for it.
+        branch = QString();
+    }
+
+    git_rebase* rebase                  = nullptr;
+    git_annotated_commit* branchCommit  = nullptr;
+    git_annotated_commit* ontoCommit    = nullptr;
+    git_annotated_commit* upstreamCommit= nullptr;
+
+    int result = git_annotated_commit_from_revspec(
+        &upstreamCommit, m_currentRepo->repo, upstream.trimmed().toUtf8().constData());
+    if (result != GIT_OK) {
+        return GitResult(false, QVariant(),
+                         QString("Invalid upstream '%1'.").arg(upstream));
+    }
+
+    if (!branch.trimmed().isEmpty()) {
+        result = git_annotated_commit_from_revspec(
+            &branchCommit, m_currentRepo->repo, branch.trimmed().toUtf8().constData());
+        if (result != GIT_OK) {
+            git_annotated_commit_free(upstreamCommit);
+            return GitResult(false, QVariant(),
+                             QString("Invalid branch '%1'.").arg(branch));
+        }
+    }
+
+    if (!onto.trimmed().isEmpty()) {
+        result = git_annotated_commit_from_revspec(
+            &ontoCommit, m_currentRepo->repo, onto.trimmed().toUtf8().constData());
+        if (result != GIT_OK) {
+            git_annotated_commit_free(branchCommit);
+            git_annotated_commit_free(upstreamCommit);
+            return GitResult(false, QVariant(),
+                             QString("Invalid onto '%1'.").arg(onto));
+        }
+    }
+
+    git_rebase_options rebaseOpts = GIT_REBASE_OPTIONS_INIT;
+    rebaseOpts.checkout_options.checkout_strategy = GIT_CHECKOUT_SAFE | GIT_CHECKOUT_RECREATE_MISSING;
+
+    result = git_rebase_init(&rebase,
+                             m_currentRepo->repo,
+                             branchCommit,
+                             upstreamCommit,
+                             ontoCommit,
+                             &rebaseOpts);
+
+    git_annotated_commit_free(branchCommit);
+    git_annotated_commit_free(upstreamCommit);
+    git_annotated_commit_free(ontoCommit);
+
+    if (result != GIT_OK) {
+        return GitResult(false, QVariant(),
+                         QString("Failed to start rebase: %1").arg(GitUtils::getLastError()));
+    }
+
+    GitResult rebaseResult = runRebase(rebase, false, skippedCommits);
+    git_rebase_free(rebase);
+
+    if (rebaseResult.success()) {
+        QString command = skippedCommits.isEmpty() ? "git rebase" : "git rebase -i";
+        if (!onto.trimmed().isEmpty()) {
+            command += " --onto " + quoteCommandArg(onto);
+        }
+        command += " " + quoteCommandArg(upstream);
+        if (hasBranch) {
+            command += " " + quoteCommandArg(originalBranch);
+        }
+        if (!skippedCommits.isEmpty()) {
+            command += QString("  # skipped %1 commit(s)").arg(skippedCommits.count());
+        }
+        emitGitCommand(command);
+    }
+
+    return rebaseResult;
 }
 
 GitResult GitRebase::continueOp()

--- a/Src/Git/GitRebase.cpp
+++ b/Src/Git/GitRebase.cpp
@@ -998,3 +998,31 @@ void GitRebase::processNextOperation()
     m_currentPlanIndex++;
     QTimer::singleShot(0, this, &GitRebase::processNextOperation);
 }
+
+void GitRebase::interactiveContinue()
+{
+    if (!m_interactiveInProgress || !m_isCherryPickActive)
+        return;
+
+    // Look up the original commit again to preserve its metadata
+    git_commit* originalCommit = lookupCommit(m_currentOpHash);
+    if (!originalCommit) {
+        cleanupInteractiveState();
+        emit rebaseFinished(false);
+        return;
+    }
+
+    // The user resolved conflicts – commit the result
+    if (!commitCherryPick(originalCommit)) {
+        git_commit_free(originalCommit);
+        cleanupInteractiveState();
+        emit rebaseFinished(false);
+        return;
+    }
+
+    git_commit_free(originalCommit);
+    emit rebaseOperationCompleted(m_currentOpHash);
+    m_currentPlanIndex++;
+    m_isCherryPickActive = false;
+    QTimer::singleShot(0, this, &GitRebase::processNextOperation);
+}

--- a/Src/Git/GitRebase.cpp
+++ b/Src/Git/GitRebase.cpp
@@ -410,7 +410,9 @@ GitResult GitRebase::rebaseStatus()
     return GitResult(true, data);
 }
 
-GitResult GitRebase::runRebase(git_rebase* rebase, bool continueCurrentOperation)
+GitResult GitRebase::runRebase(git_rebase* rebase,
+                               bool continueCurrentOperation,
+                               const QSet<QString>& skippedCommits)
 {
     if (!rebase) {
         return GitResult(false, QVariant(), "Invalid rebase state.");
@@ -424,6 +426,7 @@ GitResult GitRebase::runRebase(git_rebase* rebase, bool continueCurrentOperation
     }
 
     QVariantList rebasedCommits;
+    QVariantList skippedCommitList;
     QVariantMap rebaseData;
     rebaseData["totalOperations"] = static_cast<int>(git_rebase_operation_entrycount(rebase));
 
@@ -457,6 +460,21 @@ GitResult GitRebase::runRebase(git_rebase* rebase, bool continueCurrentOperation
                          QString("Failed to create rebased commit: %1").arg(GitUtils::getLastError()));
     };
 
+    auto operationHashByIndex = [&](size_t index) -> QString {
+        if (index == GIT_REBASE_NO_OPERATION) {
+            return QString();
+        }
+
+        git_rebase_operation* operation = git_rebase_operation_byindex(rebase, index);
+        if (!operation) {
+            return QString();
+        }
+
+        char oidStr[GIT_OID_HEXSZ + 1] = {0};
+        git_oid_tostr(oidStr, sizeof(oidStr), &operation->id);
+        return QString::fromUtf8(oidStr);
+    };
+
     if (continueCurrentOperation && git_rebase_operation_current(rebase) != GIT_REBASE_NO_OPERATION) {
         GitResult commitResult = commitCurrent();
         if (!commitResult.success()) {
@@ -475,6 +493,17 @@ GitResult GitRebase::runRebase(git_rebase* rebase, bool continueCurrentOperation
 
         if (result != GIT_OK) {
             if (repositoryHasConflicts()) {
+                const QString currentHash = operationHashByIndex(git_rebase_operation_current(rebase));
+                if (!currentHash.isEmpty() && skippedCommits.contains(currentHash)) {
+                    GitResult resetResult = resetWorktreeToHead();
+                    if (!resetResult.success()) {
+                        git_signature_free(signature);
+                        return resetResult;
+                    }
+                    skippedCommitList.push_back(currentHash);
+                    continue;
+                }
+
                 git_signature_free(signature);
                 return conflictResult(rebase,
                                       "Rebase stopped due to conflicts. Resolve conflicts and continue.");
@@ -485,7 +514,19 @@ GitResult GitRebase::runRebase(git_rebase* rebase, bool continueCurrentOperation
                              QString("Failed to apply rebase operation: %1").arg(GitUtils::getLastError()));
         }
 
-        Q_UNUSED(operation)
+        char operationId[GIT_OID_HEXSZ + 1] = {0};
+        git_oid_tostr(operationId, sizeof(operationId), &operation->id);
+        const QString operationHash = QString::fromUtf8(operationId);
+
+        if (skippedCommits.contains(operationHash)) {
+            GitResult resetResult = resetWorktreeToHead();
+            if (!resetResult.success()) {
+                git_signature_free(signature);
+                return resetResult;
+            }
+            skippedCommitList.push_back(operationHash);
+            continue;
+        }
 
         GitResult commitResult = commitCurrent();
         if (!commitResult.success()) {
@@ -502,9 +543,11 @@ GitResult GitRebase::runRebase(git_rebase* rebase, bool continueCurrentOperation
                          QString("Failed to finish rebase: %1").arg(GitUtils::getLastError()));
     }
 
-    rebaseData["rebasedCommits"] = rebasedCommits;
-    rebaseData["appliedCount"] = rebasedCommits.count();
-    rebaseData["status"] = "completed";
+    rebaseData["rebasedCommits"]= rebasedCommits;
+    rebaseData["skippedCommits"]= skippedCommitList;
+    rebaseData["appliedCount"]  = rebasedCommits.count();
+    rebaseData["skippedCount"]  = skippedCommitList.count();
+    rebaseData["status"]        = "completed";
 
     return GitResult(true, rebaseData, "Rebase completed.");
 }

--- a/Src/Git/GitRebase.cpp
+++ b/Src/Git/GitRebase.cpp
@@ -1026,3 +1026,16 @@ void GitRebase::interactiveContinue()
     m_isCherryPickActive = false;
     QTimer::singleShot(0, this, &GitRebase::processNextOperation);
 }
+
+void GitRebase::interactiveSkip()
+{
+    if (!m_interactiveInProgress || !m_isCherryPickActive)
+        return;
+
+    // Abort the cherry‑pick (reset index and worktree)
+    abortCherryPick();
+    emit rebaseOperationSkipped(m_currentOpHash);
+    m_currentPlanIndex++;
+    m_isCherryPickActive = false;
+    QTimer::singleShot(0, this, &GitRebase::processNextOperation);
+}

--- a/Src/Git/GitRebase.cpp
+++ b/Src/Git/GitRebase.cpp
@@ -761,3 +761,140 @@ QString GitRebase::getCurrentBranchName()
 
     return branchName;  // "main", "master", or Detached HEAD if detached
 }
+
+void GitRebase::startInteractiveRebase(const QString& onto,
+                                       const QString& upstream,
+                                       const QString& branch,
+                                       const QVariantList& operations)
+{
+    if (m_interactiveInProgress) {
+        emit rebaseFinished(false);
+        return;
+    }
+
+    if (!m_currentRepo || !m_currentRepo->repo) {
+        emit rebaseFinished(false);
+        return;
+    }
+
+    if (isRebaseInProgress()) {
+        emit rebaseFinished(false);
+        return;
+    }
+
+    // Check for uncommitted changes
+    git_status_list* statusList = nullptr;
+    git_status_options statusOpts = GIT_STATUS_OPTIONS_INIT;
+    statusOpts.flags = GIT_STATUS_OPT_INCLUDE_UNTRACKED;
+    if (git_status_list_new(&statusList, m_currentRepo->repo, &statusOpts) == GIT_OK) {
+        size_t count = git_status_list_entrycount(statusList);
+        git_status_list_free(statusList);
+        if (count > 0) {
+            cleanupInteractiveState();
+            emit rebaseFinished(false);
+            return;
+        }
+    }
+
+    // Store the plan
+    m_interactivePlan = operations;
+
+    m_interactiveOnto     = onto.trimmed();
+    m_interactiveUpstream = upstream.trimmed();
+    m_interactiveBranch   = branch.trimmed();
+
+    // Save original HEAD reference
+    git_reference* headRef = nullptr;
+    if (git_repository_head(&headRef, m_currentRepo->repo) == GIT_OK) {
+        m_originalHeadRef = headRef;
+    } else {
+        m_originalHeadRef = nullptr;
+    }
+
+    if (m_originalHeadRef == nullptr) {
+        // Detached HEAD – save the commit OID
+        git_oid headOid;
+        if (git_reference_name_to_id(&headOid, m_currentRepo->repo, "HEAD") == GIT_OK) {
+            m_originalHeadOid = headOid;
+            m_originalHeadDetached = true;
+        } else {
+            // Should not happen, but if it does, abort
+            cleanupInteractiveState();
+            emit rebaseFinished(false);
+            return;
+        }
+    } else {
+        m_originalHeadDetached = false;
+    }
+
+    // Checkout target branch if necessary
+    QString actualBranch = m_interactiveBranch;
+    bool hasBranch = !actualBranch.isEmpty();
+    if (hasBranch) {
+        QString currentBranch = getCurrentBranchName();
+        if (currentBranch != actualBranch) {
+            GitResult checkoutRes = checkoutBranch(actualBranch);
+            if (!checkoutRes.success()) {
+                cleanupInteractiveState();
+                emit rebaseFinished(false);
+                return;
+            }
+        }
+        actualBranch.clear(); // after checkout we use HEAD
+    }
+
+    // Resolve the new base commit
+    QString baseRef = m_interactiveOnto.isEmpty() ? m_interactiveUpstream : m_interactiveOnto;
+    if (baseRef.isEmpty()) {
+        cleanupInteractiveState();
+        emit rebaseFinished(false);
+        return;
+    }
+
+    git_object* baseObj = nullptr;
+    int result = git_revparse_single(&baseObj, m_currentRepo->repo, baseRef.toUtf8().constData());
+    if (result != GIT_OK || !baseObj) {
+        cleanupInteractiveState();
+        emit rebaseFinished(false);
+        return;
+    }
+
+    // It must be a commit
+    if (git_object_type(baseObj) != GIT_OBJ_COMMIT) {
+        git_object_free(baseObj);
+        cleanupInteractiveState();
+        emit rebaseFinished(false);
+        return;
+    }
+
+    m_newBaseCommit = reinterpret_cast<git_commit*>(baseObj); // we own it now
+
+    // Checkout the new base (detach HEAD)
+    git_checkout_options checkoutOpts = GIT_CHECKOUT_OPTIONS_INIT;
+    checkoutOpts.checkout_strategy = GIT_CHECKOUT_SAFE | GIT_CHECKOUT_RECREATE_MISSING;
+    result = git_checkout_tree(m_currentRepo->repo, reinterpret_cast<git_object*>(m_newBaseCommit), &checkoutOpts);
+    if (result != GIT_OK) {
+        cleanupInteractiveState();
+        emit rebaseFinished(false);
+        return;
+    }
+
+    // Set HEAD to the new base commit (detached)
+    result = git_repository_set_head_detached(m_currentRepo->repo, git_commit_id(m_newBaseCommit));
+    if (result != GIT_OK) {
+        cleanupInteractiveState();
+        emit rebaseFinished(false);
+        return;
+    }
+
+    // Create default committer signature
+    git_signature* sig = nullptr;
+    if (git_signature_default(&sig, m_currentRepo->repo) == GIT_OK) {
+        m_defaultSignature = sig;
+    }
+
+    // Kick off processing
+    m_interactiveInProgress = true;
+    m_currentPlanIndex = 0;
+    QTimer::singleShot(0, this, &GitRebase::processNextOperation);
+}

--- a/Src/Git/GitRebase.cpp
+++ b/Src/Git/GitRebase.cpp
@@ -1164,23 +1164,31 @@ bool GitRebase::commitCherryPick(git_commit* originalCommit)
 
 void GitRebase::abortCherryPick()
 {
-    // Reset index and worktree to HEAD
-    git_object* headObj = nullptr;
-    if (git_revparse_single(&headObj, m_currentRepo->repo, "HEAD") != GIT_OK)
+    if (!m_currentRepo || !m_currentRepo->repo)
         return;
 
-    git_checkout_options opts = GIT_CHECKOUT_OPTIONS_INIT;
-    opts.checkout_strategy = GIT_CHECKOUT_FORCE | GIT_CHECKOUT_RECREATE_MISSING;
-    git_checkout_tree(m_currentRepo->repo, headObj, &opts);
-    git_object_free(headObj);
+    git_repository* repo = m_currentRepo->repo;
 
-    // Also reset the index
+    git_object* headObj = nullptr;
+    if (git_revparse_single(&headObj, repo, "HEAD") == GIT_OK) {
+        git_checkout_options opts = GIT_CHECKOUT_OPTIONS_INIT;
+
+        opts.checkout_strategy = GIT_CHECKOUT_FORCE | GIT_CHECKOUT_RECREATE_MISSING;
+        git_checkout_tree(repo, headObj, &opts);
+        git_object_free(headObj);
+    }
+
     git_index* index = nullptr;
-    if (git_repository_index(&index, m_currentRepo->repo) == GIT_OK) {
-        git_index_read(index, true); // force reload from disk
+    if (git_repository_index(&index, repo) == GIT_OK) {
+        git_index_read(index, true);
+        git_index_conflict_cleanup(index);
+        git_index_write(index);
         git_index_free(index);
     }
+
+    git_repository_state_cleanup(repo);
 }
+
 
 bool GitRebase::resetToCommit(git_commit* target)
 {

--- a/Src/Git/GitRebase.cpp
+++ b/Src/Git/GitRebase.cpp
@@ -240,7 +240,7 @@ GitResult GitRebase::previewRebasePlan(const QString& onto,
     data["commits"] = commits;
     data["upstream"] = upstream.trimmed();
     data["onto"] = onto.trimmed();
-    data["branch"] = branchSpec;
+    data["branch"] = branch.trimmed();
     data["supportedActions"] = QStringList{ "pick", "skip" };
 
     return GitResult(true, data);

--- a/Src/Git/GitRebase.cpp
+++ b/Src/Git/GitRebase.cpp
@@ -1091,3 +1091,16 @@ void GitRebase::interactiveAbort()
     cleanupInteractiveState();
     emit rebaseAborted();
 }
+
+git_commit* GitRebase::lookupCommit(const QString& hash) const
+{
+    git_oid oid;
+    if (git_oid_fromstr(&oid, hash.toUtf8().constData()) != GIT_OK)
+        return nullptr;
+
+    git_commit* commit = nullptr;
+    if (git_commit_lookup(&commit, m_currentRepo->repo, &oid) != GIT_OK)
+        return nullptr;
+
+    return commit;
+}

--- a/Src/Git/GitRebase.cpp
+++ b/Src/Git/GitRebase.cpp
@@ -238,6 +238,28 @@ GitResult GitRebase::previewRebasePlan(const QString& onto,
     return GitResult(true, data);
 }
 
+GitResult GitRebase::rebaseWithPlan(const QString& onto,
+                                    const QString& upstream,
+                                    QString branch,
+                                    const QVariantList& operations)
+{
+    QSet<QString> skippedCommits;
+
+    for (const QVariant& operationVariant : operations) {
+        const QVariantMap operation = operationVariant.toMap();
+        const QString hash          = operation.value("hash").toString();
+        const QString action        = operation.value("action").toString().trimmed().toLower();
+
+        if (hash.isEmpty())
+            continue;
+
+        if (action == "skip")
+            skippedCommits.insert(hash);
+    }
+
+    return startRebase(onto, upstream, branch, skippedCommits);
+}
+
 GitResult GitRebase::continueOp()
 {
     if (!m_currentRepo || !m_currentRepo->repo) {

--- a/Src/Git/GitRebase.cpp
+++ b/Src/Git/GitRebase.cpp
@@ -1033,44 +1033,34 @@ void GitRebase::interactiveAbort()
     if (m_isCherryPickActive) {
         abortCherryPick();
     }
+    else if (m_currentRepo && m_currentRepo->repo) {
+        git_repository_state_cleanup(m_currentRepo->repo);
+    }
 
     // Reset to the original HEAD
     if (m_originalHeadRef) {
         git_object* target = nullptr;
         if (git_reference_peel(&target, m_originalHeadRef, GIT_OBJ_COMMIT) == GIT_OK) {
-            // Checkout the tree first
             git_checkout_options opts = GIT_CHECKOUT_OPTIONS_INIT;
             opts.checkout_strategy = GIT_CHECKOUT_SAFE | GIT_CHECKOUT_RECREATE_MISSING;
+
             git_checkout_tree(m_currentRepo->repo, target, &opts);
-            // Then reset HEAD to the original ref
+
             git_repository_set_head(m_currentRepo->repo, git_reference_name(m_originalHeadRef));
+
             git_object_free(target);
         }
-    } else {
-        if (m_originalHeadDetached) {
-            // Reset to the original detached commit
-            git_commit* target = nullptr;
-            if (git_commit_lookup(&target, m_currentRepo->repo, &m_originalHeadOid) == GIT_OK) {
-                resetToCommit(target);
-                git_commit_free(target);
-            }
-        } else if (m_originalHeadRef) {
-            // Reset to the original branch
-            git_object* target = nullptr;
-            if (git_reference_peel(&target, m_originalHeadRef, GIT_OBJ_COMMIT) == GIT_OK) {
-                resetToCommit(reinterpret_cast<git_commit*>(target));
-                git_object_free(target);
-            }
-            // Checkout the branch and update HEAD
-            git_checkout_options opts = GIT_CHECKOUT_OPTIONS_INIT;
-            opts.checkout_strategy = GIT_CHECKOUT_SAFE | GIT_CHECKOUT_RECREATE_MISSING;
-            if (git_reference_peel(&target, m_originalHeadRef, GIT_OBJ_COMMIT) == GIT_OK) {
-                git_checkout_tree(m_currentRepo->repo, target, &opts);
-                git_object_free(target);
-            }
-            git_repository_set_head(m_currentRepo->repo, git_reference_name(m_originalHeadRef));
+    }
+    else if (m_originalHeadDetached) {
+        // Reset to the original detached commit
+        git_commit* target = nullptr;
+        if (git_commit_lookup(&target, m_currentRepo->repo, &m_originalHeadOid) == GIT_OK) {
+            resetToCommit(target);
+            git_commit_free(target);
         }
     }
+
+    git_repository_state_cleanup(m_currentRepo->repo);
 
     cleanupInteractiveState();
     emit rebaseAborted();

--- a/Src/Git/GitRebase.cpp
+++ b/Src/Git/GitRebase.cpp
@@ -1187,3 +1187,23 @@ bool GitRebase::commitCherryPick(git_commit* originalCommit)
 
     return true;
 }
+
+void GitRebase::abortCherryPick()
+{
+    // Reset index and worktree to HEAD
+    git_object* headObj = nullptr;
+    if (git_revparse_single(&headObj, m_currentRepo->repo, "HEAD") != GIT_OK)
+        return;
+
+    git_checkout_options opts = GIT_CHECKOUT_OPTIONS_INIT;
+    opts.checkout_strategy = GIT_CHECKOUT_FORCE | GIT_CHECKOUT_RECREATE_MISSING;
+    git_checkout_tree(m_currentRepo->repo, headObj, &opts);
+    git_object_free(headObj);
+
+    // Also reset the index
+    git_index* index = nullptr;
+    if (git_repository_index(&index, m_currentRepo->repo) == GIT_OK) {
+        git_index_read(index, true); // force reload from disk
+        git_index_free(index);
+    }
+}

--- a/Src/Git/GitRebase.cpp
+++ b/Src/Git/GitRebase.cpp
@@ -147,28 +147,6 @@ GitResult GitRebase::previewRebasePlan(const QString& onto,
     return GitResult(true, data);
 }
 
-GitResult GitRebase::rebaseWithPlan(const QString& onto,
-                                    const QString& upstream,
-                                    QString branch,
-                                    const QVariantList& operations)
-{
-    QSet<QString> skippedCommits;
-
-    for (const QVariant& operationVariant : operations) {
-        const QVariantMap operation = operationVariant.toMap();
-        const QString hash          = operation.value("hash").toString();
-        const QString action        = operation.value("action").toString().trimmed().toLower();
-
-        if (hash.isEmpty())
-            continue;
-
-        if (action == "skip")
-            skippedCommits.insert(hash);
-    }
-
-    return startRebase(onto, upstream, branch, skippedCommits);
-}
-
 GitResult GitRebase::startRebase(const QString& onto,
                                  const QString& upstream,
                                  QString branch,

--- a/Src/Git/GitRebase.h
+++ b/Src/Git/GitRebase.h
@@ -87,7 +87,10 @@ private:
                           QString branch,
                           const QSet<QString>& skippedCommits);
 
-    GitResult runRebase(git_rebase* rebase, bool continueCurrentOperation);
+    GitResult runRebase(git_rebase* rebase,
+                        bool continueCurrentOperation,
+                        const QSet<QString>& skippedCommits = {});
+
     GitResult conflictResult(git_rebase* rebase, const QString& message);
     GitResult openRebase(git_rebase** rebase) const;
     QVariantMap rebaseProgressData(git_rebase* rebase) const;

--- a/Src/Git/GitRebase.h
+++ b/Src/Git/GitRebase.h
@@ -82,6 +82,11 @@ public:
     Q_INVOKABLE GitResult rebaseStatus();
 
 private:
+    GitResult startRebase(const QString& onto,
+                          const QString& upstream,
+                          QString branch,
+                          const QSet<QString>& skippedCommits);
+
     GitResult runRebase(git_rebase* rebase, bool continueCurrentOperation);
     GitResult conflictResult(git_rebase* rebase, const QString& message);
     GitResult openRebase(git_rebase** rebase) const;

--- a/Src/Git/GitRebase.h
+++ b/Src/Git/GitRebase.h
@@ -89,7 +89,7 @@ public:
      * @param branch      Optional branch to rebase (empty = current HEAD).
      * @param operations  The interactive plan in user‑specified order.
      */
-    Q_INVOKABLE void startInteractiveRebase(const QString& onto,
+    Q_INVOKABLE GitResult startInteractiveRebase(const QString& onto,
                                             const QString& upstream,
                                             const QString& branch,
                                             const QVariantList& operations);

--- a/Src/Git/GitRebase.h
+++ b/Src/Git/GitRebase.h
@@ -55,6 +55,11 @@ public:
                                      const QString& upstream,
                                      QString branch = QString());
 
+    /// Build an interactive rebase plan without changing the repository.
+    Q_INVOKABLE GitResult previewRebasePlan(const QString& onto,
+                                            const QString& upstream,
+                                            const QString& branch = QString());
+
     /// Continue an in-progress rebase (`git rebase --continue`).
     Q_INVOKABLE GitResult continueOp();
 

--- a/Src/Git/GitRebase.h
+++ b/Src/Git/GitRebase.h
@@ -60,6 +60,12 @@ public:
                                             const QString& upstream,
                                             const QString& branch = QString());
 
+    /// Start a rebase using a prepared plan. Supported actions: pick, skip.
+    Q_INVOKABLE GitResult rebaseWithPlan(const QString& onto,
+                                         const QString& upstream,
+                                         QString branch,
+                                         const QVariantList& operations);
+
     /// Continue an in-progress rebase (`git rebase --continue`).
     Q_INVOKABLE GitResult continueOp();
 

--- a/Src/Git/GitRebase.h
+++ b/Src/Git/GitRebase.h
@@ -60,11 +60,6 @@ public:
                                             const QString& upstream,
                                             const QString& branch = QString());
 
-    /// Start a rebase using a prepared plan. Supported actions: pick, skip.
-    Q_INVOKABLE GitResult rebaseWithPlan(const QString& onto,
-                                         const QString& upstream,
-                                         QString branch,
-                                         const QVariantList& operations);
 
     /// Continue an in-progress rebase (`git rebase --continue`).
     Q_INVOKABLE GitResult continueOp();
@@ -80,6 +75,45 @@ public:
 
     /// Return details about current rebase progress/conflicts.
     Q_INVOKABLE GitResult rebaseStatus();
+
+    /**
+     * @brief Start an interactive rebase driven by a user‑provided plan.
+     *
+     * The plan (operations) is an array of QVariantMap objects, each
+     * containing at minimum "action" (string: "pick"/"skip") and "hash".
+     * The commits are applied **in the order they appear in the array**,
+     * giving the UI full control over the sequence.
+     *
+     * @param onto        New base commit. If empty, upstream is used as the base.
+     * @param upstream    Upstream boundary (only used if onto is empty).
+     * @param branch      Optional branch to rebase (empty = current HEAD).
+     * @param operations  The interactive plan in user‑specified order.
+     */
+    Q_INVOKABLE void startInteractiveRebase(const QString& onto,
+                                            const QString& upstream,
+                                            const QString& branch,
+                                            const QVariantList& operations);
+
+    /**
+     * @brief Continue the interactive rebase after the user has resolved conflicts.
+     *
+     * This must only be called when the rebase is in a conflict state
+     * (after rebaseConflict() was emitted).
+     */
+    Q_INVOKABLE void interactiveContinue();
+
+    /**
+     * @brief Skip the current operation and move to the next one.
+     *
+     * Any conflicting changes are discarded.
+     */
+    Q_INVOKABLE void interactiveSkip();
+
+    /**
+     * @brief Abort the entire interactive rebase and return to the
+     *        original state before the rebase started.
+     */
+    Q_INVOKABLE void interactiveAbort();
 
 private:
     GitResult startRebase(const QString& onto,
@@ -101,4 +135,123 @@ private:
     // Helper to check out a branch
     GitResult checkoutBranch(const QString& branchName);
     QString getCurrentBranchName();
+
+
+    /**
+     * @brief Process the next entry in the plan.
+     *
+     * This function implements the main step‑by‑step loop of the
+     * interactive rebase.  For each entry it either skips the commit
+     * or cherry‑picks it.  It reschedules itself via QTimer::singleShot
+     * to keep the event loop responsive.
+     */
+    void processNextOperation();
+
+    /**
+     * @brief Release all resources held by the interactive rebase session.
+     */
+    void cleanupInteractiveState();
+
+    /**
+     * @brief Look up a commit by its full SHA-1 hash.
+     * @param hash 40-character hex string.
+     * @return The commit object (caller must free with git_commit_free), or nullptr.
+     */
+    git_commit* lookupCommit(const QString& hash) const;
+
+    /**
+     * @brief Perform a cherry‑pick of a commit onto the current HEAD.
+     *
+     * The cherry‑pick only stages the changes; a separate commit step
+     * is required to finalise it.
+     *
+     * @param commit  Commit to cherry‑pick.
+     * @return GIT_OK on success, GIT_EMERGECONFLICT if conflicts occur,
+     *         or another error code.
+     */
+    int cherryPickCommit(git_commit* commit);
+
+    /**
+     * @brief Create a commit from the current index, preserving the
+     *        original author and message of the cherry‑picked commit.
+     *
+     * @param originalCommit  The commit that was cherry‑picked.
+     * @return true on success.
+     */
+    bool commitCherryPick(git_commit* originalCommit);
+
+    /**
+     * @brief Abort an in‑progress cherry‑pick by resetting the index
+     *        and worktree to HEAD.
+     */
+    void abortCherryPick();
+
+    /**
+     * @brief Reset HEAD and worktree to the given commit, discarding
+     *        all local changes (used during abort).
+     */
+    bool resetToCommit(git_commit* target);
+
+    QVariantList    m_interactivePlan;                  ///< Full plan as received from the UI.
+    bool            m_interactiveInProgress = false;    ///< True while an interactive rebase is active.
+    QString         m_interactiveOnto;                  ///< --onto reference (empty if not used).
+    QString         m_interactiveUpstream;              ///< Upstream reference.
+    QString         m_interactiveBranch;                ///< Branch being rebased (empty = HEAD).
+
+    git_commit*     m_newBaseCommit         = nullptr;  ///< The commit onto which we rebase.
+    git_reference*  m_originalHeadRef       = nullptr;  ///< Original HEAD before the rebase started.
+    int             m_currentPlanIndex      = 0;        ///< Current position in m_interactivePlan.
+    QString         m_currentOpHash;                    ///< Hash of the commit currently being processed.
+    bool            m_isCherryPickActive    = false;    ///< True while a cherry‑pick is in progress (possibly conflicted).
+
+    git_oid         m_originalHeadOid;                  ///< Original HEAD commit OID (if detached).
+    bool            m_originalHeadDetached;             ///< True if we started from a detached HEAD.
+
+    git_signature*  m_defaultSignature      = nullptr;
+
+signals:
+    /**
+     * @brief Emitted when a rebase operation begins for a commit.
+     *
+     * @param commitHash Full SHA‑1 hash of the commit being processed.
+     */
+    void rebaseOperationStarted(const QString& commitHash);
+
+    /**
+     * @brief Emitted after a commit has been successfully applied.
+     *
+     * @param commitHash Full SHA‑1 hash of the rebased commit.
+     */
+    void rebaseOperationCompleted(const QString& commitHash);
+
+    /**
+     * @brief Emitted when a commit is skipped during the rebase.
+     *
+     * @param commitHash Full SHA‑1 hash of the skipped commit.
+     */
+    void rebaseOperationSkipped(const QString& commitHash);
+
+    /**
+     * @brief Emitted when a rebase operation stops due to conflicts.
+     *
+     * The UI should prompt the user to resolve conflicts and then call
+     * `interactiveContinue()` or `interactiveSkip()`.
+     *
+     * @param commitHash Full SHA‑1 hash of the commit that caused the conflict.
+     */
+    void rebaseConflict(const QString& commitHash);
+
+    /**
+     * @brief Emitted when the interactive rebase finishes.
+     *
+     * @param success True if the rebase completed successfully,
+     *                false if it failed.
+     */
+    void rebaseFinished(bool success);
+
+    /**
+     * @brief Emitted when the user aborts the interactive rebase.
+     */
+    void rebaseAborted();
+
 };


### PR DESCRIPTION
## Summary

This PR implements a fully interactive rebase workflow with real-time progress feedback.  
Instead of the previous one-shot blocking rebase, users can now see a list of commits that will be replayed, choose **pick** or **skip** per commit, watch each commit’s status change live (Pending → In Progress → Rebased / Skipped / Conflict), and resolve conflicts interactively without leaving the popup.

The feature works from both the **Rebase dock** and the **Commit Graph** context menu.

---

## Architecture

The interactive rebase is built as a **plan‑driven, step‑by‑step cherry‑pick engine** that runs on the main thread using `QTimer::singleShot` to keep the UI responsive.

1. **Preview**  
   `GitRebase::previewRebasePlan` walks `upstream..branch` and returns an ordered list of commits.  
   Already‑applied commits are detected using patch‑id and automatically marked as **skip**.

2. **User edits the plan**  
   `CommitPlanPopup` displays the list. The user can change any commit’s action to **pick** or **skip** before starting.

3. **Execution**  
   When the user clicks **Start Rebase**, the popup sends the entire plan to `startInteractiveRebase`.  
   The backend detaches HEAD at the new base and applies each commit **in the exact order of the plan** using `git_cherrypick`.  
   After each commit, a progress signal is emitted.

4. **Progress feedback**  
   The popup listens to signals (`rebaseOperationStarted`, `rebaseOperationCompleted`, `rebaseOperationSkipped`, `rebaseConflict`) and updates a **Status** column in real time, scrolling to the active commit.

5. **Conflict resolution**  
   When a conflict occurs, the existing `ConflictPopup` is opened in **interactive mode**.  
   The popup’s Continue / Skip / Abort buttons emit an `interactiveActionRequested` signal instead of calling the old non‑interactive controller methods.  
   The `CommitPlanPopup` then calls `interactiveContinue`, `interactiveSkip`, or `interactiveAbort` on the rebase controller, which resumes the step‑by‑step loop.

6. **Completion / Abort**  
   On success, the original branch is updated to the new HEAD.  
   On abort, a hard reset restores the working tree and index to the original state.  
   The popup stays open after completion, showing a final report.

---

## Key changes

### Backend (`GitRebase.h` / `GitRebase.cpp`)

- New public methods: `startInteractiveRebase` (returns `GitResult` for immediate error reporting), `interactiveContinue`, `interactiveSkip`, `interactiveAbort`.
- New signals: `rebaseOperationStarted`, `rebaseOperationCompleted`, `rebaseOperationSkipped`, `rebaseConflict`, `rebaseFinished`, `rebaseAborted`.
- New private helpers: `processNextOperation`, `lookupCommit`, `cherryPickCommit`, `commitCherryPick`, `abortCherryPick`, `resetToCommit`, `cleanupInteractiveState`.
- Improved abort: uses `git_reset` with `GIT_RESET_HARD` to fully clean the working tree and index.

### UI – `CommitPlanPopup.qml`

- Rebuilt from a simple plan viewer into a live interactive dashboard.
- Enumerations for commit status, rebase state, and action types.
- Status column (visible during and after rebase) with colour‑coded labels.
- ComboBox locked during execution; initial action correctly read from the model.
- Signal connections for live progress updates, conflict popup integration, and retry logic.
- On failure, the user can retry without re‑opening the popup.

### UI – `ConflictPopup.qml`

- Added `interactiveMode` property and `interactiveActionRequested` signal.
- `continueOperation`, `skipOperation`, `abortOperation` now emit the signal when interactive mode is on, instead of calling the non‑interactive controller.

### UI – `RebaseDock.qml`

- Now uses `previewRebase` → `CommitPlanPopup` instead of a direct blocking rebase.

### UI – `CommitGraphDock.qml`

- Rebase context menu action now opens the interactive plan popup instead of executing a blocking rebase.
- Passes required controllers to `CommitPlanPopup`.

---

## How to test

1. **Rebase dock**  
   - Fill in an upstream, optionally a branch, click **Start Rebase**.  
   - Verify the plan popup shows the correct commits.  
   - Change some actions to “skip”, then click **Start Rebase**.  
   - Watch the status column update live.  
   - To test conflicts: create conflicting changes on the branch and the upstream.

2. **Graph dock**  
   - Right‑click a commit → **Rebase onto this commit**.  
   - The same interactive plan popup appears.  
   - Verify the rebase proceeds correctly (the branch parameter is empty, meaning “current HEAD”).