### PR TITLE
256-257-stashing specific file-stashing specific lines of a file

### DIFF
--- a/Qml/Core/Controllers/StashController.qml
+++ b/Qml/Core/Controllers/StashController.qml
@@ -6,6 +6,22 @@ import GitEase
  * StashController
  * ************************************************************************************************/
 GitStash {
+    property StatusController statusController
 
+    function stashLines(filePath, startLine, endLine, mode) {
+        let content = statusController.buildSelectedLinesContent(filePath, startLine, endLine, mode)
+        if (!content || content.length === 0) {
+            return
+        }
+
+        let message = (startLine === endLine) ? `Stash line ${startLine} of ${filePath}` : `Stash lines ${startLine}-${endLine} of ${filePath}`
+        let result = stashSelectedLines(filePath, message, content)
+        if(result.success)
+        {
+            statusController.revertSelectedLines(filePath, startLine, endLine, mode)
+        }
+
+        return result
+    }
 }
 

--- a/Qml/Pages/CommittingPage.qml
+++ b/Qml/Pages/CommittingPage.qml
@@ -534,6 +534,16 @@ Item {
                 }
                 changesFileLists.updateStatus()
             }
+
+            onRequestStash: function (start, end, type) {
+                let res = root.stashController.stashLines(root.selectedFilePath, start, end, type)
+                if (res.success) {
+                    root.notificationController.success("Selected lines stashed", "Stash", 2000)
+                } else {
+                    root.notificationController.error(res.errorMessage || "Failed to stash selected lines", "Stash Error", 5000)
+                }
+                changesFileLists.updateStatus()
+            }
         }
 
         // Non-visual loader: fetches the plugin's colorizer QtObject

--- a/Qml/UiCore/UiSession.qml
+++ b/Qml/UiCore/UiSession.qml
@@ -89,6 +89,7 @@ QtObject {
     }
 
     property StashController  stashController : StashController  {
+        statusController: root.statusController
         onGitCommandGenerated: function(command){
             activityController.addActivity(command)
         }

--- a/Qml/View/Components/Diff/DiffView.qml
+++ b/Qml/View/Components/Diff/DiffView.qml
@@ -35,7 +35,7 @@ DetachablePanel {
      * ****************************************************************************************/
     signal requestStage(int start, int end, int type)
     signal requestRevert(int start, int end, int type)
-
+    signal requestStash(int start, int end, int type)
 
     /* Children
      * ****************************************************************************************/
@@ -155,6 +155,7 @@ DetachablePanel {
                     onRequestFocusPrev: diffListView.currentIndex = index - 1
                     onRequestStage: (start, end, type) => root.requestStage(start, end, type)
                     onRequestRevert: (start, end, type) => root.requestRevert(start, end, type)
+                    onRequestStash: (start, end, type) => root.requestStash(start, end, type)
                 }
             }
         }

