### PR TITLE
414 feature/maintain scroll position conflict resolver

### DIFF
--- a/Qml/Core/Scripts/ConflictPopupUtils.js
+++ b/Qml/Core/Scripts/ConflictPopupUtils.js
@@ -223,3 +223,33 @@ function mergeLineUp(displayModel, rowIndex, conflictListView) {
     conflictListView.currentIndex = rowIndex - 1;
 }
 
+/**
+ * Finds the start and end indices of a conflict block in the display model.
+ * @param model      - ListModel to search
+ * @param blockIndex - The block's index property (1‑based)
+ * @returns { start: number, end: number } or { start: -1, end: -1 } if not found
+ */
+function findBlockRowRange(model, blockIndex) {
+    let start = -1, end = -1
+    for (let i = 0; i < model.count; ++i) {
+        if (model.get(i).blockIndex === blockIndex) {
+            if (start < 0) start = i
+            end = i
+        }
+    }
+    return { start, end }
+}
+
+/**
+ * Finds a block object in an array by its index property.
+ * @param blocks - Array of block objects (from selectedConflict.blocks)
+ * @param idx    - The index property to look for
+ * @returns { block: object, pos: number } or null
+ */
+function findBlockByIndex(blocks, idx) {
+    for (let i = 0; i < blocks.length; ++i) {
+        if (blocks[i].index === idx)
+            return { block: blocks[i], pos: i }
+    }
+    return null
+}

