### PR TITLE
Feature/413 empty state placeholder

### DIFF
--- a/Qml/View/Popups/ConflictPopup.qml
+++ b/Qml/View/Popups/ConflictPopup.qml
@@ -375,6 +375,13 @@ Window {
                             conflictListView.horizontalScrollOffset = position * conflictListView.maxContentWidth
                         }
                     }
+
+                    EmptyStateView {
+                        anchors.fill: parent
+                        visible: displayModel.count === 0
+                        title: "No Conflicted files to show"
+                        details: "All conflicts have been resolved."
+                    }
                 }
             }
 


### PR DESCRIPTION

## Description
This PR adds a friendly “No Conflicted files to show” message inside the conflict editor panel, replacing the blank rectangle that appears when all conflict blocks have been resolved and staged. The left file list remains visible so the user can still click on staged files to view their content.

## What changed
- Added an `EmptyStateView` component inside the right‑panel editor `Rectangle`.
- The placeholder is bound to `displayModel.count === 0`, so it appears immediately after the last conflict file is staged (or when no conflicts exist at all).
- The placeholder is centred in the editor area and respects the existing background colour.

## How it works
1. User resolves and stages all conflict files.
2. `displayModel` is cleared → `displayModel.count` becomes `0`.
3. The `EmptyStateView` becomes visible, showing a clear “nothing to show” message.
4. The left panel (`ConflictFileList`) remains interactive – the user can select any staged file to review its contents.

## Testing
- When all conflicts are resolved and staged, the placeholder appears instead of a blank editor.
- Selecting a staged file from the left panel hides the placeholder and shows the file’s content.
- The placeholder does not interfere with normal conflict resolution or the “Continue” flow.