--- a/Qml/View/Components/FileLists/ChangesFileLists.qml
+++ b/Qml/View/Components/FileLists/ChangesFileLists.qml
@@ -112,7 +112,7 @@ Item {
             }
 
             onStashFileRequested: function(filePath) {
-                let res = stashController.saveFile(filePath)
+                let res = stashController.stashFile(filePath)
                 if (res.success) {
                     root.notificationController.success("File stashed: " + filePath, "Stash File", 3000)
                 } else {

--- a/Qml/View/Components/FileLists/ChangesFileLists.qml
+++ b/Qml/View/Components/FileLists/ChangesFileLists.qml
@@ -111,6 +111,16 @@ Item {
                 root.updateStatus()
             }
 
+            onStashFileRequested: function(filePath) {
+                let res = stashController.saveFile(filePath)
+                if (res.success) {
+                    root.notificationController.success("File stashed: " + filePath, "Stash File", 3000)
+                } else {
+                    root.notificationController.error(res.errorMessage || "Failed to stash file", "Stash Error", 5000)
+                }
+                root.updateStatus()
+            }
+
             onDiscardFileRequested: function(filePath) {
                 let res = statusController.revertFile(filePath)
                 if (res.success) {

--- a/Qml/View/Components/FileLists/ChangesFileLists.qml
+++ b/Qml/View/Components/FileLists/ChangesFileLists.qml
@@ -112,7 +112,8 @@ Item {
             }
 
             onStashFileRequested: function(filePath) {
-                let res = stashController.stashFile(filePath)
+                let message = "Stashing file: " + filePath
+                let res = stashController.stashFile(filePath, message)
                 if (res.success) {
                     root.notificationController.success("File stashed: " + filePath, "Stash File", 3000)
                 } else {

--- a/Qml/View/Components/FileLists/UnstagedFileListRow.qml
+++ b/Qml/View/Components/FileLists/UnstagedFileListRow.qml
@@ -23,6 +23,7 @@ FileListRow {
     signal stageRequested(string filePath)
     signal discardRequested(string filePath)
     signal openRequested(string filePath)
+    signal stashRequested(string filePath)
 
     /* Children
      * ****************************************************************************************/
@@ -43,6 +44,13 @@ FileListRow {
                 NumberAnimation {
                     duration: 100
                 }
+            }
+
+            ActionIconButton {
+                iconText: Style.icons.archive
+                tooltip: "Stash file"
+                textColor: Style.colors.mutedText
+                onClicked: root.stashRequested(root.filePath)
             }
 
             ActionIconButton {

--- a/Qml/View/Components/FileLists/UnstagedFileListRow.qml
+++ b/Qml/View/Components/FileLists/UnstagedFileListRow.qml
@@ -48,9 +48,16 @@ FileListRow {
 
             ActionIconButton {
                 iconText: Style.icons.archive
-                tooltip: "Stash file"
+                tooltip: "Stash"
                 textColor: Style.colors.mutedText
                 onClicked: root.stashRequested(root.filePath)
+            }
+
+            ActionIconButton {
+                iconText: Style.icons.trash
+                tooltip: "Discard"
+                textColor: Style.colors.error
+                onClicked: root.discardRequested(root.filePath)
             }
 
             ActionIconButton {
@@ -60,13 +67,6 @@ FileListRow {
                             Qt.darker(Style.colors.addedFile, 1.5) :
                             Qt.lighter(Style.colors.addedFile, 1.5)
                 onClicked: root.stageRequested(root.filePath)
-            }
-
-            ActionIconButton {
-                iconText: Style.icons.trash
-                tooltip: "Discard"
-                textColor: Style.colors.error
-                onClicked: root.discardRequested(root.filePath)
             }
 
             ActionIconButton {

--- a/Qml/View/Components/FileLists/UnstagedFileListSection.qml
+++ b/Qml/View/Components/FileLists/UnstagedFileListSection.qml
@@ -22,6 +22,7 @@ FileListSection {
     signal stageFileRequested(string filePath)
     signal discardFileRequested(string filePath)
     signal openFileRequested(string filePath)
+    signal stashFileRequested(string filePath)
     signal stageAllRequested()
     signal discardAllRequested()
     signal stashAllRequested()
@@ -80,6 +81,10 @@ FileListSection {
 
             onDiscardRequested: function(filePath) {
                 root.discardFileRequested(filePath)
+            }
+
+            onStashRequested: function(filePath) {
+                root.stashFileRequested(filePath)
             }
 
             onOpenRequested: function(filePath) {

--- a/Qml/View/Components/Repository/SideBySideDiff.qml
+++ b/Qml/View/Components/Repository/SideBySideDiff.qml
@@ -61,12 +61,13 @@ Item {
     signal requestFocusPrev()
     signal requestStage(int start, int end, int type)
     signal requestRevert(int start, int end, int type)
+    signal requestStash(int start, int end, int type)
 
     /* Object Properties
      * ****************************************************************************************/
 
     // Auto-height based on content
-    height: Math.max(hasAction ? 50 : 24, Math.max(leftTextMetrics.height, rightTextEdit.contentHeight + 4))
+    height: Math.max(hasAction ? 90 : 24, Math.max(leftTextMetrics.height, rightTextEdit.contentHeight + 4))
 
     onIsCurrentItemChanged: {
         if (isCurrentItem && !isDel) {
@@ -210,6 +211,29 @@ Item {
                             let range = getRange()
 
                             requestRevert(range.start, range.end, range.type);
+                        }
+                    }
+                }
+
+                Label {
+                    text: Style.icons.archive
+                    font.family: Style.fontTypes.font6ProSolid
+                    color: stashMsa.containsMouse ? Style.colors.secondaryForeground : Qt.darker(Style.colors.secondaryForeground, 1.4)
+                    padding: 5
+                    background: Rectangle {
+                        color: stashMsa.containsMouse ? Style.colors.accent : Qt.darker(Style.colors.linePanelBackgroound, 1.05)
+                        radius: 5
+                    }
+
+                    MouseArea {
+                        id: stashMsa
+                        anchors.fill: parent
+                        hoverEnabled: true
+                        cursorShape: "PointingHandCursor"
+                        onClicked: {
+                            let range = getRange()
+
+                            requestStash(range.start, range.end, range.type);
                         }
                     }
                 }

--- a/Qml/View/Components/Repository/SideBySideDiff.qml
+++ b/Qml/View/Components/Repository/SideBySideDiff.qml
@@ -170,7 +170,7 @@ Item {
                 Label {
                     text: Style.icons.plus
                     font.family: Style.fontTypes.font6ProSolid
-                    color: stageMsa.containsMouse ? Style.colors.secondaryForeground : Qt.darker(Style.colors.secondaryForeground, 1.4)
+                    color: stageMsa.containsMouse ? Style.colors.secondaryForeground : Style.colors.secondaryText
                     padding: 5
                     background: Rectangle {
                         color: stageMsa.containsMouse ? Style.colors.accent : Qt.darker(Style.colors.linePanelBackgroound, 1.05)
@@ -195,7 +195,7 @@ Item {
                 Label {
                     text: Style.icons.arrowRight
                     font.family: Style.fontTypes.font6ProSolid
-                    color: revertMsa.containsMouse ? Style.colors.secondaryForeground : Qt.darker(Style.colors.secondaryForeground, 1.4)
+                    color: revertMsa.containsMouse ? Style.colors.secondaryForeground : Style.colors.secondaryText
                     padding: 5
                     background: Rectangle {
                         color: revertMsa.containsMouse ? Style.colors.accent : Qt.darker(Style.colors.linePanelBackgroound, 1.05)
@@ -218,7 +218,7 @@ Item {
                 Label {
                     text: Style.icons.archive
                     font.family: Style.fontTypes.font6ProSolid
-                    color: stashMsa.containsMouse ? Style.colors.secondaryForeground : Qt.darker(Style.colors.secondaryForeground, 1.4)
+                    color: stashMsa.containsMouse ? Style.colors.secondaryForeground : Style.colors.secondaryText
                     padding: 5
                     background: Rectangle {
                         color: stashMsa.containsMouse ? Style.colors.accent : Qt.darker(Style.colors.linePanelBackgroound, 1.05)

--- a/Src/Git/GitStash.cpp
+++ b/Src/Git/GitStash.cpp
@@ -313,7 +313,6 @@ GitResult GitStash::stashSelectedLines(const QString &filePath, const QString &m
         git_commit_free(headCommit);
     };
 
-    // Hold the QByteArray in a named variable — constData() pointer must outlive the call
     QByteArray blobBytes = blob.toUtf8();
     git_oid blobOid;
     if (git_blob_create_frombuffer(&blobOid, repo,

--- a/Src/Git/GitStash.cpp
+++ b/Src/Git/GitStash.cpp
@@ -73,9 +73,12 @@ static bool buildModifiedTree(git_oid *out, git_repository *repo,
     }
 
     git_blob *blob = nullptr;
-    git_blob_lookup(&blob, repo, fileOid);
-    git_off_t blobSize = blob ? git_blob_rawsize(blob) : 0;
-    if (blob) git_blob_free(blob);
+    if (git_blob_lookup(&blob, repo, fileOid) != GIT_OK) {
+        git_index_free(idx);
+        return false;
+    }
+    git_off_t blobSize = git_blob_rawsize(blob);
+    git_blob_free(blob);
 
     git_index_entry entry = {};
     entry.path      = path;
@@ -93,7 +96,108 @@ static bool buildModifiedTree(git_oid *out, git_repository *repo,
     return rc == GIT_OK;
 }
 
-GitResult GitStash::saveFile(const QString &filePath, const QString &message)
+// Resolves HEAD to a commit and retrieves the three resources needed by stash
+static GitResult getHeadContext(git_repository *repo, git_commit **headCommit,
+                                git_signature **sig, git_tree **headTree)
+{
+    git_object *headObj = nullptr;
+    if (git_revparse_single(&headObj, repo, "HEAD") != GIT_OK)
+        return GitResult(false, {}, "No HEAD commit found.");
+
+    git_object *peeled = nullptr;
+    if (git_object_peel(&peeled, headObj, GIT_OBJECT_COMMIT) != GIT_OK) {
+        git_object_free(headObj);
+        return GitResult(false, {}, "HEAD does not resolve to a commit.");
+    }
+    git_object_free(headObj);
+    *headCommit = (git_commit *)peeled;
+
+    if (git_signature_default(sig, repo) != GIT_OK) {
+        git_commit_free(*headCommit);
+        return GitResult(false, {}, "Failed to create signature.");
+    }
+
+    if (git_commit_tree(headTree, *headCommit) != GIT_OK) {
+        git_signature_free(*sig);
+        git_commit_free(*headCommit);
+        return GitResult(false, {}, "Failed to get HEAD tree.");
+    }
+
+    return GitResult(true, {}, "");
+}
+
+// Builds the two commits that make up a git stash entry and points refs/stash at the result.
+static GitResult createStashCommits(
+    git_repository *repo,
+    git_commit *headCommit,
+    git_signature *sig,
+    const git_oid *wipTreeOid,
+    const git_oid *indexTreeOid,
+    const QString &message)
+{
+    git_reference *headRef = nullptr;
+    QString branch = "HEAD";
+    if (git_repository_head(&headRef, repo) == GIT_OK) {
+        if (git_reference_is_branch(headRef))
+            branch = QString::fromUtf8(git_reference_shorthand(headRef));
+        git_reference_free(headRef);
+    }
+
+    char shortHash[9] = {};
+    git_oid_tostr(shortHash, 8, git_commit_id(headCommit));
+    QString summary  = QString::fromUtf8(git_commit_summary(headCommit));
+    QString stashMsg = message.isEmpty()
+                           ? QString("WIP on %1: %2 %3").arg(branch, shortHash, summary)
+                           : message;
+    QString indexMsg = QString("index on %1: %2 %3").arg(branch, shortHash, summary);
+
+    // Index commit
+    git_tree *indexTree = nullptr;
+    if (git_tree_lookup(&indexTree, repo, indexTreeOid) != GIT_OK)
+        return GitResult(false, {}, "Failed to lookup index tree.");
+
+    git_oid indexCommitOid;
+    const git_commit *indexParents[] = { headCommit };
+    int rc = git_commit_create(&indexCommitOid, repo, nullptr, sig, sig,
+                               "UTF-8", indexMsg.toUtf8().constData(),
+                               indexTree, 1, indexParents);
+    git_tree_free(indexTree);
+    if (rc != GIT_OK)
+        return GitResult(false, {}, "Failed to create index commit.");
+
+    // WIP commit
+    git_commit *indexCommit = nullptr;
+    if (git_commit_lookup(&indexCommit, repo, &indexCommitOid) != GIT_OK)
+        return GitResult(false, {}, "Failed to lookup index commit.");
+
+    git_tree *wipTree = nullptr;
+    if (git_tree_lookup(&wipTree, repo, wipTreeOid) != GIT_OK) {
+        git_commit_free(indexCommit);
+        return GitResult(false, {}, "Failed to lookup WIP tree.");
+    }
+
+    git_oid wipOid;
+    const git_commit *wipParents[] = { headCommit, indexCommit };
+    rc = git_commit_create(&wipOid, repo, nullptr, sig, sig,
+                           "UTF-8", stashMsg.toUtf8().constData(),
+                           wipTree, 2, wipParents);
+    git_tree_free(wipTree);
+    git_commit_free(indexCommit);
+    if (rc != GIT_OK)
+        return GitResult(false, {}, "Failed to create stash commit.");
+
+    // Update refs/stash
+    git_reference *stashRef = nullptr;
+    int refRc = git_reference_create(&stashRef, repo, "refs/stash", &wipOid, 1,
+                                     stashMsg.toUtf8().constData());
+    if (stashRef) git_reference_free(stashRef);
+    if (refRc != GIT_OK)
+        return GitResult(false, {}, "Failed to update refs/stash.");
+
+    return GitResult(true, {}, "");
+}
+
+GitResult GitStash::stashFile(const QString &filePath, const QString &message)
 {
     if (!m_currentRepo || !m_currentRepo->repo)
         return GitResult(false, {}, "Repository not found.");
@@ -102,102 +206,73 @@ GitResult GitStash::saveFile(const QString &filePath, const QString &message)
     QByteArray pathBytes = filePath.toUtf8();
     const char *path = pathBytes.constData();
 
-    // HEAD commit
-    git_object *headObj = nullptr;
-    if (git_revparse_single(&headObj, repo, "HEAD") != GIT_OK)
-        return GitResult(false, {}, "No HEAD commit found.");
-    git_commit *headCommit = (git_commit *)headObj;
-
+    git_commit *headCommit = nullptr;
     git_signature *sig = nullptr;
-    if (git_signature_default(&sig, repo) != GIT_OK) {
-        git_commit_free(headCommit);
-        return GitResult(false, {}, "Failed to create signature.");
-    }
-
     git_tree *headTree = nullptr;
-    if (git_commit_tree(&headTree, headCommit) != GIT_OK) {
-        git_signature_free(sig); git_commit_free(headCommit);
-        return GitResult(false, {}, "Failed to get HEAD tree.");
-    }
+    GitResult ctx = getHeadContext(repo, &headCommit, &sig, &headTree);
+    if (!ctx.success())
+        return ctx;
+
+    auto cleanup = [&]() {
+        git_tree_free(headTree);
+        git_signature_free(sig);
+        git_commit_free(headCommit);
+    };
 
     // Blob from workdir
     git_oid blobOid;
     if (git_blob_create_from_workdir(&blobOid, repo, path) != GIT_OK) {
-        git_tree_free(headTree); git_signature_free(sig); git_commit_free(headCommit);
+        cleanup();
         return GitResult(false, {}, git_error_last() ? git_error_last()->message : "Failed to read file.");
     }
 
-    // WIP tree: HEAD tree with workdir file version
+    // WIP tree
     git_oid wipTreeOid;
     if (!buildModifiedTree(&wipTreeOid, repo, headTree, path, &blobOid)) {
-        git_tree_free(headTree); git_signature_free(sig); git_commit_free(headCommit);
+        cleanup();
         return GitResult(false, {}, "Failed to build WIP tree.");
     }
 
-    // Index tree: HEAD tree with staged file version (if staged)
+    // Index tree: compare staged blob against HEAD blob for this path
     git_index *repoIdx = nullptr;
     git_repository_index(&repoIdx, repo);
     git_index_read(repoIdx, 1);
     const git_index_entry *staged = git_index_get_bypath(repoIdx, path, 0);
 
     git_oid indexTreeOid;
-    if (staged && git_oid_cmp(&staged->id, git_tree_id(headTree)) != 0) {
-        buildModifiedTree(&indexTreeOid, repo, headTree, path, &staged->id);
+    bool hasDistinctStagedVersion = false;
+
+    if (staged) {
+        // Look up the blob OID for this path in the HEAD tree
+        git_tree_entry *headEntry = nullptr;
+        if (git_tree_entry_bypath(&headEntry, headTree, path) == GIT_OK) {
+            hasDistinctStagedVersion =
+                git_oid_cmp(&staged->id, git_tree_entry_id(headEntry)) != 0;
+            git_tree_entry_free(headEntry);
+        } else {
+            // File didn't exist in HEAD, so staging it is definitely a change
+            hasDistinctStagedVersion = true;
+        }
+    }
+
+    if (hasDistinctStagedVersion) {
+        if (!buildModifiedTree(&indexTreeOid, repo, headTree, path, &staged->id)) {
+            git_index_free(repoIdx);
+            cleanup();
+            return GitResult(false, {}, "Failed to build index tree.");
+        }
     } else {
         git_oid_cpy(&indexTreeOid, git_tree_id(headTree));
     }
     git_index_free(repoIdx);
 
-    // Build stash messages
-    git_reference *headRef = nullptr;
-    QString branch = "HEAD";
-    if (git_repository_head(&headRef, repo) == GIT_OK) {
-        if (git_reference_is_branch(headRef))
-            branch = QString::fromUtf8(git_reference_shorthand(headRef));
-        git_reference_free(headRef);
-    }
-    char shortHash[9] = {};
-    git_oid_tostr(shortHash, 8, git_commit_id(headCommit));
-    QString summary  = QString::fromUtf8(git_commit_summary(headCommit));
-    QString stashMsg = message.isEmpty()
-        ? QString("WIP on %1: %2 %3").arg(branch, shortHash, summary)
-        : message;
-    QString indexMsg = QString("index on %1: %2 %3").arg(branch, shortHash, summary);
+    GitResult result = createStashCommits(repo, headCommit, sig, &wipTreeOid, &indexTreeOid, message);
+    cleanup();
 
-    // Index commit (parent: HEAD)
-    git_tree *indexTree = nullptr;
-    git_tree_lookup(&indexTree, repo, &indexTreeOid);
-    git_oid indexCommitOid;
-    const git_commit *indexParents[] = { headCommit };
-    int rc = git_commit_create(&indexCommitOid, repo, nullptr, sig, sig,
-        "UTF-8", indexMsg.toUtf8().constData(), indexTree, 1, indexParents);
-    git_tree_free(indexTree);
-    if (rc != GIT_OK) {
-        git_tree_free(headTree); git_signature_free(sig); git_commit_free(headCommit);
-        return GitResult(false, {}, "Failed to create index commit.");
-    }
+    if (!result.success())
+        return result;
 
-    // WIP commit (parents: HEAD, indexCommit)
-    git_commit *indexCommit = nullptr;
-    git_commit_lookup(&indexCommit, repo, &indexCommitOid);
-    git_tree *wipTree = nullptr;
-    git_tree_lookup(&wipTree, repo, &wipTreeOid);
-    git_oid wipOid;
-    const git_commit *wipParents[] = { headCommit, indexCommit };
-    rc = git_commit_create(&wipOid, repo, nullptr, sig, sig,
-        "UTF-8", stashMsg.toUtf8().constData(), wipTree, 2, wipParents);
-    git_tree_free(wipTree); git_tree_free(headTree);
-    git_commit_free(indexCommit); git_signature_free(sig); git_commit_free(headCommit);
-    if (rc != GIT_OK)
-        return GitResult(false, {}, "Failed to create stash commit.");
-
-    // Update refs/stash (force=1 updates reflog automatically)
-    git_reference *stashRef = nullptr;
-    git_reference_create(&stashRef, repo, "refs/stash", &wipOid, 1,
-                         stashMsg.toUtf8().constData());
-    if (stashRef) git_reference_free(stashRef);
-
-    // reset index entry to HEAD (safe, path-limited)
+    // Reset index entry to HEAD
     const char *pathspecs[] = { path };
     git_strarray pathArr = { const_cast<char **>(pathspecs), 1 };
     git_object *headForReset = nullptr;
@@ -206,15 +281,92 @@ GitResult GitStash::saveFile(const QString &filePath, const QString &message)
         git_object_free(headForReset);
     }
 
-    // checkout workdir from (now HEAD-state) index — same pattern as revertFile
+    // Checkout workdir from index
     git_checkout_options coOpts = GIT_CHECKOUT_OPTIONS_INIT;
-    coOpts.checkout_strategy = GIT_CHECKOUT_FORCE
-                             | GIT_CHECKOUT_DISABLE_PATHSPEC_MATCH;
+    coOpts.checkout_strategy = GIT_CHECKOUT_FORCE | GIT_CHECKOUT_DISABLE_PATHSPEC_MATCH;
     coOpts.paths = pathArr;
     git_checkout_index(repo, nullptr, &coOpts);
 
     emitGitCommand(QString("git stash push -- %1").arg(filePath));
     return GitResult(true, {}, QString("File stashed: %1").arg(filePath));
+}
+
+GitResult GitStash::stashSelectedLines(const QString &filePath, const QString &message, const QString &blob)
+{
+    if (!m_currentRepo || !m_currentRepo->repo)
+        return GitResult(false, {}, "Repository not found.");
+
+    git_repository *repo = m_currentRepo->repo;
+    QByteArray pathBytes = filePath.toUtf8();
+    const char *path = pathBytes.constData();
+
+    git_commit *headCommit = nullptr;
+    git_signature *sig = nullptr;
+    git_tree *headTree = nullptr;
+    GitResult ctx = getHeadContext(repo, &headCommit, &sig, &headTree);
+    if (!ctx.success())
+        return ctx;
+
+    auto cleanup = [&]() {
+        git_tree_free(headTree);
+        git_signature_free(sig);
+        git_commit_free(headCommit);
+    };
+
+    // Hold the QByteArray in a named variable — constData() pointer must outlive the call
+    QByteArray blobBytes = blob.toUtf8();
+    git_oid blobOid;
+    if (git_blob_create_frombuffer(&blobOid, repo,
+                                   blobBytes.constData(), blobBytes.size()) != GIT_OK) {
+        cleanup();
+        return GitResult(false, {}, "Failed to create blob from selected lines.");
+    }
+
+    // Build WIP tree
+    git_oid wipTreeOid;
+    if (!buildModifiedTree(&wipTreeOid, repo, headTree, path, &blobOid)) {
+        cleanup();
+        return GitResult(false, {}, "Failed to build WIP tree.");
+    }
+
+    // Build index tree — compare staged blob against HEAD blob for this path
+    git_index *repoIdx = nullptr;
+    git_repository_index(&repoIdx, repo);
+    git_index_read(repoIdx, 1);
+    const git_index_entry *staged = git_index_get_bypath(repoIdx, path, 0);
+
+    git_oid indexTreeOid;
+    bool hasDistinctStagedVersion = false;
+
+    if (staged) {
+        git_tree_entry *headEntry = nullptr;
+        if (git_tree_entry_bypath(&headEntry, headTree, path) == GIT_OK) {
+            hasDistinctStagedVersion =
+                git_oid_cmp(&staged->id, git_tree_entry_id(headEntry)) != 0;
+            git_tree_entry_free(headEntry);
+        } else {
+            hasDistinctStagedVersion = true;
+        }
+    }
+
+    if (hasDistinctStagedVersion) {
+        if (!buildModifiedTree(&indexTreeOid, repo, headTree, path, &staged->id)) {
+            git_index_free(repoIdx);
+            cleanup();
+            return GitResult(false, {}, "Failed to build index tree.");
+        }
+    } else {
+        git_oid_cpy(&indexTreeOid, git_tree_id(headTree));
+    }
+    git_index_free(repoIdx);
+
+    GitResult result = createStashCommits(repo, headCommit, sig, &wipTreeOid, &indexTreeOid, message);
+    cleanup();
+    if (!result.success())
+        return result;
+
+    emitGitCommand(QString("git stash push -- %1").arg(filePath));
+    return GitResult(true, {}, "Selected lines stashed successfully.");
 }
 
 GitResult GitStash::list()

--- a/Src/Git/GitStash.cpp
+++ b/Src/Git/GitStash.cpp
@@ -1,4 +1,13 @@
 #include "GitStash.h"
+#include <git2/strarray.h>
+#include <git2/blob.h>
+#include <git2/index.h>
+#include <git2/refs.h>
+#include <git2/revparse.h>
+#include <git2/checkout.h>
+#include <git2/reset.h>
+#include <git2/tree.h>
+#include <git2/oid.h>
 
 GitStash::GitStash(QObject *parent)
     : IGitController{parent}
@@ -48,6 +57,165 @@ GitResult GitStash::save(const QString &message, bool keepIndex)
     return GitResult(true, {}, "Stash saved successfully.");
 }
 
+
+// Build a tree that is identical to baseTree except for one file replaced by fileOid.
+// Handles nested paths by using an in-memory index.
+static bool buildModifiedTree(git_oid *out, git_repository *repo,
+                              git_tree *baseTree, const char *path,
+                              const git_oid *fileOid)
+{
+    git_index *idx = nullptr;
+    if (git_index_new(&idx) != GIT_OK) return false;
+
+    if (git_index_read_tree(idx, baseTree) != GIT_OK) {
+        git_index_free(idx);
+        return false;
+    }
+
+    git_blob *blob = nullptr;
+    git_blob_lookup(&blob, repo, fileOid);
+    git_off_t blobSize = blob ? git_blob_rawsize(blob) : 0;
+    if (blob) git_blob_free(blob);
+
+    git_index_entry entry = {};
+    entry.path      = path;
+    entry.mode      = GIT_FILEMODE_BLOB;
+    entry.file_size = (uint32_t)blobSize;
+    git_oid_cpy(&entry.id, fileOid);
+
+    if (git_index_add(idx, &entry) != GIT_OK) {
+        git_index_free(idx);
+        return false;
+    }
+
+    int rc = git_index_write_tree_to(out, idx, repo);
+    git_index_free(idx);
+    return rc == GIT_OK;
+}
+
+GitResult GitStash::saveFile(const QString &filePath, const QString &message)
+{
+    if (!m_currentRepo || !m_currentRepo->repo)
+        return GitResult(false, {}, "Repository not found.");
+
+    git_repository *repo = m_currentRepo->repo;
+    QByteArray pathBytes = filePath.toUtf8();
+    const char *path = pathBytes.constData();
+
+    // HEAD commit
+    git_object *headObj = nullptr;
+    if (git_revparse_single(&headObj, repo, "HEAD") != GIT_OK)
+        return GitResult(false, {}, "No HEAD commit found.");
+    git_commit *headCommit = (git_commit *)headObj;
+
+    git_signature *sig = nullptr;
+    if (git_signature_default(&sig, repo) != GIT_OK) {
+        git_commit_free(headCommit);
+        return GitResult(false, {}, "Failed to create signature.");
+    }
+
+    git_tree *headTree = nullptr;
+    if (git_commit_tree(&headTree, headCommit) != GIT_OK) {
+        git_signature_free(sig); git_commit_free(headCommit);
+        return GitResult(false, {}, "Failed to get HEAD tree.");
+    }
+
+    // Blob from workdir
+    git_oid blobOid;
+    if (git_blob_create_from_workdir(&blobOid, repo, path) != GIT_OK) {
+        git_tree_free(headTree); git_signature_free(sig); git_commit_free(headCommit);
+        return GitResult(false, {}, git_error_last() ? git_error_last()->message : "Failed to read file.");
+    }
+
+    // WIP tree: HEAD tree with workdir file version
+    git_oid wipTreeOid;
+    if (!buildModifiedTree(&wipTreeOid, repo, headTree, path, &blobOid)) {
+        git_tree_free(headTree); git_signature_free(sig); git_commit_free(headCommit);
+        return GitResult(false, {}, "Failed to build WIP tree.");
+    }
+
+    // Index tree: HEAD tree with staged file version (if staged)
+    git_index *repoIdx = nullptr;
+    git_repository_index(&repoIdx, repo);
+    git_index_read(repoIdx, 1);
+    const git_index_entry *staged = git_index_get_bypath(repoIdx, path, 0);
+
+    git_oid indexTreeOid;
+    if (staged && git_oid_cmp(&staged->id, git_tree_id(headTree)) != 0) {
+        buildModifiedTree(&indexTreeOid, repo, headTree, path, &staged->id);
+    } else {
+        git_oid_cpy(&indexTreeOid, git_tree_id(headTree));
+    }
+    git_index_free(repoIdx);
+
+    // Build stash messages
+    git_reference *headRef = nullptr;
+    QString branch = "HEAD";
+    if (git_repository_head(&headRef, repo) == GIT_OK) {
+        if (git_reference_is_branch(headRef))
+            branch = QString::fromUtf8(git_reference_shorthand(headRef));
+        git_reference_free(headRef);
+    }
+    char shortHash[9] = {};
+    git_oid_tostr(shortHash, 8, git_commit_id(headCommit));
+    QString summary  = QString::fromUtf8(git_commit_summary(headCommit));
+    QString stashMsg = message.isEmpty()
+        ? QString("WIP on %1: %2 %3").arg(branch, shortHash, summary)
+        : message;
+    QString indexMsg = QString("index on %1: %2 %3").arg(branch, shortHash, summary);
+
+    // Index commit (parent: HEAD)
+    git_tree *indexTree = nullptr;
+    git_tree_lookup(&indexTree, repo, &indexTreeOid);
+    git_oid indexCommitOid;
+    const git_commit *indexParents[] = { headCommit };
+    int rc = git_commit_create(&indexCommitOid, repo, nullptr, sig, sig,
+        "UTF-8", indexMsg.toUtf8().constData(), indexTree, 1, indexParents);
+    git_tree_free(indexTree);
+    if (rc != GIT_OK) {
+        git_tree_free(headTree); git_signature_free(sig); git_commit_free(headCommit);
+        return GitResult(false, {}, "Failed to create index commit.");
+    }
+
+    // WIP commit (parents: HEAD, indexCommit)
+    git_commit *indexCommit = nullptr;
+    git_commit_lookup(&indexCommit, repo, &indexCommitOid);
+    git_tree *wipTree = nullptr;
+    git_tree_lookup(&wipTree, repo, &wipTreeOid);
+    git_oid wipOid;
+    const git_commit *wipParents[] = { headCommit, indexCommit };
+    rc = git_commit_create(&wipOid, repo, nullptr, sig, sig,
+        "UTF-8", stashMsg.toUtf8().constData(), wipTree, 2, wipParents);
+    git_tree_free(wipTree); git_tree_free(headTree);
+    git_commit_free(indexCommit); git_signature_free(sig); git_commit_free(headCommit);
+    if (rc != GIT_OK)
+        return GitResult(false, {}, "Failed to create stash commit.");
+
+    // Update refs/stash (force=1 updates reflog automatically)
+    git_reference *stashRef = nullptr;
+    git_reference_create(&stashRef, repo, "refs/stash", &wipOid, 1,
+                         stashMsg.toUtf8().constData());
+    if (stashRef) git_reference_free(stashRef);
+
+    // reset index entry to HEAD (safe, path-limited)
+    const char *pathspecs[] = { path };
+    git_strarray pathArr = { const_cast<char **>(pathspecs), 1 };
+    git_object *headForReset = nullptr;
+    if (git_revparse_single(&headForReset, repo, "HEAD") == GIT_OK) {
+        git_reset_default(repo, headForReset, &pathArr);
+        git_object_free(headForReset);
+    }
+
+    // checkout workdir from (now HEAD-state) index — same pattern as revertFile
+    git_checkout_options coOpts = GIT_CHECKOUT_OPTIONS_INIT;
+    coOpts.checkout_strategy = GIT_CHECKOUT_FORCE
+                             | GIT_CHECKOUT_DISABLE_PATHSPEC_MATCH;
+    coOpts.paths = pathArr;
+    git_checkout_index(repo, nullptr, &coOpts);
+
+    emitGitCommand(QString("git stash push -- %1").arg(filePath));
+    return GitResult(true, {}, QString("File stashed: %1").arg(filePath));
+}
 
 GitResult GitStash::list()
 {

--- a/Src/Git/GitStash.h
+++ b/Src/Git/GitStash.h
@@ -26,7 +26,8 @@ public:
      * \param keepIndex Whether to keep staged changes in index
      * \return GitResult
      */
-    Q_INVOKABLE GitResult save(const QString &message = "", bool keepIndex = false);
+    Q_INVOKABLE GitResult save    (const QString &message = "", bool keepIndex = false);
+    Q_INVOKABLE GitResult saveFile(const QString &filePath, const QString &message = "");
 
     /**
      * \brief Get list of all stashes

--- a/Src/Git/GitStash.h
+++ b/Src/Git/GitStash.h
@@ -26,8 +26,24 @@ public:
      * \param keepIndex Whether to keep staged changes in index
      * \return GitResult
      */
-    Q_INVOKABLE GitResult save    (const QString &message = "", bool keepIndex = false);
-    Q_INVOKABLE GitResult saveFile(const QString &filePath, const QString &message = "");
+    Q_INVOKABLE GitResult save(const QString &message = "", bool keepIndex = false);
+
+    /**
+     * \brief Stahes the selected file
+     * \param filePath Selected file path
+     * \param message Optional stash message
+     * \return GitResult
+     */
+    Q_INVOKABLE GitResult stashFile(const QString &filePath, const QString &message = "");
+
+    /**
+     * \brief Stahes the selected lines of a file
+     * \param filePath Selected file path
+     * \param message Optional stash message
+     * \param blob The file content representing the partial state to be stored in the stash.
+     * \return GitResult
+     */
+    Q_INVOKABLE GitResult stashSelectedLines(const QString &filePath, const QString &message, const QString &blob);
 
     /**
      * \brief Get list of all stashes

--- a/Src/Git/GitStatus.cpp
+++ b/Src/Git/GitStatus.cpp
@@ -900,49 +900,12 @@ GitResult GitStatus::stageSelectedLines(const QString &filePath, int startLine, 
     if (!m_currentRepo || !m_currentRepo->repo)
         return GitResult(false, QVariant(), "No repository available.");
 
-    const git_delta_t type = static_cast<git_delta_t>(mode);
+    QString stagedText = buildSelectedLinesContent(filePath, startLine, endLine, mode);
+    if (stagedText.isEmpty())
+        return GitResult(false, QVariant(), "Failed to build selected lines.");
+
     uint32_t baseMode = 0;
-    auto indexBlob = getIndexBlob(m_currentRepo->repo, filePath, &baseMode);
-
-    if (!indexBlob) {
-        return GitResult(false, QVariant(), "File does not exist in the index.");
-    }
-
-    const auto indexLines = readBlobLines(indexBlob.get());
-
-    git_diff* diffRaw = nullptr;
-    git_diff_options diffOpts = GIT_DIFF_OPTIONS_INIT;
-    diffOpts.flags |= (GIT_DIFF_PATIENCE | GIT_DIFF_MINIMAL);
-
-    // If the file is physically gone (DELETED), we need a diff that represents the
-    // total removal, so we can pick which "removals" to stage.
-    if (type == GIT_DELTA_DELETED) {
-        git_diff_index_to_workdir(&diffRaw, m_currentRepo->repo, nullptr, &diffOpts);
-    } else {
-        QByteArray pathUtf8 = filePath.toUtf8();
-        char* path = const_cast<char*>(pathUtf8.constData());
-        diffOpts.pathspec.strings = &path;
-        diffOpts.pathspec.count = 1;
-        git_diff_index_to_workdir(&diffRaw, m_currentRepo->repo, nullptr, &diffOpts);
-    }
-
-    UniqueDiff diff(diffRaw);
-    git_patch* patchRaw = nullptr;
-    if (git_patch_from_diff(&patchRaw, diff.get(), 0) != GIT_OK)
-        return GitResult(false, QVariant(), "Could not generate patch for selection.");
-
-    UniquePatch patch(patchRaw);
-
-    const auto stagedLines = applySelectedFromPatch(indexLines, patch.get(), startLine, endLine);
-    QString stagedText = joinLines(stagedLines);
-
-    const char* rawContent = static_cast<const char*>(git_blob_rawcontent(indexBlob.get()));
-    git_object_size_t rawSize = git_blob_rawsize(indexBlob.get());
-    QByteArray originalData = QByteArray::fromRawData(rawContent, static_cast<int>(rawSize));
-
-    if (originalData.contains("\r\n")) {
-        stagedText.replace("\n", "\r\n");
-    }
+    getIndexBlob(m_currentRepo->repo, filePath, &baseMode);
 
     GitResult writeResult = writeIndexFromBuffer(m_currentRepo->repo, filePath, stagedText.toUtf8(), baseMode);
     if (writeResult.success()) {
@@ -950,6 +913,48 @@ GitResult GitStatus::stageSelectedLines(const QString &filePath, int startLine, 
     }
 
     return writeResult;
+}
+
+QString GitStatus::buildSelectedLinesContent(const QString &filePath, int startLine, int endLine, int mode)
+{
+    const git_delta_t type = static_cast<git_delta_t>(mode);
+    uint32_t baseMode = 0;
+    auto indexBlob = getIndexBlob(m_currentRepo->repo, filePath, &baseMode);
+    if (!indexBlob)
+        return {};
+
+    const auto indexLines = readBlobLines(indexBlob.get());
+
+    git_diff *diffRaw = nullptr;
+    git_diff_options diffOpts = GIT_DIFF_OPTIONS_INIT;
+    diffOpts.flags |= (GIT_DIFF_PATIENCE | GIT_DIFF_MINIMAL);
+
+    if (type == GIT_DELTA_DELETED) {
+        git_diff_index_to_workdir(&diffRaw, m_currentRepo->repo, nullptr, &diffOpts);
+    } else {
+        QByteArray pathUtf8 = filePath.toUtf8();
+        char *path = const_cast<char *>(pathUtf8.constData());
+        diffOpts.pathspec.strings = &path;
+        diffOpts.pathspec.count = 1;
+        git_diff_index_to_workdir(&diffRaw, m_currentRepo->repo, nullptr, &diffOpts);
+    }
+
+    UniqueDiff diff(diffRaw);
+    git_patch *patchRaw = nullptr;
+    if (git_patch_from_diff(&patchRaw, diff.get(), 0) != GIT_OK)
+        return {};
+
+    UniquePatch patch(patchRaw);
+    const auto selectedLines = applySelectedFromPatch(indexLines, patch.get(), startLine, endLine);
+    QString selectedText = joinLines(selectedLines);
+
+    const char *rawContent = static_cast<const char *>(git_blob_rawcontent(indexBlob.get()));
+    git_object_size_t rawSize = git_blob_rawsize(indexBlob.get());
+    QByteArray originalData = QByteArray::fromRawData(rawContent, static_cast<int>(rawSize));
+    if (originalData.contains("\r\n"))
+        selectedText.replace("\n", "\r\n");
+
+    return selectedText;
 }
 
 GitResult GitStatus::writeIndexFromBuffer(git_repository* repo,

--- a/Src/Git/GitStatus.h
+++ b/Src/Git/GitStatus.h
@@ -144,6 +144,21 @@ public:
     Q_INVOKABLE GitResult stageSelectedLines(const QString &filePath, int startLine, int endLine, int mode);
 
     /**
+     * @brief Builds the file content for a partial line selection.
+     *
+     * Generates a new version of the file by applying only the selected line
+     * changes from the working directory to the index version of the file.
+     *
+     * @param filePath Relative path of the file.
+     * @param startLine The first line number in the selection.
+     * @param endLine The last line number in the selection.
+     * @param mode The Git delta type (1: Added, 2: Deleted, 4: Modified).
+     * @return The generated file content, or an empty string if the content
+     *         could not be constructed.
+     */
+    Q_INVOKABLE QString buildSelectedLinesContent(const QString &filePath, int startLine, int endLine, int mode);
+
+    /**
      * @brief Discards all unstaged changes in a file, resetting it to the index state.
      * @param filePath Path to the file to revert.
      * @return GitResult indicating success or failure.


### PR DESCRIPTION
## Summary
Added the ability to stash a file or specific lines of a file in committing page

## Changes
- Functions `stashFile`  `stashSelectedLines` implemented in `GitStash.cpp`
- `buildSelectedLinesContent` is added in `GitStatus.cpp` to be used as a part of `stashLines` function in qml
- statusController passed as a property to stashController
- `stashLines` in stashController includes calling `buildSelectedLinesContent`, `stashSelectedLines` , `revertSelectedLines`

## Notes
The stashing functionality behaves the same as Git: both staged and unstaged changes to the file are stashed.