--- a/Qml/Core/Scripts/ConflictPopupUtils.js
+++ b/Qml/Core/Scripts/ConflictPopupUtils.js
@@ -329,11 +329,11 @@ function replaceBlockInModel(displayModel, blockIndex, block, resolvedLines) {
 /**
  * Updates the remaining blocks array after one block is resolved.
  * Renumbers indices and shifts line references accordingly.
- * @param blocks       - The blocks array (selectedConflict.blocks)
- * @param blockIndex   - The resolved block's original index
- * @param resolvedPos  - Position of the resolved block in the array
- * @param lineDelta    - Number of lines gained/lost
- * @param blockEndLine - The original endLine of the resolved block
+ * @param selectedConflict  - The conflict object (must have a blocks array)
+ * @param blockIndex        - The resolved block's original index
+ * @param resolvedPos       - Position of the resolved block in the array
+ * @param lineDelta         - Number of lines gained/lost
+ * @param blockEndLine      - The original endLine of the resolved block
  */
 function updateRemainingBlocks(selectedConflict, blockIndex, resolvedPos, lineDelta, blockEndLine) {
     for (let i = 0; i < selectedConflict.blocks.length; ++i) {

--- a/Qml/Core/Scripts/ConflictPopupUtils.js
+++ b/Qml/Core/Scripts/ConflictPopupUtils.js
@@ -253,3 +253,117 @@ function findBlockByIndex(blocks, idx) {
     }
     return null
 }
+
+/**
+ * Returns the lines that should replace a resolved conflict block.
+ * @param block - The block object (with currentText, incomingText)
+ * @param mode  - "ours", "theirs", or "both"
+ * @returns String[] of resolved lines
+ */
+function computeResolvedLines(block, mode) {
+    if (mode === "ours")
+        return block.currentText  ? block.currentText.split("\n")  : []
+
+    if (mode === "theirs")
+        return block.incomingText ? block.incomingText.split("\n") : []
+
+    if (mode === "both") {
+        let ours   = block.currentText  ? block.currentText.split("\n")  : []
+        let theirs = block.incomingText ? block.incomingText.split("\n") : []
+        return ours.concat(theirs)
+    }
+
+    return []
+}
+
+/**
+ * Replaces a conflict block's rows in the displayModel with resolved lines.
+ * Also updates line numbers and blockIndex values of subsequent rows.
+ * @param displayModel  - The ListModel
+ * @param blockIndex    - The block's index (1‑based)
+ * @param block         - The block object (needs startLine, endLine)
+ * @param resolvedLines - The resolved text lines to insert
+ */
+function replaceBlockInModel(displayModel, blockIndex, block, resolvedLines) {
+    let { start, end } = findBlockRowRange(displayModel, blockIndex)
+    if (start < 0)
+        return
+
+    let removedRowCount     = end - start + 1
+    let originalLineCount   = block.endLine - block.startLine + 1
+    let lineDelta           = resolvedLines.length - originalLineCount
+
+    // Remove old conflict rows
+    displayModel.remove(start, removedRowCount)
+
+    // Insert resolved rows
+    for (let i = 0; i < resolvedLines.length; ++i) {
+        displayModel.insert(start + i, {
+            type: "line",
+            text: resolvedLines[i],
+            lineNumber: block.startLine + i,
+            blockIndex: -1,
+            role: "resolved"
+        })
+    }
+
+    // Shift line numbers of rows after the block
+    if (lineDelta !== 0) {
+        for (let i = start + resolvedLines.length; i < displayModel.count; ++i) {
+            let row = displayModel.get(i)
+            if (row.lineNumber !== undefined && row.lineNumber !== null) {
+                displayModel.setProperty(i, "lineNumber", row.lineNumber + lineDelta)
+            }
+        }
+    }
+
+    // Decrement blockIndex for later blocks
+    for (let i = 0; i < displayModel.count; ++i) {
+        let bi = displayModel.get(i).blockIndex
+        if (bi !== undefined && bi > blockIndex) {
+            displayModel.setProperty(i, "blockIndex", bi - 1)
+        }
+    }
+}
+
+/**
+ * Updates the remaining blocks array after one block is resolved.
+ * Renumbers indices and shifts line references accordingly.
+ * @param blocks       - The blocks array (selectedConflict.blocks)
+ * @param blockIndex   - The resolved block's original index
+ * @param resolvedPos  - Position of the resolved block in the array
+ * @param lineDelta    - Number of lines gained/lost
+ * @param blockEndLine - The original endLine of the resolved block
+ */
+function updateRemainingBlocks(selectedConflict, blockIndex, resolvedPos, lineDelta, blockEndLine) {
+    for (let i = 0; i < selectedConflict.blocks.length; ++i) {
+        if (i === resolvedPos)
+            continue
+
+        let b = selectedConflict.blocks[i]
+        if (b.index > blockIndex)
+            b.index -= 1
+
+        if (b.startLine > blockEndLine) {
+            b.startLine += lineDelta
+            b.endLine   += lineDelta
+        }
+    }
+    selectedConflict.blocks.splice(resolvedPos, 1)
+}
+
+/**
+ * Replaces the conflict block in the raw file-lines array.
+ * @param lines         - The lines array (selectedConflict.lines)
+ * @param block         - The resolved block object (needs startLine, endLine)
+ * @param resolvedLines - The resolved text lines
+ * @returns The updated lines array
+ */
+function updateLinesArray(lines, block, resolvedLines) {
+    if (!lines)
+        return lines
+
+    let prefix = lines.slice(0, block.startLine - 1)
+    let suffix = lines.slice(block.endLine)
+    return prefix.concat(resolvedLines, suffix)
+}

--- a/Qml/View/Components/Conflict/ConflictFileList.qml
+++ b/Qml/View/Components/Conflict/ConflictFileList.qml
@@ -90,13 +90,6 @@ Rectangle {
             Layout.preferredHeight: 28
             radius: 3
 
-            property bool isResolved: {
-                if (modelData && modelData.blocks !== undefined)
-                    return modelData.blocks.length === 0
-
-                return true
-            }
-
             property bool isStaged  : root.stagedFiles && root.stagedFiles.some(f => f.path === modelData.path)
             property bool isCurrent : root.currentPath === modelData.path
             property bool isHovered : hoverHandler.hovered

--- a/Qml/View/Popups/ConflictPopup.qml
+++ b/Qml/View/Popups/ConflictPopup.qml
@@ -594,6 +594,9 @@ Window {
         // Keep the raw lines array in sync
         selectedConflict.lines = ConflictUtils.updateLinesArray(selectedConflict.lines, block, resolvedLines)
 
+        // Rebuilt the conflict‑zone indicators
+        Qt.callLater(updateConflictMarkers)
+
         notificationController.success("Conflicts Resolved", "Conflict", 2000)
     }
 

--- a/Qml/View/Popups/ConflictPopup.qml
+++ b/Qml/View/Popups/ConflictPopup.qml
@@ -594,51 +594,103 @@ Window {
     }
 
     function acceptBlock(blockIndex, mode) {
-        if (!selectedPath)
+        if (!selectedPath || !selectedConflict)
             return
 
-        var visibleIndex = conflictListView.indexAt(0, conflictListView.contentY)
-        if (visibleIndex >= 0 && visibleIndex < displayModel.count) {
-            var topItem = displayModel.get(visibleIndex)
-            pendingRestoreLineNumber = (topItem.lineNumber !== undefined) ? topItem.lineNumber : -1
-        } else {
-            pendingRestoreLineNumber = -1
-        }
+        let found = findBlockByIndex(selectedConflict.blocks, blockIndex)
+        if (!found)
+            return
+        let block = found.block
 
         let currentContent = ConflictUtils.buildFullContent(displayModel)
         conflictController.writeWorkingFile(selectedPath, currentContent)
 
         let res
         switch (mode) {
-            case "ours":
-                res = conflictController.acceptBlockOurs(selectedPath, blockIndex)
-                break
-            case "theirs":
-                res = conflictController.acceptBlockTheirs(selectedPath, blockIndex)
-                break
-            case "both":
-                res = conflictController.acceptBlockBoth(selectedPath, blockIndex)
-                break
-            default:
-                break
+            case "ours":   res = conflictController.acceptBlockOurs(selectedPath, blockIndex); break
+            case "theirs": res = conflictController.acceptBlockTheirs(selectedPath, blockIndex); break
+            case "both":   res = conflictController.acceptBlockBoth(selectedPath, blockIndex); break
+            default: return
         }
-
         if (!res.success) {
             notificationController.error(res.errorMessage, "Conflict Resolution", 4000)
+            return
         }
 
-        else {
-            notificationController.success("Conflicts Resolved", "Conflict", 2500)
+        // Compute resolved lines
+        let resolvedLines = []
+        if (mode === "ours")   resolvedLines = block.currentText  ? block.currentText.split("\n")  : []
+        if (mode === "theirs") resolvedLines = block.incomingText ? block.incomingText.split("\n") : []
+        if (mode === "both") {
+            resolvedLines = (block.currentText ? block.currentText.split("\n") : [])
+                             .concat(block.incomingText ? block.incomingText.split("\n") : [])
+        }
 
-            // Clear memory state so fresh Git changes load
+        // Locate the rows belonging to this block in the display model
+        let { start, end } = findBlockRowRange(displayModel, blockIndex)
+        if (start < 0) return
+
+        let removedRowCount   = end - start + 1
+        let originalLineCount = block.endLine - block.startLine + 1
+        let lineDelta          = resolvedLines.length - originalLineCount
+
+        // Replace the block's rows with resolved lines
+        displayModel.remove(start, removedRowCount)
+        for (let i = 0; i < resolvedLines.length; ++i) {
+            displayModel.insert(start + i, {
+                type: "line",
+                text: resolvedLines[i],
+                lineNumber: block.startLine + i,
+                blockIndex: -1,
+                role: "resolved"
+            })
+        }
+
+        // Shift line numbers of later rows
+        if (lineDelta !== 0) {
+            for (let i = start + resolvedLines.length; i < displayModel.count; ++i) {
+                let row = displayModel.get(i)
+                if (row.lineNumber !== undefined && row.lineNumber !== null) {
+                    displayModel.setProperty(i, "lineNumber", row.lineNumber + lineDelta)
+                }
+            }
+        }
+
+        // Renumber blockIndex for later blocks
+        for (let i = 0; i < displayModel.count; ++i) {
+            let bi = displayModel.get(i).blockIndex
+            if (bi !== undefined && bi > blockIndex) {
+                displayModel.setProperty(i, "blockIndex", bi - 1)
+            }
+        }
+
+        // Update cached block objects
+        for (let i = 0; i < selectedConflict.blocks.length; ++i) {
+            if (i === found.pos) continue
+            let b = selectedConflict.blocks[i]
+            if (b.index > blockIndex) b.index -= 1
+            if (b.startLine > block.endLine) {
+                b.startLine += lineDelta
+                b.endLine   += lineDelta
+            }
+        }
+        selectedConflict.blocks.splice(found.pos, 1)
+
+        // Keep the raw lines array in sync
+        if (selectedConflict.lines) {
+            let prefix = selectedConflict.lines.slice(0, block.startLine - 1)
+            let suffix = selectedConflict.lines.slice(block.endLine)
+            selectedConflict.lines = prefix.concat(resolvedLines, suffix)
+        }
+
+        if (selectedConflict.blocks.length === 0) {
+            conflicts = conflicts.filter(c => c.path !== selectedPath)
             let copy = Object.assign({}, modifiedFiles)
             delete copy[selectedPath]
             modifiedFiles = copy
-
-            loadConflicts(true)
-
-            Qt.callLater(restoreScrollPosition)
         }
+
+        notificationController.success("Conflicts Resolved", "Conflict", 2000)
     }
 
     function saveAndStage(path) {

--- a/Qml/View/Popups/ConflictPopup.qml
+++ b/Qml/View/Popups/ConflictPopup.qml
@@ -594,6 +594,13 @@ Window {
         // Keep the raw lines array in sync
         selectedConflict.lines = ConflictUtils.updateLinesArray(selectedConflict.lines, block, resolvedLines)
 
+        let idx = conflicts.findIndex(c => c.path === selectedPath)
+        if (idx >= 0) {
+            let updated = conflicts.slice()
+            updated[idx] = selectedConflict
+            conflicts = updated
+        }
+
         // Rebuilt the conflict‑zone indicators
         Qt.callLater(updateConflictMarkers)
 

--- a/Qml/View/Popups/ConflictPopup.qml
+++ b/Qml/View/Popups/ConflictPopup.qml
@@ -617,6 +617,8 @@ Window {
             modifiedFiles = copy
 
             loadConflicts(true)
+
+            Qt.callLater(restoreScrollPosition)
         }
     }
 

--- a/Qml/View/Popups/ConflictPopup.qml
+++ b/Qml/View/Popups/ConflictPopup.qml
@@ -550,7 +550,7 @@ Window {
         if (!selectedPath || !selectedConflict)
             return
 
-        let found = findBlockByIndex(selectedConflict.blocks, blockIndex)
+        let found = ConflictUtils.findBlockByIndex(selectedConflict.blocks, blockIndex)
         if (!found)
             return
         let block = found.block
@@ -597,14 +597,6 @@ Window {
         notificationController.success("Conflicts Resolved", "Conflict", 2000)
     }
 
-    function findBlockByIndex(blocks, idx) {
-        for (let i = 0; i < blocks.length; ++i) {
-            if (blocks[i].index === idx)
-                return { block: blocks[i], pos: i }
-        }
-        return null
-    }
-
     function computeResolvedLines(block, mode) {
         if (mode === "ours")
             return block.currentText  ? block.currentText.split("\n")  : []
@@ -622,7 +614,7 @@ Window {
     }
 
     function replaceBlockInModel(blockIndex, block, resolvedLines) {
-        let { start, end } = findBlockRowRange(displayModel, blockIndex)
+        let { start, end } = ConflictUtils.findBlockRowRange(displayModel, blockIndex)
         if (start < 0)
             return
 
@@ -661,17 +653,6 @@ Window {
                 displayModel.setProperty(i, "blockIndex", bi - 1)
             }
         }
-    }
-
-    function findBlockRowRange(model, blockIndex) {
-        let start = -1, end = -1
-        for (let i = 0; i < model.count; ++i) {
-            if (model.get(i).blockIndex === blockIndex) {
-                if (start < 0) start = i
-                end = i
-            }
-        }
-        return { start, end }
     }
 
     function updateRemainingBlocks(selectedConflict, blockIndex, resolvedPos, lineDelta, blockEndLine) {

--- a/Qml/View/Popups/ConflictPopup.qml
+++ b/Qml/View/Popups/ConflictPopup.qml
@@ -548,6 +548,25 @@ Window {
         });
     }
 
+    function findBlockRowRange(model, blockIndex) {
+        let start = -1, end = -1
+        for (let i = 0; i < model.count; ++i) {
+            if (model.get(i).blockIndex === blockIndex) {
+                if (start < 0) start = i
+                end = i
+            }
+        }
+        return { start, end }
+    }
+
+    function findBlockByIndex(blocks, idx) {
+        for (let i = 0; i < blocks.length; ++i) {
+            if (blocks[i].index === idx)
+                return { block: blocks[i], pos: i }
+        }
+        return null
+    }
+
     function restoreScrollPosition() {
         if (pendingRestoreLineNumber < 0)
             return

--- a/Qml/View/Popups/ConflictPopup.qml
+++ b/Qml/View/Popups/ConflictPopup.qml
@@ -71,6 +71,8 @@ Window {
 
     property bool interactiveMode: false
 
+    property int pendingRestoreLineNumber: -1
+
     /* Signals
      * ****************************************************************************************/
     signal operationCompleted();
@@ -546,9 +548,43 @@ Window {
         });
     }
 
+    function restoreScrollPosition() {
+        if (pendingRestoreLineNumber < 0)
+            return
+
+        var targetLine = pendingRestoreLineNumber
+        pendingRestoreLineNumber = -1
+
+        if (displayModel.count === 0)
+            return
+
+        var targetIndex = -1
+        for (var i = 0; i < displayModel.count; i++) {
+            var item = displayModel.get(i)
+            if (item.lineNumber !== undefined && item.lineNumber >= targetLine) {
+                targetIndex = i
+                break
+            }
+        }
+
+        if (targetIndex < 0) {
+            targetIndex = displayModel.count - 1
+        }
+
+        conflictListView.positionViewAtIndex(targetIndex, ListView.Beginning)
+    }
+
     function acceptBlock(blockIndex, mode) {
         if (!selectedPath)
             return
+
+        var visibleIndex = conflictListView.indexAt(0, conflictListView.contentY)
+        if (visibleIndex >= 0 && visibleIndex < displayModel.count) {
+            var topItem = displayModel.get(visibleIndex)
+            pendingRestoreLineNumber = (topItem.lineNumber !== undefined) ? topItem.lineNumber : -1
+        } else {
+            pendingRestoreLineNumber = -1
+        }
 
         let currentContent = ConflictUtils.buildFullContent(displayModel)
         conflictController.writeWorkingFile(selectedPath, currentContent)

--- a/Qml/View/Popups/ConflictPopup.qml
+++ b/Qml/View/Popups/ConflictPopup.qml
@@ -546,6 +546,123 @@ Window {
         });
     }
 
+    function acceptBlock(blockIndex, mode) {
+        if (!selectedPath || !selectedConflict)
+            return
+
+        let found = findBlockByIndex(selectedConflict.blocks, blockIndex)
+        if (!found)
+            return
+        let block = found.block
+
+        // Write current editor content and perform C++ resolution
+        let currentContent = ConflictUtils.buildFullContent(displayModel)
+        conflictController.writeWorkingFile(selectedPath, currentContent)
+
+        let res
+        switch (mode) {
+            case "ours":
+                res = conflictController.acceptBlockOurs(selectedPath, blockIndex)
+                break
+
+            case "theirs":
+                res = conflictController.acceptBlockTheirs(selectedPath, blockIndex)
+                break
+
+            case "both":
+                res = conflictController.acceptBlockBoth(selectedPath, blockIndex)
+                break
+
+            default:
+                return
+        }
+        if (!res.success) {
+            notificationController.error(res.errorMessage, "Conflict Resolution", 4000)
+            return
+        }
+
+        // Compute the text to keep
+        let resolvedLines = computeResolvedLines(block, mode)
+
+        // Update the ListModel in place
+        replaceBlockInModel(blockIndex, block, resolvedLines)
+
+        // Update the cached block objects
+        let lineDelta = resolvedLines.length - (block.endLine - block.startLine + 1)
+        updateRemainingBlocks(selectedConflict, blockIndex, found.pos, lineDelta, block.endLine)
+
+        // Keep the raw lines array in sync
+        updateLinesArray(selectedConflict, block, resolvedLines)
+
+        notificationController.success("Conflicts Resolved", "Conflict", 2000)
+    }
+
+    function findBlockByIndex(blocks, idx) {
+        for (let i = 0; i < blocks.length; ++i) {
+            if (blocks[i].index === idx)
+                return { block: blocks[i], pos: i }
+        }
+        return null
+    }
+
+    function computeResolvedLines(block, mode) {
+        if (mode === "ours")
+            return block.currentText  ? block.currentText.split("\n")  : []
+
+        if (mode === "theirs")
+            return block.incomingText ? block.incomingText.split("\n") : []
+
+        if (mode === "both") {
+            let ours   = block.currentText  ? block.currentText.split("\n")  : []
+            let theirs = block.incomingText ? block.incomingText.split("\n") : []
+            return ours.concat(theirs)
+        }
+
+        return []
+    }
+
+    function replaceBlockInModel(blockIndex, block, resolvedLines) {
+        let { start, end } = findBlockRowRange(displayModel, blockIndex)
+        if (start < 0)
+            return
+
+        let removedRowCount     = end - start + 1
+        let originalLineCount   = block.endLine - block.startLine + 1
+        let lineDelta           = resolvedLines.length - originalLineCount
+
+        // Remove old conflict rows
+        displayModel.remove(start, removedRowCount)
+
+        // Insert resolved rows
+        for (let i = 0; i < resolvedLines.length; ++i) {
+            displayModel.insert(start + i, {
+                type: "line",
+                text: resolvedLines[i],
+                lineNumber: block.startLine + i,
+                blockIndex: -1,
+                role: "resolved"
+            })
+        }
+
+        // Shift line numbers of rows after the block
+        if (lineDelta !== 0) {
+            for (let i = start + resolvedLines.length; i < displayModel.count; ++i) {
+                let row = displayModel.get(i)
+                if (row.lineNumber !== undefined && row.lineNumber !== null) {
+                    displayModel.setProperty(i, "lineNumber", row.lineNumber + lineDelta)
+                }
+            }
+        }
+
+        // Decrement blockIndex for later blocks
+        for (let i = 0; i < displayModel.count; ++i) {
+            let bi = displayModel.get(i).blockIndex
+            if (bi !== undefined && bi > blockIndex) {
+                displayModel.setProperty(i, "blockIndex", bi - 1)
+            }
+        }
+    }
+
     function findBlockRowRange(model, blockIndex) {
         let start = -1, end = -1
         for (let i = 0; i < model.count; ++i) {
@@ -557,112 +674,30 @@ Window {
         return { start, end }
     }
 
-    function findBlockByIndex(blocks, idx) {
-        for (let i = 0; i < blocks.length; ++i) {
-            if (blocks[i].index === idx)
-                return { block: blocks[i], pos: i }
-        }
-        return null
-    }
-
-    function acceptBlock(blockIndex, mode) {
-        if (!selectedPath || !selectedConflict)
-            return
-
-        let found = findBlockByIndex(selectedConflict.blocks, blockIndex)
-        if (!found)
-            return
-        let block = found.block
-
-        let currentContent = ConflictUtils.buildFullContent(displayModel)
-        conflictController.writeWorkingFile(selectedPath, currentContent)
-
-        let res
-        switch (mode) {
-            case "ours":   res = conflictController.acceptBlockOurs(selectedPath, blockIndex); break
-            case "theirs": res = conflictController.acceptBlockTheirs(selectedPath, blockIndex); break
-            case "both":   res = conflictController.acceptBlockBoth(selectedPath, blockIndex); break
-            default: return
-        }
-        if (!res.success) {
-            notificationController.error(res.errorMessage, "Conflict Resolution", 4000)
-            return
-        }
-
-        // Compute resolved lines
-        let resolvedLines = []
-        if (mode === "ours")   resolvedLines = block.currentText  ? block.currentText.split("\n")  : []
-        if (mode === "theirs") resolvedLines = block.incomingText ? block.incomingText.split("\n") : []
-        if (mode === "both") {
-            resolvedLines = (block.currentText ? block.currentText.split("\n") : [])
-                             .concat(block.incomingText ? block.incomingText.split("\n") : [])
-        }
-
-        // Locate the rows belonging to this block in the display model
-        let { start, end } = findBlockRowRange(displayModel, blockIndex)
-        if (start < 0) return
-
-        let removedRowCount   = end - start + 1
-        let originalLineCount = block.endLine - block.startLine + 1
-        let lineDelta          = resolvedLines.length - originalLineCount
-
-        // Replace the block's rows with resolved lines
-        displayModel.remove(start, removedRowCount)
-        for (let i = 0; i < resolvedLines.length; ++i) {
-            displayModel.insert(start + i, {
-                type: "line",
-                text: resolvedLines[i],
-                lineNumber: block.startLine + i,
-                blockIndex: -1,
-                role: "resolved"
-            })
-        }
-
-        // Shift line numbers of later rows
-        if (lineDelta !== 0) {
-            for (let i = start + resolvedLines.length; i < displayModel.count; ++i) {
-                let row = displayModel.get(i)
-                if (row.lineNumber !== undefined && row.lineNumber !== null) {
-                    displayModel.setProperty(i, "lineNumber", row.lineNumber + lineDelta)
-                }
-            }
-        }
-
-        // Renumber blockIndex for later blocks
-        for (let i = 0; i < displayModel.count; ++i) {
-            let bi = displayModel.get(i).blockIndex
-            if (bi !== undefined && bi > blockIndex) {
-                displayModel.setProperty(i, "blockIndex", bi - 1)
-            }
-        }
-
-        // Update cached block objects
+    function updateRemainingBlocks(selectedConflict, blockIndex, resolvedPos, lineDelta, blockEndLine) {
         for (let i = 0; i < selectedConflict.blocks.length; ++i) {
-            if (i === found.pos) continue
+            if (i === resolvedPos)
+                continue
+
             let b = selectedConflict.blocks[i]
-            if (b.index > blockIndex) b.index -= 1
-            if (b.startLine > block.endLine) {
+            if (b.index > blockIndex)
+                b.index -= 1
+
+            if (b.startLine > blockEndLine) {
                 b.startLine += lineDelta
                 b.endLine   += lineDelta
             }
         }
-        selectedConflict.blocks.splice(found.pos, 1)
+        selectedConflict.blocks.splice(resolvedPos, 1)
+    }
 
-        // Keep the raw lines array in sync
-        if (selectedConflict.lines) {
-            let prefix = selectedConflict.lines.slice(0, block.startLine - 1)
-            let suffix = selectedConflict.lines.slice(block.endLine)
-            selectedConflict.lines = prefix.concat(resolvedLines, suffix)
-        }
+    function updateLinesArray(selectedConflict, block, resolvedLines) {
+        if (!selectedConflict.lines)
+            return
 
-        if (selectedConflict.blocks.length === 0) {
-            conflicts = conflicts.filter(c => c.path !== selectedPath)
-            let copy = Object.assign({}, modifiedFiles)
-            delete copy[selectedPath]
-            modifiedFiles = copy
-        }
-
-        notificationController.success("Conflicts Resolved", "Conflict", 2000)
+        let prefix = selectedConflict.lines.slice(0, block.startLine - 1)
+        let suffix = selectedConflict.lines.slice(block.endLine)
+        selectedConflict.lines = prefix.concat(resolvedLines, suffix)
     }
 
     function saveAndStage(path) {

--- a/Qml/View/Popups/ConflictPopup.qml
+++ b/Qml/View/Popups/ConflictPopup.qml
@@ -582,103 +582,19 @@ Window {
         }
 
         // Compute the text to keep
-        let resolvedLines = computeResolvedLines(block, mode)
+        let resolvedLines = ConflictUtils.computeResolvedLines(block, mode)
 
         // Update the ListModel in place
-        replaceBlockInModel(blockIndex, block, resolvedLines)
+        ConflictUtils.replaceBlockInModel(displayModel, blockIndex, block, resolvedLines)
 
         // Update the cached block objects
         let lineDelta = resolvedLines.length - (block.endLine - block.startLine + 1)
-        updateRemainingBlocks(selectedConflict, blockIndex, found.pos, lineDelta, block.endLine)
+        ConflictUtils.updateRemainingBlocks(selectedConflict, blockIndex, found.pos, lineDelta, block.endLine)
 
         // Keep the raw lines array in sync
-        updateLinesArray(selectedConflict, block, resolvedLines)
+        selectedConflict.lines = ConflictUtils.updateLinesArray(selectedConflict.lines, block, resolvedLines)
 
         notificationController.success("Conflicts Resolved", "Conflict", 2000)
-    }
-
-    function computeResolvedLines(block, mode) {
-        if (mode === "ours")
-            return block.currentText  ? block.currentText.split("\n")  : []
-
-        if (mode === "theirs")
-            return block.incomingText ? block.incomingText.split("\n") : []
-
-        if (mode === "both") {
-            let ours   = block.currentText  ? block.currentText.split("\n")  : []
-            let theirs = block.incomingText ? block.incomingText.split("\n") : []
-            return ours.concat(theirs)
-        }
-
-        return []
-    }
-
-    function replaceBlockInModel(blockIndex, block, resolvedLines) {
-        let { start, end } = ConflictUtils.findBlockRowRange(displayModel, blockIndex)
-        if (start < 0)
-            return
-
-        let removedRowCount     = end - start + 1
-        let originalLineCount   = block.endLine - block.startLine + 1
-        let lineDelta           = resolvedLines.length - originalLineCount
-
-        // Remove old conflict rows
-        displayModel.remove(start, removedRowCount)
-
-        // Insert resolved rows
-        for (let i = 0; i < resolvedLines.length; ++i) {
-            displayModel.insert(start + i, {
-                type: "line",
-                text: resolvedLines[i],
-                lineNumber: block.startLine + i,
-                blockIndex: -1,
-                role: "resolved"
-            })
-        }
-
-        // Shift line numbers of rows after the block
-        if (lineDelta !== 0) {
-            for (let i = start + resolvedLines.length; i < displayModel.count; ++i) {
-                let row = displayModel.get(i)
-                if (row.lineNumber !== undefined && row.lineNumber !== null) {
-                    displayModel.setProperty(i, "lineNumber", row.lineNumber + lineDelta)
-                }
-            }
-        }
-
-        // Decrement blockIndex for later blocks
-        for (let i = 0; i < displayModel.count; ++i) {
-            let bi = displayModel.get(i).blockIndex
-            if (bi !== undefined && bi > blockIndex) {
-                displayModel.setProperty(i, "blockIndex", bi - 1)
-            }
-        }
-    }
-
-    function updateRemainingBlocks(selectedConflict, blockIndex, resolvedPos, lineDelta, blockEndLine) {
-        for (let i = 0; i < selectedConflict.blocks.length; ++i) {
-            if (i === resolvedPos)
-                continue
-
-            let b = selectedConflict.blocks[i]
-            if (b.index > blockIndex)
-                b.index -= 1
-
-            if (b.startLine > blockEndLine) {
-                b.startLine += lineDelta
-                b.endLine   += lineDelta
-            }
-        }
-        selectedConflict.blocks.splice(resolvedPos, 1)
-    }
-
-    function updateLinesArray(selectedConflict, block, resolvedLines) {
-        if (!selectedConflict.lines)
-            return
-
-        let prefix = selectedConflict.lines.slice(0, block.startLine - 1)
-        let suffix = selectedConflict.lines.slice(block.endLine)
-        selectedConflict.lines = prefix.concat(resolvedLines, suffix)
     }
 
     function saveAndStage(path) {

--- a/Qml/View/Popups/ConflictPopup.qml
+++ b/Qml/View/Popups/ConflictPopup.qml
@@ -71,8 +71,6 @@ Window {
 
     property bool interactiveMode: false
 
-    property int pendingRestoreLineNumber: -1
-
     /* Signals
      * ****************************************************************************************/
     signal operationCompleted();
@@ -565,32 +563,6 @@ Window {
                 return { block: blocks[i], pos: i }
         }
         return null
-    }
-
-    function restoreScrollPosition() {
-        if (pendingRestoreLineNumber < 0)
-            return
-
-        var targetLine = pendingRestoreLineNumber
-        pendingRestoreLineNumber = -1
-
-        if (displayModel.count === 0)
-            return
-
-        var targetIndex = -1
-        for (var i = 0; i < displayModel.count; i++) {
-            var item = displayModel.get(i)
-            if (item.lineNumber !== undefined && item.lineNumber >= targetLine) {
-                targetIndex = i
-                break
-            }
-        }
-
-        if (targetIndex < 0) {
-            targetIndex = displayModel.count - 1
-        }
-
-        conflictListView.positionViewAtIndex(targetIndex, ListView.Beginning)
     }
 
     function acceptBlock(blockIndex, mode) {


### PR DESCRIPTION

## Description
This PR implements a VS Code‑like conflict resolution flow that keeps the editor viewport stable and the UI instantly reactive after resolving a block.

## What changed
- **In‑place model update** – After accepting a block, the `displayModel` is surgically modified instead of reloading the whole file from Git. This completely removes the scroll‑jump and flicker.
- **No more `loadConflicts(true)` inside `acceptBlock`** – The resolution is fast and local, while the working file and Git index are still correctly updated via the existing C++ backend.
- **Reactive file‑list updates** – By reassigning the `conflicts` property after in‑place mutations, the `ConflictFileList` immediately reflects the new block count and switches from `!` to `M` status without a full reload.
- **Cleanup** – Removed the old scroll‑capture/restore infrastructure (`pendingRestoreLineNumber`, `restoreScrollPosition`), as it is no longer needed.
- **Conflict markers** – The scrollbar markers are correctly rebuilt after each resolution so that removed blocks disappear.

## How it works
1. User clicks “Accept Current” (or “Accept Incoming” / “Accept Both”).
2. The editor content is written to disk, the C++ backend resolves the block in the working file.
3. `ConflictPopupUtils.replaceBlockInModel()` replaces the block’s rows with the chosen text directly in the `ListModel`.
4. The in‑memory conflict data (`blocks`, `lines`) is updated to keep everything in sync.
5. The `conflicts` property is reassigned to trigger a binding refresh, updating the file list and the plus‑button visibility.
6. The scroll position stays where it was – no jump to top.

## Testing
- Multiple conflict blocks, resolved in any order – the editor stays exactly at the same scroll position.
- The plus‑button appears normally for fully resolved files, allowing manual staging.
- Staging via the button correctly moves the file to “Staged Changes” and updates the UI.
- All conflict operations (Continue, Skip, Abort) still work as before.