### PR TITLE
378-program-crashes-after-switching-between-committing-page-and-graphview

### DIFF
--- a/Qml/Core/Scripts/CommitGraphDataLoader.js
+++ b/Qml/Core/Scripts/CommitGraphDataLoader.js
@@ -6,7 +6,7 @@
 
 // Global map for commit hashes whose branch names will be resolved in later
 // pages. Needed for pagination. Entries are removed once processed.
-let branchAssignmentByHash = {};
+let branchAssignmentByHash = new Map();
 
 /**
  * Compiles graph‑ready commits from raw controller data.
@@ -101,24 +101,24 @@ function compileGraphCommits(rawCommits, rawBranches, rawStashes, allTags, appSe
 
         let branchNames = []
         if (haveBranchName) {
-            branchNames = tipHashToBranches[commit.hash]
-            for (var pr = 0; pr < commit.parentHashes.length ; ++pr) {
-                if (!branchAssignmentByHash[commit.parentHashes[pr]])
-                    branchAssignmentByHash[commit.parentHashes[pr]] = branchNames
+            branchNames = tipHashToBranches[commit.hash];
+            for (let pr = 0; pr < commit.parentHashes.length; ++pr) {
+                if (!branchAssignmentByHash.has(commit.parentHashes[pr]))
+                    branchAssignmentByHash.set(commit.parentHashes[pr], branchNames);
             }
         }
 
         if (!haveBranchName) {
-            if (branchAssignmentByHash && branchAssignmentByHash[commit.hash]) {
-                branchNames = branchAssignmentByHash[commit.hash]
+            if (branchAssignmentByHash.has(commit.hash)) {
+                branchNames = branchAssignmentByHash.get(commit.hash)
 
-                for (var pr1 = 0; pr1 < commit.parentHashes.length ; ++pr1) {
-                    if (!branchAssignmentByHash[commit.parentHashes[pr1]])
-                        branchAssignmentByHash[commit.parentHashes[pr1]] = branchNames
+                for (let pr1 = 0; pr1 < commit.parentHashes.length; ++pr1) {
+                    if (!branchAssignmentByHash.has(commit.parentHashes[pr1]))
+                        branchAssignmentByHash.set(commit.parentHashes[pr1], branchNames)
                 }
 
                 // delete used key
-                delete branchAssignmentByHash[commit.hash]
+                branchAssignmentByHash.delete(commit.hash);
             }
         }
 

--- a/Qml/Core/Scripts/CommitGraphDataLoader.js
+++ b/Qml/Core/Scripts/CommitGraphDataLoader.js
@@ -104,7 +104,7 @@ function compileGraphCommits(rawCommits, rawBranches, rawStashes, allTags, appSe
             branchNames = tipHashToBranches[commit.hash];
             for (let pr = 0; pr < commit.parentHashes.length; ++pr) {
                 if (!branchAssignmentByHash.has(commit.parentHashes[pr]))
-                    branchAssignmentByHash.set(commit.parentHashes[pr], branchNames);
+                    branchAssignmentByHash.set(commit.parentHashes[pr], branchNames)
             }
         }
 
@@ -118,7 +118,7 @@ function compileGraphCommits(rawCommits, rawBranches, rawStashes, allTags, appSe
                 }
 
                 // delete used key
-                branchAssignmentByHash.delete(commit.hash);
+                branchAssignmentByHash.delete(commit.hash)
             }
         }
 


### PR DESCRIPTION
## Summary
Fixes #378 - Program crashes after switching between the committing page and GraphView.

---

##  Root Cause
The crash was caused by:
- deleting the key of  branchAssignmentByHash

---

## Solution
This PR fixes the issue by:
- using Map() instead of plain object `let branchAssignmentByHash = new Map();`


