### PR TITLE
Ge 502 utilities card panel some changes

### DIFF
--- a/Qml/Pages/GraphViewPage.qml
+++ b/Qml/Pages/GraphViewPage.qml
@@ -48,7 +48,7 @@ Page {
     property GitTreeController       gitTreeController       : null
 
     // Utility panel (moved in from the old UtilitiesPage), open by default.
-    property bool                    utilityPanelOpen        : true
+    property bool                    utilityPanelOpen        : false
 
     property alias                   graphRef                : commitGraph
 
@@ -152,7 +152,7 @@ Page {
         target: root.terminalController
 
         function onGitStateChanged() {
-            root.reloadUtilityPanel()
+            utilityPanel.reload()
         }
     }
 
@@ -242,244 +242,26 @@ Page {
         }
 
         // Utility panel (moved in from the old UtilitiesPage), toggled from GraphViewHeader.
-        Rectangle {
+        UtilityPanel {
             id: utilityPanel
-            visible: root.utilityPanelOpen
-            Layout.fillHeight: true
-            Layout.preferredWidth: Style.dp(279)
+            open: root.utilityPanelOpen
 
-            color: Style.colors.primaryBackground
-            border.width: 1
-            border.color: Style.colors.primaryBorder
-
-            ColumnLayout {
-                anchors.fill: parent
-                spacing: 0
-
-                TextField {
-                    id: utilityPanelFilterField
-                    Layout.fillWidth: true
-                    Layout.margins: Style.dp(8)
-                    minHeight: 23
-                    placeholderText: qsTr("Filter...")
-                    backgroundColor: Style.colors.secondaryBackground
-                    borderWidth: 1
-                    borderColor: Style.colors.secondaryBorder
-                    focusBorderWidth: 1
-                    font.family: Style.fontTypes.inter
-                    font.weight: 400
-                    font.pixelSize: Style.appFont.captionPt
-
-                    onTextChanged: utilityPanelFlow.filterText = text
-                }
-
-                Flickable {
-                    id: utilityPanelFlick
-                    Layout.fillWidth: true
-                    Layout.fillHeight: true
-                    clip: true
-
-                    interactive: !utilityPanelFlow.dockHovered
-                    flickableDirection: Flickable.VerticalFlick
-                    boundsBehavior: Flickable.StopAtBounds
-
-                    contentWidth: utilityPanelFlow.width
-                    contentHeight: utilityPanelFlow.implicitHeight
-
-                    ScrollBar.vertical: ScrollBar {
-                        policy: ScrollBar.AsNeeded
-                    }
-
-                    Flow {
-                        id: utilityPanelFlow
-                        width: utilityPanelFlick.width
-
-                        property bool dockHovered: false
-                        property string filterText: ""
-
-                        function matchesFilter(sectionTitle) {
-                            var needle = utilityPanelFlow.filterText.trim().toLowerCase()
-                            if (needle.length === 0)
-                                return true
-                            return sectionTitle.toLowerCase().indexOf(needle) !== -1
-                        }
-
-                        function scrollBlockingHovered(item) {
-                            return item
-                                && item.visible !== false
-                                && item.hasOwnProperty("pageScrollBlocking")
-                                && item.pageScrollBlocking === true
-                                && item.hasOwnProperty("hovered")
-                                && item.hovered === true
-                        }
-
-                        function updateDockHovered() {
-                            for (let i = 0; i < children.length; ++i) {
-                                const child = children[i]
-                                if (scrollBlockingHovered(child) || scrollBlockingHovered(child.item)) {
-                                    utilityPanelFlow.dockHovered = true
-                                    return
-                                }
-                            }
-
-                            utilityPanelFlow.dockHovered = false
-                        }
-
-                        function setupPluginDock(item) {
-                            if (!item)
-                                return
-
-                        if (item.hasOwnProperty("pageScrollBlocking")
-                                && item.pageScrollBlocking === true
-                                && item.hoveredChanged)
-                            {
-                            item.hoveredChanged.connect(utilityPanelFlow.updateDockHovered)
-                        }
-
-                            updateDockHovered()
-                        }
-
-                        ImportExportBundleDock {
-                            visible: utilityPanelFlow.matchesFilter("Export / Import Project")
-                            branchController: root.branchController
-                            bundleController: root.bundleController
-                            notificationController: root.notificationController
-                            guideController: root.guideController
-                        }
-
-                        RemoteView {
-                            visible: utilityPanelFlow.matchesFilter("Remotes")
-                            remoteController: root.remoteController
-                            repositoryController: root.repositoryController
-                            userAuthenticationPopup: root.userAuthenticationPopup
-                            uiSessionPopups: root.uiSessionPopups
-                            addEditRemotePopup: uiSessionPopups.addEditRemotePopup
-                            notificationController: root.notificationController
-                            guideController: root.guideController
-
-                            onHoveredChanged: utilityPanelFlow.updateDockHovered()
-                        }
-
-
-                        BranchManagementView {
-                            id: branchManagementView
-                            visible: utilityPanelFlow.matchesFilter("Branch Management")
-                            branchController: root.branchController
-                            addBranchPopup: uiSessionPopups.addBranchPopup
-                            notificationController: root.notificationController
-                            guideController: root.guideController
-
-                            onHoveredChanged: utilityPanelFlow.updateDockHovered()
-                        }
-
-
-                        StashManagerDock {
-                            id: stashManagerDock
-                            visible: utilityPanelFlow.matchesFilter("Stash Manager")
-                            stashController: root.stashController
-                            commitController: root.commitController
-                            statusController: root.statusController
-                            addStashPopup: uiSessionPopups.addStashPopup
-                            manageStashPopup: uiSessionPopups.manageStashPopup
-                            guideController: root.guideController
-
-                            notificationController: root.notificationController
-
-                            onHoveredChanged: utilityPanelFlow.updateDockHovered()
-                        }
-
-                        TagManagementView {
-                            id: tagManagementView
-                            visible: utilityPanelFlow.matchesFilter("Tag Management")
-                            tagController: root.tagController
-                            addTagPopup: uiSessionPopups.addTagPopup
-                            guideController: root.guideController
-                            notificationController: root.notificationController
-
-                            onHoveredChanged: utilityPanelFlow.updateDockHovered()
-                        }
-
-                        RecentActivityDock {
-                            visible: utilityPanelFlow.matchesFilter("Recent Activity")
-                            activityController: root.activityController
-                            guideController: root.guideController
-
-                            onHoveredChanged: utilityPanelFlow.updateDockHovered()
-                        }
-
-                        RepositoriesHistoryDock {
-                            visible: utilityPanelFlow.matchesFilter("Repositories History")
-                            repositoryController: root.repositoryController
-                            guideController: root.guideController
-
-                            onHoveredChanged: utilityPanelFlow.updateDockHovered()
-                        }
-
-                        RebaseDock {
-                            id: rebaseDock
-                            visible: utilityPanelFlow.matchesFilter("Rebase")
-                            branchController        : root.branchController
-                            rebaseController        : root.rebaseController
-                            commitController        : root.commitController
-                            statusController        : root.statusController
-                            notificationController  : root.notificationController
-                            conflictController      : root.conflictController
-                            guideController         : root.guideController
-                        }
-
-                        // ── Plugin docks ─────────────────────────────────────────────────
-                        Repeater {
-                            model: root.pluginController?.pluginManager?.registeredDocks ?? []
-
-                            delegate: Loader {
-                                width:  Style.dp(279)
-                                height: 390
-                                visible: utilityPanelFlow.matchesFilter(modelData.title ?? "")
-
-                                source: modelData.url
-
-                            onLoaded: {
-                                if (!item) return
-                                if (item.hasOwnProperty("pluginManager"))
-                                    item.pluginManager = Qt.binding(function() { return root.pluginController?.pluginManager })
-                                if (item.hasOwnProperty("pluginId"))
-                                    item.pluginId = modelData.id
-                                utilityPanelFlow.setupPluginDock(item)
-                                if (item.hasOwnProperty("repositoryController"))
-                                    item.repositoryController = Qt.binding(function() { return root.repositoryController })
-                                if (item.hasOwnProperty("branchController"))
-                                    item.branchController = Qt.binding(function() { return root.branchController })
-                                if (item.hasOwnProperty("remoteController"))
-                                    item.remoteController = Qt.binding(function() { return root.remoteController })
-                                if (item.hasOwnProperty("userAuthenticationPopup"))
-                                    item.userAuthenticationPopup = Qt.binding(function() { return root.userAuthenticationPopup })
-                                if (item.hasOwnProperty("uiSessionPopups"))
-                                    item.uiSessionPopups = Qt.binding(function() { return root.uiSessionPopups })
-                                if (item.hasOwnProperty("notificationController"))
-                                    item.notificationController = Qt.binding(function() { return root.notificationController })
-                                if (item.hasOwnProperty("guideController"))
-                                    item.guideController = Qt.binding(function() { return root.guideController })       
-                                if (item.hasOwnProperty("commitController"))
-                                    item.commitController = Qt.binding(function() { return root.commitController })
-                                if (item.hasOwnProperty("statusController"))
-                                    item.statusController = Qt.binding(function() { return root.statusController })
-                                if (item.hasOwnProperty("stashController"))
-                                    item.stashController = Qt.binding(function() { return root.stashController })
-                                if (item.hasOwnProperty("tagController"))
-                                    item.tagController = Qt.binding(function() { return root.tagController })
-                                if (item.hasOwnProperty("eventBus"))
-                                    item.eventBus = Qt.binding(function() { return root.pluginController?.pluginManager })
-                            }
-
-                                onStatusChanged: {
-                                    if (status === Loader.Error)
-                                        console.error("[GraphViewPage] Failed to load plugin dock:", source)
-                                }
-                            }
-                        }
-                    }
-                }
-            }
+            branchController        : root.branchController
+            remoteController        : root.remoteController
+            repositoryController    : root.repositoryController
+            commitController        : root.commitController
+            statusController        : root.statusController
+            stashController         : root.stashController
+            tagController           : root.tagController
+            rebaseController        : root.rebaseController
+            conflictController      : root.conflictController
+            bundleController        : root.bundleController
+            activityController      : root.activityController
+            notificationController  : root.notificationController
+            guideController         : root.guideController
+            userAuthenticationPopup : root.userAuthenticationPopup
+            uiSessionPopups         : root.uiSessionPopups
+            pluginController        : root.pluginController
         }
     }
 
@@ -568,13 +350,6 @@ Page {
 
     function activePageState() {
         return root.state
-    }
-
-    function reloadUtilityPanel() {
-        branchManagementView.update()
-        stashManagerDock.updateStashes()
-        tagManagementView.update()
-        rebaseDock.refreshBranches()
     }
 
     function branchNames() {

--- a/Qml/Style/Colors.qml
+++ b/Qml/Style/Colors.qml
@@ -2,10 +2,10 @@ import QtQuick
 
 QtObject{
     property color midnightBlack:       "#101013"
+    property color warmChalk:           "#EFEFEC"
     property color darkCharcoal:        "#1D1D22"
     property color graphiteDark:        "#17171C"
     property color obsidianDark:        "#0D0D0F"
-    property color onyxShadow:          "#17171C"
     property color mintyFresh:          "#86EFAC"
     property color softMintGlow:        "#144ADE80"
     property color paleCoralMist:       "#14F87171"
@@ -30,6 +30,22 @@ QtObject{
     property color subtleAzureGlow:     "#243B82F6"
     property color obsidianDeep:        "#111118"
     property color softCloudWhite:      "#F4F4F8"
+    property color slateLavender:       "#9898B4"
+    property color deepMidnight:        "#323248"
+    property color darkObsidian:        "#222230"
+    property color abyssBlack:          "#131316"
+    property color offWhite:            "#E8E8E3"
+    property color softParchment:       "#ECECE9"
+    property color darkGraphite:        "#0D0D0F"
+    property color charcoalGray:        "#222228"
+    property color lightPlatinum:       "#DDDDDF"
+    property color azureTint:           "#1F3B82F6"
+    property color accentWash:          "#14074E96"
+    property color graphiteSurface:     "#1A1A20"
+    property color graphiteHover:       "#202028"
+    property color graphiteSelected:    "#26262F"
+    property color slateMuted:          "#6A6A78"
+    property color frostWash:           "#14F4F4F8"
 
     // Primary colors
     property color primaryBackground:   "#FDFDFD"
@@ -70,9 +86,9 @@ QtObject{
     property color linePanelForeground: "#666666"
     
     // Surface & Background colors
-    property color cardBackground:      "#E8E8E8"
+    property color cardBackground:      "#DCDCDC"
     property color surfaceLight:        "#F3F3F3"
-    property color surfaceMuted:        "#D9D9D9"
+    property color surfaceMuted:        "#CECECE"
     property color hintBackground:      "#DEE5EB"
     
     // Border colors
@@ -203,6 +219,7 @@ QtObject{
     property color contextMenuBorder:     "#CDD2DA"
     property color contextMenuSeparator:  "#DCE1E9"
     property color contextMenuHover:      "#E7E7E7"
+    property color contextMenuDanger:     "#DC3545"
 
     property color branchSelectedAccent:  "#2563EB"
 
@@ -248,4 +265,90 @@ QtObject{
     property color commitButton:         branchAccent         // #2563EB
     property color fileBrowserRowHoverBg: Qt.rgba(0,0,0,0.04)
     property color fileBrowserSearchBg:  Qt.rgba(0,0,0,0.05)
+    property color headerBackground:            warmChalk
+    property color headerButtonBackground:      offWhite
+    property color headerButtonBackgroundHover: "#E0E0DC"
+    property color headerButtonBorder:          lightPlatinum
+
+    property color segmentedSelected:           "#FDFDFD"
+
+    property color utilitiesPanelBackground:            controlBackground
+    property color utilitiesPanelBorder:                primaryBorder
+    property color utilitiesPanelScrollBar:             controlBorder
+    property color utilitiesPanelScrollBarHover:        mutedText
+
+    property color utilitiesFilterBackground:           primaryBackground
+    property color utilitiesFilterBorder:               controlBorder
+    property color utilitiesFilterBorderFocus:          accent
+    property color utilitiesFilterText:                 foreground
+    property color utilitiesFilterPlaceholder:          placeholderText
+
+    property color utilitiesCardBackground:             primaryBackground
+    property color utilitiesCardSeparator:              primaryBorder
+
+    property color utilitiesCardHeaderBackground:       controlBackground
+    property color utilitiesCardHeaderHoverBackground:  controlBackgroundHover
+    property color utilitiesCardHeaderIcon:             accent
+    property color utilitiesCardTitle:                  foreground
+    property color utilitiesCardChevron:                mutedText
+
+    property color utilitiesCardBadgeBackground:        primaryBackground
+    property color utilitiesCardBadgeBorder:            controlBorder
+    property color utilitiesCardBadgeText:              secondaryText
+
+    property color utilitiesSegmentTrackBackground:     secondaryBorder
+    property color utilitiesSegmentTrackBorder:         controlBorder
+    property color utilitiesSegmentHoverBackground:     controlBackground
+    property color utilitiesSegmentSelectedBackground:  segmentedSelected
+    property color utilitiesSegmentText:                secondaryText
+    property color utilitiesSegmentSelectedText:        foreground
+
+    property color utilitiesSurfaceBackground:          controlBackground
+    property color utilitiesSurfaceBorder:              secondaryBorder
+    property color utilitiesHintText:                   secondaryText
+
+    property color utilitiesRowBackground:              primaryBackground
+    property color utilitiesRowHoverBackground:         controlBackground
+    property color utilitiesRowSelectedBackground:      azureTint
+    property color utilitiesRowBorder:                  controlBorder
+    property color utilitiesRowSelectedIndicator:       accent
+    property color utilitiesRowText:                    foreground
+    property color utilitiesRowSelectedText:            accent
+    property color utilitiesRowIcon:                    secondaryText
+    property color utilitiesRowIconAccent:              accent
+    property color utilitiesRowMetaText:                secondaryText
+    property color utilitiesRowSubText:                 mutedText
+    property color utilitiesRowMissingText:             error
+    property color utilitiesEmptyStateText:             mutedText
+
+    property color utilitiesFieldLabel:                 secondaryText
+    property color utilitiesInputBackground:            controlBackground
+    property color utilitiesInputHoverBackground:       controlBackgroundHover
+    property color utilitiesInputBorder:                controlBorder
+    property color utilitiesInputBorderFocus:           accent
+    property color utilitiesInputText:                  foreground
+    property color utilitiesInputPlaceholder:           placeholderText
+    property color utilitiesInputPopupBackground:       primaryBackground
+
+    property color utilitiesCheckBoxAccent:             accent
+    property color utilitiesCheckBoxText:               foreground
+
+    property color utilitiesPickerButtonBackground:      "transparent"
+    property color utilitiesPickerButtonHoverBackground: accentHover
+    property color utilitiesPickerButtonBorder:          controlBorder
+    property color utilitiesPickerButtonIcon:            secondaryText
+    property color utilitiesPickerButtonIconHover:       onAccentText
+
+    property color dashedButtonText:                    secondaryText
+    property color dashedButtonBorder:                  controlBorder
+    property color dashedButtonTextHover:               accent
+    property color dashedButtonBorderHover:             accent
+    property color dashedButtonBackgroundHover:         accentWash
+    property color dashedButtonTextDanger:              error
+    property color dashedButtonBorderDanger:            error
+
+    property color utilitiesActionIcon:                 secondaryText
+    property color utilitiesActionIconActive:           accent
+    property color utilitiesActionIconWarning:          "#B26A00"
+    property color utilitiesActionIconDanger:           error
 }

--- a/Qml/Style/Icons.qml
+++ b/Qml/Style/Icons.qml
@@ -51,6 +51,7 @@ QtObject{
     property string tree:              "\uF1BB" // tree
     property string cloud:             "\uf0c2" // cloud
     property string laptop:            "\uf109" // laptop
+    property string globe:             "\uf0ac" // globe
 
     property string palette:           "\uf53f"
     property string terminal:          "\uf120"

--- a/Qml/Style/Style.qml
+++ b/Qml/Style/Style.qml
@@ -37,7 +37,7 @@ QtObject {
     property          Colors        modernDarkColors:           Colors {
         accent:              "#3B82F6"
         accentHover:         "#2F6FE0"
-        primaryBackground:   midnightBlack
+        primaryBackground:   darkGraphite
         secondaryBackground: graphiteDark
         foreground:          softCloudWhite
         secondaryForeground: "#010101"
@@ -66,7 +66,7 @@ QtObject {
         linePanelBackgroound:obsidianDark
         linePanelForeground: deepCharcoalBlue
 
-        cardBackground:      onyxShadow
+        cardBackground:      charcoalGray
 
         primaryBorder:       darkCharcoal
         secondaryBorder:     darkCharcoal
@@ -173,6 +173,7 @@ QtObject {
         contextMenuBorder:     "#2C2C33"
         contextMenuSeparator:  "#2C2C33"
         contextMenuHover:      "#34343D"
+        contextMenuDanger:     "#FF6B6B"
 
         branchSelectedAccent:  "#93C5FD"
 
@@ -217,6 +218,98 @@ QtObject {
         commitButton:      "#3B82F6"
         fileBrowserRowHoverBg: Qt.rgba(1,1,1,0.04)
         fileBrowserSearchBg:  Qt.rgba(1,1,1,0.05)
+        headerBackground:            midnightBlack
+        headerButtonBackground:      graphiteDark
+        headerButtonBackgroundHover: "#26262E"
+        headerButtonBorder:          charcoalGray
+
+        segmentedSelected:           "#2A2A32"
+
+        // panel chrome
+        utilitiesPanelBackground:            abyssBlack
+        utilitiesPanelBorder:                charcoalGray
+        utilitiesPanelScrollBar:             deepCharcoalBlue
+        utilitiesPanelScrollBarHover:        slateMuted
+
+        // filter field
+        utilitiesFilterBackground:           graphiteSurface
+        utilitiesFilterBorder:               charcoalGray
+        utilitiesFilterText:                 softCloudWhite
+        utilitiesFilterPlaceholder:          slateMuted
+
+        // card shell
+        utilitiesCardBackground:             abyssBlack
+        utilitiesCardSeparator:              charcoalGray
+
+        // card header
+        utilitiesCardHeaderBackground:       midnightBlack
+        utilitiesCardHeaderHoverBackground:  graphiteHover
+        utilitiesCardTitle:                  slateLavender
+        utilitiesCardChevron:                slateMuted
+
+        // card header badge
+        utilitiesCardBadgeBackground:        graphiteHover
+        utilitiesCardBadgeBorder:            deepCharcoalBlue
+        utilitiesCardBadgeText:              slateLavender
+
+        // segmented control
+        utilitiesSegmentTrackBackground:     graphiteSurface
+        utilitiesSegmentTrackBorder:         charcoalGray
+        utilitiesSegmentHoverBackground:     graphiteHover
+        utilitiesSegmentSelectedBackground:  "#2A2A32"
+        utilitiesSegmentText:                slateLavender
+        utilitiesSegmentSelectedText:        softCloudWhite
+
+        // inset surface
+        utilitiesSurfaceBackground:          graphiteSurface
+        utilitiesSurfaceBorder:              charcoalGray
+        utilitiesHintText:                   slateLavender
+
+        // list rows
+        utilitiesRowBackground:              graphiteSurface
+        utilitiesRowHoverBackground:         graphiteHover
+        utilitiesRowSelectedBackground:      graphiteSelected
+        utilitiesRowBorder:                  charcoalGray
+        utilitiesRowSelectedIndicator:       "#93C5FD"
+        utilitiesRowText:                    softCloudWhite
+        utilitiesRowSelectedText:            "#93C5FD"
+        utilitiesRowIcon:                    slateLavender
+        utilitiesRowIconAccent:              "#93C5FD"
+        utilitiesRowMetaText:                slateLavender
+        utilitiesRowSubText:                 slateMuted
+        utilitiesRowMissingText:             softCoralMist
+        utilitiesEmptyStateText:             slateMuted
+
+        // inputs
+        utilitiesFieldLabel:                 slateLavender
+        utilitiesInputBackground:            graphiteSurface
+        utilitiesInputHoverBackground:       graphiteHover
+        utilitiesInputBorder:                charcoalGray
+        utilitiesInputText:                  softCloudWhite
+        utilitiesInputPlaceholder:           slateMuted
+        utilitiesInputPopupBackground:       obsidianDeep
+
+        // check box
+        utilitiesCheckBoxText:               softCloudWhite
+
+        // file / folder picker button
+        utilitiesPickerButtonBorder:         charcoalGray
+        utilitiesPickerButtonIcon:           slateLavender
+
+        // dashed ghost button
+        dashedButtonText:                    slateLavender
+        dashedButtonBorder:                  deepCharcoalBlue
+        dashedButtonTextHover:               softCloudWhite
+        dashedButtonBorderHover:             slateLavender
+        dashedButtonBackgroundHover:         frostWash
+        dashedButtonTextDanger:              softCoralMist
+        dashedButtonBorderDanger:            softCoralMist
+
+        // per-row action icons
+        utilitiesActionIcon:                 slateMuted
+        utilitiesActionIconActive:           "#7AB9FF"
+        utilitiesActionIconWarning:          "#FFD966"
+        utilitiesActionIconDanger:           softCoralMist
     }
 
     property           string       currentTheme:               "Modern Light"

--- a/Qml/Style/impl/IconButton.qml
+++ b/Qml/Style/impl/IconButton.qml
@@ -30,6 +30,11 @@ T.Button {
     property string tooltip:      ""
     property real   maximumWidth: -1
 
+    property color  backgroundColor:      Style.colors.secondaryBackground
+    property color  hoverBackgroundColor: Style.colors.cardBackground
+    property color  borderColor:          "transparent"
+    property real   borderWidth:          0
+
     /* Object Properties
      * ****************************************************************************************/
     implicitWidth: Math.max(implicitBackgroundWidth + leftInset + rightInset,
@@ -136,7 +141,9 @@ T.Button {
         radius: 5
         color: !control.enabled ? Style.colors.primaryBackground :
                control.down ? Style.colors.surfaceMuted :
-               control.hovered ? Style.colors.cardBackground : Style.colors.secondaryBackground
+               control.hovered ? control.hoverBackgroundColor : control.backgroundColor
+        border.width: control.borderWidth
+        border.color: control.borderColor
     }
 
     ToolTip {

--- a/Qml/View/Components/Base/ContextMenu.qml
+++ b/Qml/View/Components/Base/ContextMenu.qml
@@ -13,7 +13,10 @@ Popup {
 
     /* Property Declarations
      * ****************************************************************************************/
-    property var menuModel: [] // Format: [{ text: "Checkout", icon: "\uf00c", action: function(){}, enabled: true }]
+    //! Format: [{ text: "Checkout", icon: "\uf00c", action: function(){}, enabled: true,
+    //!            color: "#DC3545",      // optional: tints both label and icon
+    //!            iconColor: "#DC3545" }] // optional: tints the icon only
+    property var menuModel: []
 
     /* Object Properties
      * ****************************************************************************************/
@@ -77,6 +80,15 @@ Popup {
             readonly property bool isEnabled: !isSep && modelData.enabled !== false
             readonly property bool hasSub:    !isSep && !!modelData.subItems && modelData.subItems.length > 0
 
+            //! Per-item tinting: "color" applies to label and icon, "iconColor" overrides the icon.
+            readonly property bool  hasColor:  !isSep && modelData.color !== undefined && modelData.color !== ""
+            readonly property color textColor: hasColor ? modelData.color : Style.colors.foreground
+            readonly property color iconColor: (!isSep && modelData.iconColor !== undefined && modelData.iconColor !== "")
+                                               ? modelData.iconColor
+                                               : (hasColor ? modelData.color
+                                                           : (itemMouse.containsMouse ? Style.colors.accent
+                                                                                      : Style.colors.foreground))
+
             // Separator line
             Rectangle {
                 visible: isSep
@@ -111,7 +123,7 @@ Popup {
                     text: modelData.icon || ""
                     font.family: Style.fontTypes.font6ProSolid
                     font.pixelSize: Style.appFont.mediumPt
-                    color: itemMouse.containsMouse ? Style.colors.accent : Style.colors.foreground
+                    color: menuOption.iconColor
                     visible: text !== ""
                     Layout.preferredWidth: 16
                 }
@@ -121,7 +133,7 @@ Popup {
                     text: modelData.text || ""
                     font.family: Style.fontTypes.inter
                     font.pixelSize: Style.appFont.mediumPt
-                    color: Style.colors.foreground
+                    color: menuOption.textColor
                     Layout.fillWidth: true
                 }
 

--- a/Qml/View/Components/Base/DashedButton.qml
+++ b/Qml/View/Components/Base/DashedButton.qml
@@ -1,0 +1,130 @@
+import QtQuick
+import QtQuick.Controls
+
+import GitEase_Style
+import GitEase_Style_Impl
+
+/*! ***********************************************************************************************
+ * DashedButton
+ * ************************************************************************************************/
+AbstractButton {
+    id: root
+
+    /* Property Declarations
+     * ****************************************************************************************/
+    property real   radius:          Style.dp(4)
+    property string iconText:        Style.icons.plus
+    property real   disabledOpacity: 0.4
+    property color  textColor:       root.hovered && root.enabled ? Style.colors.dashedButtonTextHover
+                                                                  : Style.colors.dashedButtonText
+    property color  borderColor:     root.hovered && root.enabled ? Style.colors.dashedButtonBorderHover
+                                                                  : Style.colors.dashedButtonBorder
+
+
+    readonly property color effectiveTextColor:
+        root.enabled ? root.textColor
+                     : Qt.rgba(root.textColor.r, root.textColor.g, root.textColor.b,
+                               root.disabledOpacity)
+
+    readonly property color effectiveBorderColor:
+        root.enabled ? root.borderColor
+                     : Qt.rgba(root.borderColor.r, root.borderColor.g, root.borderColor.b,
+                               root.disabledOpacity)
+
+    /* Object Properties
+     * ****************************************************************************************/
+    implicitHeight: Style.dp(27)
+    implicitWidth:  label.implicitWidth + Style.dp(28)
+
+    hoverEnabled: true
+
+    font.family:    Style.fontTypes.inter
+    font.weight:    Font.Medium
+    font.pixelSize: Style.appFont.captionPt
+
+    onEffectiveBorderColorChanged: dashedBorder.requestPaint()
+
+    /* Children
+     * ****************************************************************************************/
+    background: Item {
+        Rectangle {
+            anchors.fill: parent
+            radius: root.radius
+            color: root.hovered && root.enabled ? Style.colors.dashedButtonBackgroundHover
+                                                : "transparent"
+
+            Behavior on color {
+                ColorAnimation {
+                    duration: 120
+                }
+            }
+        }
+
+        Canvas {
+            id: dashedBorder
+            anchors.fill: parent
+            antialiasing: true
+
+            onPaint: {
+                const ctx = getContext("2d")
+                ctx.reset()
+
+                const inset = 0.5
+                const w = width  - inset * 2
+                const h = height - inset * 2
+                if (w <= 0 || h <= 0)
+                    return
+
+                const r = Math.min(root.radius, w / 2, h / 2)
+
+                ctx.strokeStyle = root.effectiveBorderColor
+                ctx.lineWidth = 1
+                ctx.setLineDash([2, 2])
+
+                ctx.beginPath()
+                ctx.moveTo(inset + r, inset)
+                ctx.lineTo(inset + w - r, inset)
+                ctx.arcTo(inset + w, inset, inset + w, inset + r, r)
+                ctx.lineTo(inset + w, inset + h - r)
+                ctx.arcTo(inset + w, inset + h, inset + w - r, inset + h, r)
+                ctx.lineTo(inset + r, inset + h)
+                ctx.arcTo(inset, inset + h, inset, inset + h - r, r)
+                ctx.lineTo(inset, inset + r)
+                ctx.arcTo(inset, inset, inset + r, inset, r)
+                ctx.closePath()
+                ctx.stroke()
+            }
+        }
+    }
+
+    contentItem: Item {
+        Row {
+            anchors.centerIn: parent
+            spacing: Style.dp(6)
+
+            Text {
+                anchors.verticalCenter: parent.verticalCenter
+                visible: root.iconText.length > 0
+                text: root.iconText
+                font.family: Style.fontTypes.font6Pro
+                font.weight: 400
+                font.pixelSize: root.font.pixelSize
+                color: root.effectiveTextColor
+            }
+
+            Text {
+                id: label
+                anchors.verticalCenter: parent.verticalCenter
+                text: root.text
+                font: root.font
+                color: root.effectiveTextColor
+            }
+        }
+    }
+
+    MouseArea {
+        anchors.fill: parent
+        acceptedButtons: Qt.NoButton
+        cursorShape: root.enabled ? Qt.PointingHandCursor : Qt.ArrowCursor
+    }
+}

--- a/Qml/View/Components/Base/RepositoryListItem.qml
+++ b/Qml/View/Components/Base/RepositoryListItem.qml
@@ -26,6 +26,15 @@ Rectangle {
 
     property bool   isExists:       false
 
+    property color backgroundColor:              Style.colors.secondaryBackground
+    property color hoverBackgroundColor:         Qt.darker(Style.colors.surfaceLight, 1.05)
+    property color selectedBackgroundColor:      Style.colors.accent
+    property color selectedHoverBackgroundColor: Style.colors.accentHover
+    property color nameColor:                    Style.colors.foreground
+    property color pathColor:                    Style.colors.mutedText
+    property color selectedTextColor:            Style.colors.secondaryForeground
+    property color missingPathColor:             Style.colors.error
+
     /* Signals
      * ****************************************************************************************/
     signal clicked(index : int)
@@ -37,14 +46,14 @@ Rectangle {
     color: {
         if (msa.containsMouse) {
             if (isSelected)
-                return Style.colors.accentHover
+                return root.selectedHoverBackgroundColor
             else
-                return Qt.darker(Style.colors.surfaceLight, 1.05)
+                return root.hoverBackgroundColor
         } else {
             if (isSelected)
-                return Style.colors.accent
+                return root.selectedBackgroundColor
             else
-                return Style.colors.secondaryBackground
+                return root.backgroundColor
         }
     }
 
@@ -67,7 +76,7 @@ Rectangle {
             font.family: Style.fontTypes.inter
             font.weight: 400
             font.letterSpacing: 0
-            color: root.isSelected ? Style.colors.secondaryForeground : Style.colors.foreground
+            color: root.isSelected ? root.selectedTextColor : root.nameColor
         }
 
         // Path row
@@ -80,7 +89,7 @@ Rectangle {
                 text: Style.icons.folder
                 font.family: Style.fontTypes.font6Pro
                 font.pixelSize: Style.appFont.smallPt
-                color: root.isSelected ? Style.colors.secondaryForeground : Style.colors.foreground
+                color: root.isSelected ? root.selectedTextColor : root.nameColor
             }
 
             // Path
@@ -88,7 +97,8 @@ Rectangle {
                 text: root.path
                 font.pixelSize: Style.appFont.smallPt
                 font.family: Style.fontTypes.inter
-                color: root.isSelected ? Style.colors.secondaryForeground : root.isExists ? Style.colors.mutedText : Style.colors.error
+                color: root.isSelected ? root.selectedTextColor
+                                       : root.isExists ? root.pathColor : root.missingPathColor
                 font.weight: 400
                 font.strikeout: !root.isExists
                 font.letterSpacing: 0

--- a/Qml/View/Components/Base/UtilitiesCard.qml
+++ b/Qml/View/Components/Base/UtilitiesCard.qml
@@ -27,18 +27,22 @@ Rectangle {
     property int                badgeCount:         -1
     property bool               collapsed:          true
 
+    property real               headerHeight:       Style.dp(30)
+
+    property real               contentBottomInset: Style.dp(10)
+
     /* Object Properties
      * ****************************************************************************************/
     width: Style.dp(279)
-    height: root.collapsed ? headerRow.implicitHeight + 12 : mainColumn.implicitHeight
+    height: (root.collapsed ? root.headerHeight
+                            : mainColumn.implicitHeight + root.contentBottomInset) + topBorder.height
 
-    color: Style.colors.primaryBackground
-    border.width: 1
-    border.color: Style.colors.primaryBorder
+    color: Style.colors.utilitiesCardBackground
+    border.width: 0
 
     Behavior on height {
         NumberAnimation {
-            duration: 150
+            duration: 200
             easing.type: Easing.OutCubic
         }
     }
@@ -49,12 +53,20 @@ Rectangle {
     /* Children
      * ****************************************************************************************/
 
+    Rectangle {
+        id: topBorder
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.top: parent.top
+        height: 1
+        color: Style.colors.utilitiesCardSeparator
+    }
+
     ColumnLayout {
         id: mainColumn
         anchors.left: parent.left
         anchors.right: parent.right
-        anchors.top: parent.top
-        anchors.margins: 1
+        anchors.top: topBorder.bottom
         height: implicitHeight
         spacing: 0
 
@@ -62,51 +74,55 @@ Rectangle {
         Rectangle {
             id: headerRectangle
             Layout.fillWidth: true
-            Layout.alignment: Qt.AlignVCenter
-            Layout.preferredHeight: headerRow.implicitHeight + 10
-            color: hoverHandler.hovered ? Style.colors.secondaryBackground : "transparent"
+            Layout.preferredHeight: root.headerHeight
+            color: hoverHandler.hovered ? Style.colors.utilitiesCardHeaderHoverBackground
+                                        : Style.colors.utilitiesCardHeaderBackground
 
             RowLayout {
                 id: headerRow
                 anchors.fill: parent
                 anchors.leftMargin: 15
                 anchors.rightMargin: 15
-                anchors.topMargin: 5
-                anchors.bottomMargin: 5
                 spacing: 10
 
                 Label {
+                    Layout.alignment: Qt.AlignVCenter
                     text: root.icon
-                    color: Style.colors.accent
+                    color: Style.colors.utilitiesCardHeaderIcon
                     font.family: Style.fontTypes.font6Pro
-                    font.pixelSize: Style.appFont.largerPt
+                    font.weight: 400
+                    font.pixelSize: Style.appFont.largePt
+                    verticalAlignment: Text.AlignVCenter
                 }
 
                 Label {
                     Layout.fillWidth: true
+                    Layout.alignment: Qt.AlignVCenter
                     text: root.title
-                    color: Style.colors.foreground
+                    color: Style.colors.utilitiesCardTitle
                     font.family: Style.fontTypes.inter
                     font.pixelSize: Style.appFont.h4Pt
                     font.bold: true
                     elide: Text.ElideRight
+                    verticalAlignment: Text.AlignVCenter
                 }
 
                 Rectangle {
                     id: badge
+                    Layout.alignment: Qt.AlignVCenter
                     visible: root.badgeCount >= 0
                     implicitHeight: 18
                     implicitWidth: Math.max(implicitHeight, badgeLabel.implicitWidth + 10)
                     radius: implicitHeight / 2
-                    color: Style.colors.secondaryBackground
+                    color: Style.colors.utilitiesCardBadgeBackground
                     border.width: 1
-                    border.color: Style.colors.primaryBorder
+                    border.color: Style.colors.utilitiesCardBadgeBorder
 
                     Label {
                         id: badgeLabel
                         anchors.centerIn: parent
                         text: root.badgeCount
-                        color: Style.colors.mutedText
+                        color: Style.colors.utilitiesCardBadgeText
                         font.family: Style.fontTypes.inter
                         font.pixelSize: 10
                         font.bold: true
@@ -118,11 +134,13 @@ Rectangle {
                 }
 
                 Label {
+                    Layout.alignment: Qt.AlignVCenter
                     text: root.collapsed ? Style.icons.caretDown : Style.icons.caretUp
-                    color: Style.colors.mutedText
+                    color: Style.colors.utilitiesCardChevron
                     font.family: Style.fontTypes.inter
                     font.pixelSize: 10
                     font.bold: true
+                    verticalAlignment: Text.AlignVCenter
                 }
 
                 TapHandler {
@@ -131,6 +149,7 @@ Rectangle {
 
                 HoverHandler {
                     id: hoverHandler
+                    cursorShape: Qt.PointingHandCursor
                 }
             }
         }
@@ -141,7 +160,6 @@ Rectangle {
             visible: !root.collapsed
             sourceComponent: root.content
             Layout.fillWidth: true
-            Layout.margins: 10
             Layout.topMargin: 5
             Layout.preferredHeight: item ? item.implicitHeight : 0
 

--- a/Qml/View/Components/Branch/BranchManagementView.qml
+++ b/Qml/View/Components/Branch/BranchManagementView.qml
@@ -53,7 +53,7 @@ UtilitiesCard {
                         targetProvider: function() { return listView },
                         icon: Style.icons.branch,
                         title: "All Branches",
-                        description: "Every local and remote-tracking branch appears here. Click Checkout to switch to one, or the trash icon to delete it."
+                        description: "Every local and remote-tracking branch appears here. The current branch is marked HEAD. Right-click a branch to check it out, copy its name or delete it."
                     },
                     {
                         targetProvider: function() { return addBranchBtn },
@@ -99,19 +99,21 @@ UtilitiesCard {
         Rectangle {
             id: viewControl
             Layout.fillWidth: true
-            Layout.preferredHeight: Style.dp(25)
+            Layout.leftMargin: Style.dp(10)
+            Layout.rightMargin: Style.dp(10)
+            Layout.preferredHeight: Style.dp(27)
             radius: Style.dp(5)
-            color: Style.colors.cardBackground
+            color: Style.colors.utilitiesSegmentTrackBackground
 
             border {
                 width: Style.dp(1)
-                color: Style.colors.primaryBorder
+                color: Style.colors.utilitiesSegmentTrackBorder
             }
 
             RowLayout {
                 anchors.fill: parent
                 spacing: 4
-                anchors.margins: 2
+                anchors.margins: 3
 
                 IconButton {
                     id: localBtn
@@ -128,15 +130,18 @@ UtilitiesCard {
 
                     display: IconButton.TextBesideIcon
                     icon.name: Style.icons.laptop
-                    icon.width: Style.appFont.smallPt
-                    icon.height: Style.appFont.smallPt
-                    icon.color: Style.colors.foreground
+                    icon.width: Style.appFont.mediumPt
+                    icon.height: Style.appFont.mediumPt
+                    icon.color: localBtn.checked ? Style.colors.utilitiesSegmentSelectedText
+                                                 : Style.colors.utilitiesSegmentText
                     text: "Local"
-                    font.pixelSize: Style.appFont.smallPt
+                    font.pixelSize: Style.appFont.mediumPt
 
                     background: Rectangle {
                         radius: viewControl.radius
-                        color: localBtn.checked ? Style.colors.primaryBackground : "transparent"
+                        color: localBtn.checked ? Style.colors.utilitiesSegmentSelectedBackground
+                               : (localBtn.hovered ? Style.colors.utilitiesSegmentHoverBackground
+                                                   : "transparent")
                     }
 
                     onClicked: content.currentIndex = 0
@@ -157,15 +162,18 @@ UtilitiesCard {
 
                     display: IconButton.TextBesideIcon
                     icon.name: Style.icons.cloud
-                    icon.width: Style.appFont.smallPt
-                    icon.height: Style.appFont.smallPt
-                    icon.color: Style.colors.foreground
+                    icon.width: Style.appFont.mediumPt
+                    icon.height: Style.appFont.mediumPt
+                    icon.color: remoteBtn.checked ? Style.colors.utilitiesSegmentSelectedText
+                                                  : Style.colors.utilitiesSegmentText
                     text: "Remote"
-                    font.pixelSize: Style.appFont.smallPt
+                    font.pixelSize: Style.appFont.mediumPt
 
                     background: Rectangle {
                         radius: viewControl.radius
-                        color: remoteBtn.checked ? Style.colors.primaryBackground : "transparent"
+                        color: remoteBtn.checked ? Style.colors.utilitiesSegmentSelectedBackground
+                               : (remoteBtn.hovered ? Style.colors.utilitiesSegmentHoverBackground
+                                                    : "transparent")
                     }
 
                     onClicked: content.currentIndex = 1
@@ -182,24 +190,15 @@ UtilitiesCard {
             onUpdateRequested: content.update()
         }
 
-        IconButton {
+        DashedButton {
             id: addBranchBtn
             Layout.fillWidth: true
-            implicitHeight: Style.dp(25)
+            Layout.leftMargin: Style.dp(10)
+            Layout.rightMargin: Style.dp(10)
+            Layout.topMargin: Style.dp(2)
             visible: content.currentIndex === 0
 
-            display: IconButton.TextBesideIcon
-            icon.name: Style.icons.plus
-            icon.width: Style.appFont.smallPt
-            icon.height: Style.appFont.smallPt
-            icon.color: Style.colors.textButton
-            text: "Add New Branch"
-            font.pixelSize: Style.appFont.mediumPt
-
-            background: Rectangle {
-                radius: Style.dp(4)
-                color: enabled ? Style.colors.accent : Style.colors.disabledButton
-            }
+            text: "Add Branch"
 
             onClicked: {
                 openAddBranchPopup()
@@ -211,12 +210,21 @@ UtilitiesCard {
                 root.currentBranch = branchController.getCurrentBranchName()
                 let res = branchController.getBranches();
 
-                content.localBranches = res.filter(branch => branch["isLocal"])
+                content.localBranches = content.headFirst(res.filter(branch => branch["isLocal"]))
                 content.remoteBranches = res.filter(branch => branch["isRemote"])
 
                 content.updateModel(res)
                 root.badgeCount = content.localBranches.length + content.remoteBranches.length
             }
+        }
+
+        //! Moves the checked-out branch to the top; the rest keep the order git reported.
+        function headFirst(branches) {
+            let head = branches.findIndex(branch => branch["name"] === root.currentBranch)
+            if (head > 0)
+                branches.unshift(branches.splice(head, 1)[0])
+
+            return branches
         }
 
         function updateModel(res) {

--- a/Qml/View/Components/Branch/BranchesList.qml
+++ b/Qml/View/Components/Branch/BranchesList.qml
@@ -30,7 +30,7 @@ ListView {
      * ****************************************************************************************/
     Layout.fillWidth: true
     Layout.preferredHeight: Math.min(contentHeight, maxHeight)
-    spacing: 4
+    spacing: 0
     clip: true
 
     ScrollBar.vertical: ScrollBar {
@@ -50,27 +50,43 @@ ListView {
 
     delegate: Rectangle {
         id: branchDelegate
-        property var branch: modelData
-        property bool hovered: false
+
+        readonly property var  branch:     modelData
+        readonly property bool isSelected: branchDelegate.branch.name === root.currentBranch
 
         width: root.width
-        height: 32
-        radius: 4
-        color: hoverHandler.hovered ? Style.colors.surfaceLight : Style.colors.secondaryBackground
+        height: Style.dp(30)
 
-        readonly property bool isSelected: branch.name === root.currentBranch
+        color: branchDelegate.isSelected ? Style.colors.utilitiesRowSelectedBackground
+                                         : (hoverHandler.hovered ? Style.colors.utilitiesRowHoverBackground
+                                                                 : "transparent")
+
+        border.width: 0
 
         HoverHandler {
             id: hoverHandler
         }
 
+        //! Selected-row indicator
+        Rectangle {
+            id: selectedIndicator
+            visible: branchDelegate.isSelected
+            anchors.left: parent.left
+            anchors.top: parent.top
+            anchors.bottom: parent.bottom
+            width: Style.dp(3)
+            radius: Style.dp(1.5)
+            color: Style.colors.utilitiesRowSelectedIndicator
+        }
+
+        //! Every branch action lives in the context menu
         MouseArea {
             id: rightClickArea
             anchors.fill: parent
             acceptedButtons: Qt.RightButton
             onClicked: (mouse) => {
                 var pos = mapToItem(Overlay.overlay, mouse.x, mouse.y)
-                itemContextMenu.menuModel = root.buildBranchMenu(branch)
+                itemContextMenu.menuModel = root.buildBranchMenu(branchDelegate.branch)
                 itemContextMenu.x = pos.x
                 itemContextMenu.y = pos.y
                 itemContextMenu.open()
@@ -79,78 +95,39 @@ ListView {
 
         RowLayout {
             anchors.fill: parent
-            anchors.margins: 6
-            anchors.leftMargin: Style.dp(10)
-            spacing: 6
+            //! Constant inset so rows stay aligned whether or not the indicator is shown
+            anchors.leftMargin: Style.dp(16)
+            anchors.rightMargin: Style.dp(10)
+            spacing: Style.dp(8)
 
             Text {
-                text: Style.icons.branch
+                text: root.isLocal ? Style.icons.branch : Style.icons.globe
                 font.family: Style.fontTypes.font6Pro
                 font.pixelSize: Style.appFont.smallPt
-                color: branchDelegate.isSelected ? Style.colors.branchSelectedAccent : Style.colors.foreground
+                color: branchDelegate.isSelected ? Style.colors.utilitiesRowSelectedText
+                                                 : Style.colors.utilitiesRowIcon
                 Layout.alignment: Qt.AlignVCenter
             }
 
             ScrollingText {
-                text: branch.name
+                text: branchDelegate.branch.name
                 Layout.fillWidth: true
                 font.family: Style.fontTypes.inter
                 font.pixelSize: Style.appFont.smallPt
                 font.bold: branchDelegate.isSelected
-                color: branchDelegate.isSelected ? Style.colors.branchSelectedAccent : Style.colors.foreground
+                color: branchDelegate.isSelected ? Style.colors.utilitiesRowSelectedText
+                                                 : Style.colors.utilitiesRowText
             }
 
-            RowLayout {
-                spacing: 4
+            Text {
+                text: "HEAD"
+                visible: branchDelegate.isSelected
+                font.family: Style.fontTypes.inter
+                font.pixelSize: Style.appFont.microPt
+                font.bold: true
+                font.letterSpacing: Style.dp(0.5)
+                color: Style.colors.utilitiesRowSelectedText
                 Layout.alignment: Qt.AlignVCenter
-
-                RowLayout {
-                    spacing: 3
-                    visible: branch.name !== root.currentBranch
-
-                    MouseArea {
-                        id: checkoutArea
-                        Layout.preferredWidth: checkoutRow.implicitWidth
-                        Layout.preferredHeight: checkoutRow.implicitHeight
-                        cursorShape: Qt.PointingHandCursor
-
-                        onClicked: root.doCheckout(branch)
-
-                        RowLayout {
-                            id: checkoutRow
-                            anchors.fill: parent
-                            spacing: 4
-
-                            Text {
-                                text: Style.icons.check
-                                font.family: Style.fontTypes.font6Pro
-                                color: !hoverHandler.hovered ? Style.colors.accent : Qt.darker(Style.colors.accent, 1.5)
-                                font.pixelSize: Style.appFont.smallPt
-                                font.bold: true
-                                Layout.alignment: Qt.AlignVCenter
-                            }
-
-                            Text {
-                                text: "Checkout"
-                                font.family: Style.fontTypes.inter
-                                color: !hoverHandler.hovered ? Style.colors.accent : Qt.darker(Style.colors.accent, 1.5)
-                                font.pixelSize: Style.appFont.smallPt
-                                font.bold: true
-                                Layout.alignment: Qt.AlignVCenter
-                            }
-                        }
-                    }
-                }
-
-                // Delete Button
-                ActionIconButton {
-                    iconText: Style.icons.trash
-                    textColor: Style.colors.deletededFile
-                    tooltip: "Delete Branch"
-                    visible: branch.name !== root.currentBranch && root.isLocal
-                    Layout.alignment: Qt.AlignVCenter
-                    onClicked: root.doDeleteBranch(branch)
-                }
             }
         }
     }
@@ -235,6 +212,7 @@ ListView {
             actions.push({
                 text: "Delete Branch",
                 icon: Style.icons.trash,
+                color: Style.colors.contextMenuDanger,
                 action: function() { root.doDeleteBranch(branch) }
             })
         }

--- a/Qml/View/Components/Docks/RebaseDock.qml
+++ b/Qml/View/Components/Docks/RebaseDock.qml
@@ -30,6 +30,9 @@ UtilitiesCard {
     icon: Style.icons.copy
 
     content: ColumnLayout {
+        anchors.fill: parent
+        anchors.leftMargin: Style.dp(10)
+        anchors.rightMargin: Style.dp(10)
         spacing: 6
 
         GuideHoverTrigger {
@@ -78,7 +81,7 @@ UtilitiesCard {
             Text {
                 text: "Upstream"
                 font.pixelSize: Style.appFont.captionPt
-                color: Style.colors.mutedText
+                color: Style.colors.utilitiesFieldLabel
             }
             TextField {
                 id: upstreamInput
@@ -87,12 +90,16 @@ UtilitiesCard {
                 placeholderText: "branch, tag, or commit SHA"
                 selectByMouse: true
                 font.pixelSize: Style.appFont.smallPt
+                color: Style.colors.utilitiesInputText
+                placeholderTextColor: Style.colors.utilitiesInputPlaceholder
 
                 background: Rectangle {
                     implicitHeight: Style.dp(25)
-                    color: Style.colors.secondaryBackground
+                    color: Style.colors.utilitiesInputBackground
                     radius: Style.dp(4)
-                    border.color: upstreamInput.activeFocus ? Style.colors.accent : "transparent"
+                    border.width: 1
+                    border.color: upstreamInput.activeFocus ? Style.colors.utilitiesInputBorderFocus
+                                                              : Style.colors.utilitiesInputBorder
                 }
             }
         }
@@ -105,7 +112,7 @@ UtilitiesCard {
             Text {
                 text: "Branch to rebase"
                 font.pixelSize: Style.appFont.captionPt
-                color: Style.colors.mutedText
+                color: Style.colors.utilitiesFieldLabel
             }
 
             ComboBox {
@@ -120,13 +127,16 @@ UtilitiesCard {
                 model: branchModel
                 currentIndex: 0
 
-                Material.background: Style.colors.primaryBackground
-                Material.foreground: Style.colors.secondaryText
+                Material.background: Style.colors.utilitiesInputPopupBackground
+                Material.foreground: Style.colors.utilitiesInputText
 
                 background: Rectangle {
                     radius: Style.dp(4)
-                    color: branchCombo.hovered ? Style.colors.cardBackground : Style.colors.secondaryBackground
-                    border.color: branchCombo.activeFocus ? Style.colors.accent : "transparent"
+                    color: branchCombo.hovered ? Style.colors.utilitiesInputHoverBackground
+                                               : Style.colors.utilitiesInputBackground
+                    border.width: 1
+                    border.color: branchCombo.activeFocus ? Style.colors.utilitiesInputBorderFocus
+                                                            : Style.colors.utilitiesInputBorder
                 }
             }
         }
@@ -139,10 +149,10 @@ UtilitiesCard {
             font.family: Style.fontTypes.inter
             font.pixelSize: Style.appFont.smallPt
             implicitHeight: Style.dp(25)
-            Material.accent: Style.colors.accent
-            Material.foreground: Style.colors.foreground
+            Material.accent: Style.colors.utilitiesCheckBoxAccent
+            Material.foreground: Style.colors.utilitiesCheckBoxText
             palette {
-                text: Style.colors.foreground
+                text: Style.colors.utilitiesCheckBoxText
             }
 
             checked: false
@@ -158,7 +168,7 @@ UtilitiesCard {
                 text: "Onto (new base)"
                 Layout.fillWidth: true
                 font.pixelSize: Style.appFont.captionPt
-                color: Style.colors.mutedText
+                color: Style.colors.utilitiesFieldLabel
             }
             TextField {
                 id: ontoInput
@@ -167,36 +177,29 @@ UtilitiesCard {
                 placeholderText: "branch, tag, or commit SHA"
                 selectByMouse: true
                 font.pixelSize: Style.appFont.smallPt
+                color: Style.colors.utilitiesInputText
+                placeholderTextColor: Style.colors.utilitiesInputPlaceholder
 
                 background: Rectangle {
                     implicitHeight: Style.dp(25)
-                    color: Style.colors.secondaryBackground
+                    color: Style.colors.utilitiesInputBackground
                     radius: Style.dp(4)
-                    border.color: ontoInput.activeFocus ? Style.colors.accent : "transparent"
+                    border.width: 1
+                    border.color: ontoInput.activeFocus ? Style.colors.utilitiesInputBorderFocus
+                                                          : Style.colors.utilitiesInputBorder
                 }
             }
         }
 
         // Rebase button
-        IconButton {
+        DashedButton {
             id: startRebaseBtn
             Layout.fillWidth: true
-            implicitHeight: Style.dp(25)
+            Layout.topMargin: Style.dp(2)
             enabled: upstreamInput.text.trim().length > 0
 
-            display: IconButton.TextBesideIcon
-            icon.name: Style.icons.copy
-            icon.width: Style.appFont.smallPt
-            icon.height: Style.appFont.smallPt
-            icon.color: Style.colors.secondaryForeground
+            iconText: Style.icons.copy
             text: "Start Rebase"
-            font.pixelSize: Style.appFont.mediumPt
-
-            background: Rectangle {
-                radius: Style.dp(4)
-                color: startRebaseBtn.enabled ? (startRebaseBtn.hovered ? Style.colors.accentHover : Style.colors.accent)
-                                               : Style.colors.disabledButton
-            }
 
             onClicked: previewRebase(upstreamInput.text, ontoInput.text, advancedToggle.checked, branchCombo.currentIndex)
         }

--- a/Qml/View/Components/Docks/RecentActivityDock.qml
+++ b/Qml/View/Components/Docks/RecentActivityDock.qml
@@ -18,6 +18,8 @@ UtilitiesCard {
 
     content: ColumnLayout {
         anchors.fill: parent
+        anchors.leftMargin: Style.dp(10)
+        anchors.rightMargin: Style.dp(10)
         spacing: 8
 
         GuideHoverTrigger {
@@ -42,7 +44,7 @@ UtilitiesCard {
             Layout.fillWidth: true
             Layout.preferredHeight: Math.min(listView.contentHeight, 220) + 12
             radius: 4
-            color: Style.colors.secondaryBackground
+            color: Style.colors.utilitiesSurfaceBackground
 
             ListView {
                 id: listView
@@ -59,7 +61,9 @@ UtilitiesCard {
                     width: listView.width
                     height: Style.dp(35)
                     radius: Style.dp(4)
-                    color: Style.colors.primaryBackground
+                    color: Style.colors.utilitiesRowBackground
+                    border.width: 1
+                    border.color: Style.colors.utilitiesRowBorder
 
                     ColumnLayout {
                         anchors.fill: parent
@@ -71,7 +75,7 @@ UtilitiesCard {
                             spacing: 1
 
                             Text  {
-                                color: Style.colors.foreground
+                                color: Style.colors.utilitiesRowIcon
                                 font.family: Style.fontTypes.inter
                                 font.pixelSize: Style.appFont.smallPt
                                 text: "$ "
@@ -79,7 +83,7 @@ UtilitiesCard {
 
                             ScrollingText  {
                                 Layout.fillWidth: true
-                                color: Style.colors.foreground
+                                color: Style.colors.utilitiesRowText
                                 font.family: Style.fontTypes.inter
                                 font.pixelSize: Style.appFont.smallPt
                                 text: modelData.command
@@ -89,7 +93,7 @@ UtilitiesCard {
                         Text {
                             Layout.fillWidth: true
                             text: Qt.formatDateTime(modelData.time, "MMM dd, yyyy hh:mm:ss")
-                            color: Style.colors.mutedText
+                            color: Style.colors.utilitiesRowMetaText
                             font.family: Style.fontTypes.inter
                             font.pixelSize: Style.appFont.captionPt
                             elide: Text.ElideRight
@@ -104,7 +108,7 @@ UtilitiesCard {
                 anchors.centerIn: parent
                 visible: activityController.activities.length === 0
                 text: "No recent activity yet"
-                color: Style.colors.mutedText
+                color: Style.colors.utilitiesEmptyStateText
                 font.family: Style.fontTypes.inter
                 font.pixelSize: Style.appFont.smallPt
             }

--- a/Qml/View/Components/Docks/RepositoriesHistoryDock.qml
+++ b/Qml/View/Components/Docks/RepositoriesHistoryDock.qml
@@ -29,6 +29,8 @@ UtilitiesCard {
     content: ColumnLayout {
         id: content
         anchors.fill: parent
+        anchors.leftMargin: Style.dp(10)
+        anchors.rightMargin: Style.dp(10)
         spacing: 6
 
         GuideHoverTrigger {
@@ -67,6 +69,15 @@ UtilitiesCard {
                 id: item
                 implicitWidth: parent.width
                 implicitHeight: Style.dp(35)
+                border.width: 1
+                border.color: Style.colors.utilitiesRowBorder
+
+                backgroundColor:      Style.colors.utilitiesRowBackground
+                hoverBackgroundColor: Style.colors.utilitiesRowHoverBackground
+                nameColor:            Style.colors.utilitiesRowText
+                pathColor:            Style.colors.utilitiesRowSubText
+                missingPathColor:     Style.colors.utilitiesRowMissingText
+
                 name: modelData.split('/').pop() || modelData.split('\\').pop()
                 path: modelData
                 isExists: root.repositoryController.appModel.fileIO.isFileExist(modelData)
@@ -78,25 +89,20 @@ UtilitiesCard {
             onContentHeightChanged: root.pageScrollBlocking = scrollView.contentHeight > scrollView.height + 1
         }
 
-        IconButton {
+        DashedButton {
             id: actionBtn
             Layout.fillWidth: true
-            implicitHeight: Style.dp(25)
+            Layout.topMargin: Style.dp(2)
 
             enabled: root.repositoryController.appModel.repositoriesHistory.length > 0
 
-            display: IconButton.TextBesideIcon
-            icon.name: Style.icons.trash
-            icon.width: Style.appFont.smallPt
-            icon.height: Style.appFont.smallPt
-            icon.color: Style.colors.selectedText
+            iconText: Style.icons.trash
             text: "Clear history"
-            font.pixelSize: Style.appFont.mediumPt
 
-            background: Rectangle {
-                radius: Style.dp(4)
-                color: actionBtn.enabled ? Style.colors.error : Style.colors.disabledButton
-            }
+            textColor: actionBtn.hovered && actionBtn.enabled ? Style.colors.dashedButtonTextDanger
+                                                              : Style.colors.dashedButtonText
+            borderColor: actionBtn.hovered && actionBtn.enabled ? Style.colors.dashedButtonBorderDanger
+                                                                : Style.colors.dashedButtonBorder
 
             onClicked: {
                 root.repositoryController.appModel.repositoriesHistory = []

--- a/Qml/View/Components/Docks/StashManagerDock.qml
+++ b/Qml/View/Components/Docks/StashManagerDock.qml
@@ -44,6 +44,8 @@ UtilitiesCard {
     content: ColumnLayout {
         id: content
         anchors.fill: parent
+        anchors.leftMargin: Style.dp(10)
+        anchors.rightMargin: Style.dp(10)
         spacing: 6
 
         GuideHoverTrigger {
@@ -119,7 +121,10 @@ UtilitiesCard {
                 height: Style.dp(35)
                 radius: 4
                 property bool selected: root.selectedStash && root.selectedStash.index === modelData.index
-                color: selected ? Style.colors.hoverTitle : Style.colors.secondaryBackground
+                color: selected ? Style.colors.utilitiesRowSelectedBackground
+                                : Style.colors.utilitiesRowBackground
+                border.width: 1
+                border.color: Style.colors.utilitiesRowBorder
 
                 MouseArea {
                     id: rightClickArea
@@ -145,14 +150,14 @@ UtilitiesCard {
                         ScrollingText {
                             Layout.fillWidth: true
                             text: modelData.message || qsTr("WIP on %1").arg(modelData.author || "unknown")
-                            color: Style.colors.foreground
+                            color: Style.colors.utilitiesRowText
                             font.family: Style.fontTypes.inter
                             font.pixelSize: Style.appFont.smallPt
                         }
                         Text {
                             Layout.fillWidth: true
                             text: modelData.dateTime ? Qt.formatDateTime(modelData.dateTime, "MMM dd, yyyy hh:mm") : ""
-                            color: Style.colors.mutedText
+                            color: Style.colors.utilitiesRowMetaText
                             font.family: Style.fontTypes.inter
                             font.pixelSize: Style.appFont.captionPt
                             elide: Text.ElideRight
@@ -165,28 +170,28 @@ UtilitiesCard {
                         ActionIconButton {
                             iconText: Style.icons.file
                             tooltip: "Open"
-                            textColor: Style.colors.mutedText
+                            textColor: Style.colors.utilitiesActionIcon
                             onClicked: root.openPreview(modelData)
                         }
 
                         ActionIconButton {
                             iconText: Style.icons.undo
                             tooltip: "Pop"
-                            textColor: Style.colors.mutedText
+                            textColor: Style.colors.utilitiesActionIcon
                             onClicked: root.popStash(modelData)
                         }
 
                         ActionIconButton {
                             iconText: Style.icons.check
                             tooltip: "Apply"
-                            textColor: Style.colors.mutedText
+                            textColor: Style.colors.utilitiesActionIcon
                             onClicked: root.applyStash(modelData)
                         }
 
                         ActionIconButton {
                             iconText: Style.icons.trash
                             tooltip: "Drop"
-                            textColor: Style.colors.deletededFile
+                            textColor: Style.colors.utilitiesActionIconDanger
                             onClicked: root.dropStash(modelData)
                         }
                     }
@@ -196,26 +201,14 @@ UtilitiesCard {
             onContentHeightChanged: root.pageScrollBlocking = stashListView.contentHeight > stashListView.height + 1
         }
 
-        IconButton {
+        DashedButton {
             id: actionBtn
             Layout.fillWidth: true
-            implicitHeight: Style.dp(25)
+            Layout.topMargin: Style.dp(2)
 
             enabled: root.canStash
 
-            display: IconButton.TextBesideIcon
-            icon.name: Style.icons.plus
-            icon.width: Style.appFont.smallPt
-            icon.height: Style.appFont.smallPt
-            icon.color: Style.colors.textButton
-            text: "Stash"
-            font.pixelSize: Style.appFont.mediumPt
-
-            background: Rectangle {
-                radius: Style.dp(4)
-                color: actionBtn.enabled ? (actionBtn.hovered ? Style.colors.accentHover : Style.colors.accent)
-                                            : Style.colors.disabledButton
-            }
+            text: "Add Stash"
 
             onClicked: root.openAddEditPopup()
         }

--- a/Qml/View/Components/GraphView/GraphViewHeader.qml
+++ b/Qml/View/Components/GraphView/GraphViewHeader.qml
@@ -49,9 +49,29 @@ RowLayout {
 
     /* Object Properties
      * ****************************************************************************************/
-    spacing             : (parent && parent.width < Style.appHeight) ? 6 : 10
+    spacing             : (parent && parent.width < Style.appHeight) ? 3 : 5
     anchors.leftMargin  : (parent && parent.width < Style.appHeight) ? 8 : 20
     anchors.rightMargin : (parent && parent.width < Style.appHeight) ? 4 : 5
+
+    Text {
+        text: "Commit Graph"
+        color: Style.colors.descriptionText
+        font.family: Style.fontTypes.inter
+        font.weight: Font.DemiBold
+        font.pixelSize: Style.appFont.smallPt
+
+        visible: !headerRow.compact
+    }
+
+    Rectangle {
+        Layout.preferredHeight: parent.height - Style.dp(8)
+        Layout.preferredWidth: Style.dp(1)
+        Layout.alignment: Qt.AlignVCenter
+
+        color: Style.colors.primaryBorder
+
+        visible: !headerRow.compact
+    }
 
     Item {
         id: textFilterArea
@@ -66,7 +86,11 @@ RowLayout {
             width: textFilterArea.width
             height: textFilterArea.height
             placeholderTextColor: Style.colors.descriptionText
-            backgroundColor: hovered ? Style.colors.cardBackground : Style.colors.secondaryBackground
+            hoverEnabled: true
+            backgroundColor: textFilterField.hovered ? Style.colors.headerButtonBackgroundHover
+                                                     : Style.colors.headerButtonBackground
+            borderColor: Style.colors.headerButtonBorder
+
             minHeight: headerRow.controlSize
             placeholderText: {
                 var modes = headerRow.filterModes || []
@@ -78,7 +102,7 @@ RowLayout {
             font.weight: 400
             font.pixelSize: Style.appFont.captionPt
             borderRadius: 5
-            borderWidth: 0
+            borderWidth: 1
             focusBorderWidth: 1
             onTextChanged: {
                 headerRow.filterText = text
@@ -96,6 +120,10 @@ RowLayout {
 
     IconButton {
         id: filterButton
+        backgroundColor: Style.colors.headerButtonBackground
+        hoverBackgroundColor: Style.colors.headerButtonBackgroundHover
+        borderColor: Style.colors.headerButtonBorder
+        borderWidth: 1
         Layout.preferredHeight: headerRow.controlSize
 
         text: "Filters"
@@ -226,6 +254,10 @@ RowLayout {
 
     IconButton {
         id: pullBtn
+        backgroundColor: Style.colors.headerButtonBackground
+        hoverBackgroundColor: Style.colors.headerButtonBackgroundHover
+        borderColor: Style.colors.headerButtonBorder
+        borderWidth: 1
         Layout.preferredHeight: headerRow.controlSize
 
         solidIcon: true
@@ -253,7 +285,9 @@ RowLayout {
         background: Rectangle {
             radius: 5
             color: pushBtnHeader.down ? Style.colors.surfaceMuted :
-                   pushBtnHeader.hovered ? Style.colors.cardBackground : Style.colors.secondaryBackground
+                   pushBtnHeader.hovered ? Style.colors.headerButtonBackgroundHover : Style.colors.headerButtonBackground
+            border.width: 1
+            border.color: Style.colors.headerButtonBorder
         }
 
         BusyIndicator {
@@ -282,6 +316,10 @@ RowLayout {
 
     IconButton {
         id: fetchBtnHeader
+        backgroundColor: Style.colors.headerButtonBackground
+        hoverBackgroundColor: Style.colors.headerButtonBackgroundHover
+        borderColor: Style.colors.headerButtonBorder
+        borderWidth: 1
         Layout.preferredHeight: headerRow.controlSize
 
         enabled: !headerRow.isFetching
@@ -302,6 +340,10 @@ RowLayout {
 
     IconButton {
         id: reloadButton
+        backgroundColor: Style.colors.headerButtonBackground
+        hoverBackgroundColor: Style.colors.headerButtonBackgroundHover
+        borderColor: Style.colors.headerButtonBorder
+        borderWidth: 1
         Layout.preferredWidth: headerRow.controlSize
         Layout.preferredHeight: headerRow.controlSize
         Layout.leftMargin: compact ? 3 : (tight ? 5 : 7)
@@ -332,8 +374,11 @@ RowLayout {
         background: Rectangle {
             radius: 5
             color: panelToggleButton.down ? Style.colors.surfaceMuted :
-                   panelToggleButton.hovered ? Style.colors.cardBackground :
-                   headerRow.panelOpen ? Style.colors.subtleAzureGlow : "transparent"
+                   panelToggleButton.hovered ? Style.colors.headerButtonBackgroundHover :
+                   headerRow.panelOpen ? Style.colors.subtleAzureGlow
+                                       : Style.colors.headerButtonBackground
+            border.width: 1
+            border.color: Style.colors.headerButtonBorder
         }
 
         onClicked: headerRow.panelToggleRequested()

--- a/Qml/View/Components/ImportExport/ExportView.qml
+++ b/Qml/View/Components/ImportExport/ExportView.qml
@@ -45,8 +45,8 @@ Item {
 
             Text {
                 text: "Target Branch"
-                font.pixelSize: Style.appFont.captionPt
-                color: Style.colors.mutedText
+                font.pixelSize: Style.appFont.smallPt
+                color: Style.colors.utilitiesFieldLabel
             }
 
             ComboBox {
@@ -61,12 +61,16 @@ Item {
 
                 placeholderText: "Select branch"
 
-                Material.background: Style.colors.primaryBackground
-                Material.foreground: Style.colors.secondaryText
+                Material.background: Style.colors.utilitiesInputPopupBackground
+                Material.foreground: Style.colors.utilitiesInputText
 
                 background: Rectangle {
                     radius: Style.dp(5)
-                    color: branchesCombo.hovered ? Style.colors.cardBackground : Style.colors.secondaryBackground
+                    color: branchesCombo.hovered ? Style.colors.utilitiesInputHoverBackground
+                                                 : Style.colors.utilitiesInputBackground
+                    border.width: 1
+                    border.color: branchesCombo.activeFocus ? Style.colors.utilitiesInputBorderFocus
+                                                              : Style.colors.utilitiesInputBorder
                 }
 
                 onCurrentIndexChanged: {
@@ -90,8 +94,8 @@ Item {
 
             Text {
                 text: "Base Branch"
-                font.pixelSize: Style.appFont.captionPt
-                color: Style.colors.mutedText
+                font.pixelSize: Style.appFont.smallPt
+                color: Style.colors.utilitiesFieldLabel
             }
 
             ComboBox {
@@ -105,12 +109,16 @@ Item {
 
                 placeholderText: "Select Base"
 
-                Material.background: Style.colors.primaryBackground
-                Material.foreground: Style.colors.secondaryText
+                Material.background: Style.colors.utilitiesInputPopupBackground
+                Material.foreground: Style.colors.utilitiesInputText
 
                 background: Rectangle {
                     radius: Style.dp(5)
-                    color: baseBranchCombo.hovered ? Style.colors.cardBackground : Style.colors.secondaryBackground
+                    color: baseBranchCombo.hovered ? Style.colors.utilitiesInputHoverBackground
+                                                   : Style.colors.utilitiesInputBackground
+                    border.width: 1
+                    border.color: baseBranchCombo.activeFocus ? Style.colors.utilitiesInputBorderFocus
+                                                                : Style.colors.utilitiesInputBorder
                 }
             }
         }
@@ -121,8 +129,8 @@ Item {
 
             Text {
                 text: "Output Directory"
-                font.pixelSize: Style.appFont.captionPt
-                color: Style.colors.mutedText
+                font.pixelSize: Style.appFont.smallPt
+                color: Style.colors.utilitiesFieldLabel
             }
 
             RowLayout {
@@ -134,7 +142,9 @@ Item {
                     Layout.fillWidth: true
                     Layout.preferredHeight: Style.dp(25)
                     radius: Style.dp(5)
-                    color: Style.colors.secondaryBackground
+                    color: Style.colors.utilitiesInputBackground
+                    border.width: 1
+                    border.color: Style.colors.utilitiesInputBorder
 
                     ScrollingText {
                         id: fileLabel
@@ -143,7 +153,8 @@ Item {
                         anchors.left: parent.left
                         anchors.right: parent.right
                         font.pixelSize: Style.appFont.smallPt
-                        color: root.selectedFolder === "" ? Style.colors.placeholderText : Style.colors.secondaryText
+                        color: root.selectedFolder === "" ? Style.colors.utilitiesInputPlaceholder
+                                                         : Style.colors.utilitiesInputText
                         text: root.selectedFolder !== "" ? root.selectedFolder : "Select Directory..."
                     }
                 }
@@ -162,14 +173,16 @@ Item {
                     icon.name: Style.icons.folder
                     icon.width: Style.appFont.smallPt
                     icon.height: Style.appFont.smallPt
-                    icon.color: fileButton.hovered ? Style.colors.secondaryForeground : Style.colors.secondaryText
+                    icon.color: fileButton.hovered ? Style.colors.utilitiesPickerButtonIconHover
+                                                   : Style.colors.utilitiesPickerButtonIcon
                     tooltip: "Select Directory"
 
                     background: Rectangle {
                         radius: 6
-                        color: fileButton.hovered ? Style.colors.accentHover : "transparent"
+                        color: fileButton.hovered ? Style.colors.utilitiesPickerButtonHoverBackground
+                                                  : Style.colors.utilitiesPickerButtonBackground
                         border.width: 1
-                        border.color: Style.colors.primaryBorder
+                        border.color: Style.colors.utilitiesPickerButtonBorder
                     }
 
                     onClicked: folderDialog.open()
@@ -177,25 +190,14 @@ Item {
             }
         }
 
-        IconButton {
+        DashedButton {
             id: exportButton
             Layout.fillWidth: true
             Layout.topMargin: Style.dp(5)
-            implicitHeight: Style.dp(25)
             enabled: root.selectedFolder !== "" && branchesCombo.currentIndex !== -1 && baseBranchCombo.currentIndex !== -1
 
-            display: IconButton.TextBesideIcon
-            icon.name: Style.icons.download
-            icon.width: Style.appFont.smallPt
-            icon.height: Style.appFont.smallPt
-            icon.color: Style.colors.secondaryForeground
+            iconText: Style.icons.download
             text: "Export"
-            font.pixelSize: Style.appFont.mediumPt
-
-            background: Rectangle {
-                radius: Style.dp(4)
-                color: exportButton.enabled ? Style.colors.accent : Style.colors.disabledButton
-            }
 
             onClicked: {
                 let base   = baseBranchCombo.model[baseBranchCombo.currentIndex]

--- a/Qml/View/Components/ImportExport/ImportExportBundle.qml
+++ b/Qml/View/Components/ImportExport/ImportExportBundle.qml
@@ -35,6 +35,9 @@ UtilitiesCard {
     icon: Style.icons.arowLeftRight
 
     content: ColumnLayout {
+        anchors.fill: parent
+        anchors.leftMargin: Style.dp(10)
+        anchors.rightMargin: Style.dp(10)
 
         GuideHoverTrigger {
             guideController: root.guideController
@@ -63,19 +66,19 @@ UtilitiesCard {
         Rectangle {
             id: viewControl
             Layout.fillWidth: true
-            Layout.preferredHeight: Style.dp(25)
+            Layout.preferredHeight: Style.dp(27)
             radius: Style.dp(5)
-            color: Style.colors.cardBackground
+            color: Style.colors.utilitiesSegmentTrackBackground
 
             border {
                 width: Style.dp(1)
-                color: Style.colors.primaryBorder
+                color: Style.colors.utilitiesSegmentTrackBorder
             }
 
             RowLayout {
                 anchors.fill: parent
                 spacing: 4
-                anchors.margins: 2
+                anchors.margins: 3
 
                 IconButton {
                     id: exportBtn
@@ -92,15 +95,18 @@ UtilitiesCard {
 
                     display: IconButton.TextBesideIcon
                     icon.name: Style.icons.download
-                    icon.width: Style.appFont.smallPt
-                    icon.height: Style.appFont.smallPt
-                    icon.color: Style.colors.foreground
+                    icon.width: Style.appFont.mediumPt
+                    icon.height: Style.appFont.mediumPt
+                    icon.color: exportBtn.checked ? Style.colors.utilitiesSegmentSelectedText
+                                                  : Style.colors.utilitiesSegmentText
                     text: "Export"
-                    font.pixelSize: Style.appFont.smallPt
+                    font.pixelSize: Style.appFont.mediumPt
 
                     background: Rectangle {
                         radius: viewControl.radius
-                        color: exportBtn.checked ? Style.colors.primaryBackground : "transparent"
+                        color: exportBtn.checked ? Style.colors.utilitiesSegmentSelectedBackground
+                               : (exportBtn.hovered ? Style.colors.utilitiesSegmentHoverBackground
+                                                    : "transparent")
                     }
 
                     onClicked: root.currentIndex = 0
@@ -121,15 +127,18 @@ UtilitiesCard {
 
                     display: IconButton.TextBesideIcon
                     icon.name: Style.icons.upload
-                    icon.width: Style.appFont.smallPt
-                    icon.height: Style.appFont.smallPt
-                    icon.color: Style.colors.foreground
+                    icon.width: Style.appFont.mediumPt
+                    icon.height: Style.appFont.mediumPt
+                    icon.color: importBtn.checked ? Style.colors.utilitiesSegmentSelectedText
+                                                  : Style.colors.utilitiesSegmentText
                     text: "Import"
-                    font.pixelSize: Style.appFont.smallPt
+                    font.pixelSize: Style.appFont.mediumPt
 
                     background: Rectangle {
                         radius: viewControl.radius
-                        color: importBtn.checked ? Style.colors.primaryBackground : "transparent"
+                        color: importBtn.checked ? Style.colors.utilitiesSegmentSelectedBackground
+                               : (importBtn.hovered ? Style.colors.utilitiesSegmentHoverBackground
+                                                    : "transparent")
                     }
 
                     onClicked: root.currentIndex = 1

--- a/Qml/View/Components/ImportExport/ImportView.qml
+++ b/Qml/View/Components/ImportExport/ImportView.qml
@@ -46,8 +46,8 @@ Item {
 
             Text {
                 text: "Bundle"
-                font.pixelSize: Style.appFont.captionPt
-                color: Style.colors.mutedText
+                font.pixelSize: Style.appFont.smallPt
+                color: Style.colors.utilitiesFieldLabel
             }
 
             RowLayout {
@@ -59,14 +59,18 @@ Item {
                     Layout.fillWidth: true
                     Layout.preferredHeight: Style.dp(25)
                     radius: Style.dp(5)
-                    color: Style.colors.secondaryBackground
+                    color: Style.colors.utilitiesInputBackground
+                    border.width: 1
+                    border.color: Style.colors.utilitiesInputBorder
+
                     ScrollingText {
                         id: fileLabel
                         anchors.verticalCenter: parent.verticalCenter
                         anchors.leftMargin: Style.dp(15)
                         anchors.left: parent.left
                         anchors.right: parent.right
-                        color: root.selectedFile === "" ? Style.colors.placeholderText : Style.colors.secondaryText
+                        color: root.selectedFile === "" ? Style.colors.utilitiesInputPlaceholder
+                                                       : Style.colors.utilitiesInputText
                         text: root.selectedFile !== "" ? root.selectedFile : "Select .bundle file..."
                     }
                 }
@@ -84,14 +88,16 @@ Item {
                     icon.name: Style.icons.folder
                     icon.width: Style.appFont.smallPt
                     icon.height: Style.appFont.smallPt
-                    icon.color: fileButton.hovered ? Style.colors.secondaryForeground : Style.colors.secondaryText
+                    icon.color: fileButton.hovered ? Style.colors.utilitiesPickerButtonIconHover
+                                                   : Style.colors.utilitiesPickerButtonIcon
                     tooltip: "Select bundle"
 
                     background: Rectangle {
                         radius: 6
-                        color: fileButton.hovered ? Style.colors.accentHover : "transparent"
+                        color: fileButton.hovered ? Style.colors.utilitiesPickerButtonHoverBackground
+                                                  : Style.colors.utilitiesPickerButtonBackground
                         border.width: 1
-                        border.color: Style.colors.primaryBorder
+                        border.color: Style.colors.utilitiesPickerButtonBorder
                     }
 
                     onClicked: fileDialog.open()
@@ -105,17 +111,22 @@ Item {
 
             Text {
                 text: "Branch"
-                font.pixelSize: Style.appFont.captionPt
-                color: Style.colors.mutedText
+                font.pixelSize: Style.appFont.smallPt
+                color: Style.colors.utilitiesFieldLabel
             }
 
             TextField {
                 id: branchTXF
                 Layout.fillWidth: true
                 Layout.preferredHeight: Style.dp(25)
+                color: Style.colors.utilitiesInputText
+                placeholderTextColor: Style.colors.utilitiesInputPlaceholder
                 background: Rectangle {
                     radius: Style.dp(5)
-                    color: Style.colors.secondaryBackground
+                    color: Style.colors.utilitiesInputBackground
+                    border.width: 1
+                    border.color: branchTXF.activeFocus ? Style.colors.utilitiesInputBorderFocus
+                                                        : Style.colors.utilitiesInputBorder
                 }
             }
         }
@@ -123,11 +134,11 @@ Item {
         // Hint row
         Rectangle {
             Layout.fillWidth: true
-            Layout.preferredHeight: Style.dp(32)
+            Layout.preferredHeight: Style.dp(46)
             radius: 4
-            color: Style.colors.secondaryBackground
+            color: Style.colors.utilitiesSurfaceBackground
             border.width: 1
-            border.color: Style.colors.secondaryBorder
+            border.color: Style.colors.utilitiesSurfaceBorder
 
             RowLayout {
                 anchors.fill: parent
@@ -144,32 +155,22 @@ Item {
                         anchors.leftMargin: 8
                         text: "Import will extract and restore the project structure, branches, and commit history from the selected archive."
                         wrapMode: Text.WordWrap
-                        font.pixelSize: Style.appFont.captionPt
-                        color: Style.colors.mutedText
+                        font.pixelSize: Style.appFont.smallPt
+                        color: Style.colors.utilitiesHintText
                         font.family: Style.fontTypes.inter
                     }
                 }
             }
         }
 
-        IconButton {
+        DashedButton {
             id: importButton
             Layout.fillWidth: true
-            implicitHeight: Style.dp(25)
+            Layout.topMargin: Style.dp(5)
             enabled: root.selectedFile !== "" && branchTXF.text !== ""
 
-            display: IconButton.TextBesideIcon
-            icon.name: Style.icons.upload
-            icon.width: Style.appFont.smallPt
-            icon.height: Style.appFont.smallPt
-            icon.color: Style.colors.secondaryForeground
+            iconText: Style.icons.upload
             text: "Import"
-            font.pixelSize: Style.appFont.mediumPt
-
-            background: Rectangle {
-                radius: Style.dp(4)
-                color: importButton.enabled ? Style.colors.accent : Style.colors.disabledButton
-            }
 
             onClicked: {
                 let res = root.bundleController.unbundle(root.selectedFile)

--- a/Qml/View/Components/Navigation/PagesRail.qml
+++ b/Qml/View/Components/Navigation/PagesRail.qml
@@ -151,7 +151,7 @@ Rectangle {
                                         text: (modelData && modelData.icon && modelData.icon.length)
                                               ? modelData.icon
                                               : Style.icons.download
-                                        font.pixelSize: 13
+                                        font.pixelSize: Style.appFont.h3Pt
                                         font.family: Style.fontTypes.font6Pro
                                         font.weight: (root.useAccentIndicator && item.isSelected) ? 600 : 500
                                         color: item.isSelected ? item.activeColor : item.inactiveColor
@@ -165,7 +165,7 @@ Rectangle {
                                     Layout.fillWidth: true
                                     Layout.alignment: Qt.AlignVCenter
                                     text: (modelData && modelData.title) ? modelData.title : ""
-                                    font.pixelSize: 13
+                                    font.pixelSize: Style.appFont.h3Pt
                                     font.family: Style.fontTypes.inter
                                     font.weight: (root.useAccentIndicator && item.isSelected) ? Font.DemiBold : Font.Normal
                                     color: item.isSelected ? item.activeColor : item.inactiveColor
@@ -187,7 +187,7 @@ Rectangle {
                                         text: modelData?.badgeCount ?? ""
                                         color: "white"
                                         font.family: Style.fontTypes.inter
-                                        font.pixelSize: 9
+                                        font.pixelSize: Style.appFont.smallPt
                                         font.bold: true
                                     }
                                 }

--- a/Qml/View/Components/Pages/CommittingPage/CommittingPageHeader.qml
+++ b/Qml/View/Components/Pages/CommittingPage/CommittingPageHeader.qml
@@ -39,7 +39,11 @@ RowLayout {
 
     IconButton {
         id: branchChip
-        Layout.preferredHeight: 26
+        backgroundColor: Style.colors.headerButtonBackground
+        hoverBackgroundColor: Style.colors.headerButtonBackgroundHover
+        borderColor: Style.colors.headerButtonBorder
+        borderWidth: 1
+        Layout.preferredHeight: 25
         maximumWidth: 150
 
         topPadding      : 4
@@ -91,6 +95,10 @@ RowLayout {
 
     IconButton {
         id: pullBtn
+        backgroundColor: Style.colors.headerButtonBackground
+        hoverBackgroundColor: Style.colors.headerButtonBackgroundHover
+        borderColor: Style.colors.headerButtonBorder
+        borderWidth: 1
         Layout.preferredHeight: 26
 
         topPadding      : 5
@@ -164,9 +172,9 @@ RowLayout {
         background: Rectangle {
             radius: 5
             color: pushBtnHeader.down ? Style.colors.surfaceMuted :
-                   pushBtnHeader.hovered ? Style.colors.cardBackground : Style.colors.secondaryBackground
+                   pushBtnHeader.hovered ? Style.colors.headerButtonBackgroundHover : Style.colors.headerButtonBackground
             border.width: 1
-            border.color: Style.colors.chipBorder
+            border.color: Style.colors.headerButtonBorder
         }
 
         BusyIndicator {
@@ -195,6 +203,10 @@ RowLayout {
 
     IconButton {
         id: fetchBtnHeader
+        backgroundColor: Style.colors.headerButtonBackground
+        hoverBackgroundColor: Style.colors.headerButtonBackgroundHover
+        borderColor: Style.colors.headerButtonBorder
+        borderWidth: 1
         Layout.preferredHeight: 26
 
         topPadding      : 5
@@ -269,9 +281,9 @@ RowLayout {
         background: Rectangle {
             radius: 5
             color: pushForceBtnHeader.down ? Style.colors.surfaceMuted :
-                   pushForceBtnHeader.hovered ? Style.colors.cardBackground : Style.colors.secondaryBackground
+                   pushForceBtnHeader.hovered ? Style.colors.headerButtonBackgroundHover : Style.colors.headerButtonBackground
             border.width: 1
-            border.color: Style.colors.forcePushBorder
+            border.color: Style.colors.headerButtonBorder
         }
 
         BusyIndicator {

--- a/Qml/View/Components/Pages/PluginsPage/PluginsPageHeader.qml
+++ b/Qml/View/Components/Pages/PluginsPage/PluginsPageHeader.qml
@@ -110,7 +110,9 @@ RowLayout {
             radius: 5
             color: !filterButton.enabled ? Style.colors.primaryBackground :
                    filterButton.down ? Style.colors.surfaceMuted :
-                   filterButton.hovered ? Style.colors.cardBackground : Style.colors.secondaryBackground
+                   filterButton.hovered ? Style.colors.headerButtonBackgroundHover : Style.colors.headerButtonBackground
+            border.width: 1
+            border.color: Style.colors.headerButtonBorder
         }
 
         onClicked: filterOptionsPopup.open()

--- a/Qml/View/Components/Remotes/RemoteView.qml
+++ b/Qml/View/Components/Remotes/RemoteView.qml
@@ -88,6 +88,9 @@ UtilitiesCard {
 
     content: ColumnLayout {
         id: content
+        anchors.fill: parent
+        anchors.leftMargin: Style.dp(10)
+        anchors.rightMargin: Style.dp(10)
         spacing: 6
 
         GuideHoverTrigger {
@@ -197,14 +200,12 @@ UtilitiesCard {
                 spacing: 6
                 clip: true
 
-                delegate: Rectangle {
+                delegate: Item {
 
                     property Remote currentRemote: modelData
 
                     width: listView.width
                     height: Style.dp(35)
-                    color: Style.colors.secondaryBackground
-                    radius: 4
 
                     MouseArea {
                         id: rightClickArea
@@ -233,16 +234,16 @@ UtilitiesCard {
                             ScrollingText {
                                 Layout.fillWidth: true
                                 text: currentRemote.name
-                                color: Style.colors.foreground
+                                color: Style.colors.utilitiesRowText
                                 font.family: Style.fontTypes.inter
-                                font.pixelSize: Style.appFont.smallPt
+                                font.pixelSize: Style.appFont.mediumPt
                             }
                             ScrollingText {
                                 Layout.fillWidth: true
                                 text: currentRemote.url
-                                color: Style.colors.mutedText
+                                color: Style.colors.utilitiesRowSubText
                                 font.family: Style.fontTypes.inter
-                                font.pixelSize: Style.appFont.captionPt
+                                font.pixelSize: Style.appFont.smallPt
                             }
                         }
 
@@ -253,27 +254,29 @@ UtilitiesCard {
                             ActionIconButton {
                                 iconText: Style.icons.download
                                 tooltip: root.isFetching ? "Fetching..." : "Fetch"
-                                textColor: root.isFetching ? Style.colors.accent : Style.colors.mutedText
+                                textColor: root.isFetching ? Style.colors.utilitiesActionIconActive
+                                                           : Style.colors.utilitiesActionIcon
                                 enabled: !root.isFetching
                                 onClicked: content.fetchRemote(currentRemote)
                             }
                             ActionIconButton {
                                 iconText: Style.icons.arrowDown
                                 tooltip: root.isFetching ? "Pulling..." : "Pull"
-                                textColor: root.isFetching ? Style.colors.accent : Style.colors.mutedText
+                                textColor: root.isFetching ? Style.colors.utilitiesActionIconActive
+                                                           : Style.colors.utilitiesActionIcon
                                 enabled: !root.isFetching
                                 onClicked: content.pullRemote(currentRemote)
                             }
                             ActionIconButton {
                                 iconText: Style.icons.edit
                                 tooltip: "Edit"
-                                textColor: Style.colors.mutedText
+                                textColor: Style.colors.utilitiesActionIcon
                                 onClicked: content.editRemote(currentRemote)
                             }
                             ActionIconButton {
                                 iconText: Style.icons.trash
                                 tooltip: "Remove"
-                                textColor: Style.colors.deletededFile
+                                textColor: Style.colors.utilitiesActionIconDanger
                                 onClicked: content.removeRemoteItem(currentRemote)
                             }
                         }
@@ -284,23 +287,12 @@ UtilitiesCard {
             }
         }
 
-        IconButton {
+        DashedButton {
             id: addRemoteBtn
             Layout.fillWidth: true
-            implicitHeight: Style.dp(25)
+            Layout.topMargin: Style.dp(2)
 
-            display: IconButton.TextBesideIcon
-            icon.name: Style.icons.plus
-            icon.width: Style.appFont.smallPt
-            icon.height: Style.appFont.smallPt
-            icon.color: Style.colors.textButton
-            text: "Add New Remote"
-            font.pixelSize: Style.appFont.mediumPt
-
-            background: Rectangle {
-                radius: Style.dp(4)
-                color: enabled ? Style.colors.accent : Style.colors.disabledButton
-            }
+            text: "Add Remote"
 
             onClicked: {
                 openAddEditPopup()
@@ -402,12 +394,13 @@ UtilitiesCard {
 
         function buildRemoteMenu(remoteItem) {
             return [
-                { text: "Copy URL", icon: Style.icons.copy, action: function() { content.copyRemoteUrl(remoteItem) } },
-                { separator: true },
                 { text: "Fetch",  icon: Style.icons.download,  enabled: !root.isFetching, action: function() { content.fetchRemote(remoteItem) } },
                 { text: "Pull",   icon: Style.icons.arrowDown, enabled: !root.isFetching, action: function() { content.pullRemote(remoteItem) } },
+                { separator: true },
                 { text: "Edit",   icon: Style.icons.edit,      action: function() { content.editRemote(remoteItem) } },
-                { text: "Remove", icon: Style.icons.trash,     action: function() { content.removeRemoteItem(remoteItem) } }
+                { text: "Remove", icon: Style.icons.trash, color: Style.colors.contextMenuDanger, action: function() { content.removeRemoteItem(remoteItem) } },
+                { separator: true },
+                { text: "Copy URL", icon: Style.icons.copy, action: function() { content.copyRemoteUrl(remoteItem) } },
             ]
         }
     }

--- a/Qml/View/Components/Tag/TagManagementView.qml
+++ b/Qml/View/Components/Tag/TagManagementView.qml
@@ -81,13 +81,15 @@ UtilitiesCard {
             { text: "Copy Name", icon: Style.icons.copy, action: function() { root.copyTagName(tag) } },
             { text: "Copy Hash", icon: Style.icons.copy, action: function() { root.copyTagHash(tag) } },
             { separator: true },
-            { text: "Delete Tag (Local Only)", icon: Style.icons.trash, action: function() { root.deleteTagLocal(tag) } },
-            { text: "Delete Tag from Remote (Origin)", icon: Style.icons.trash, action: function() { root.deleteTagRemote(tag) } }
+            { text: "Delete Tag (Local Only)", icon: Style.icons.trash, color: Style.colors.contextMenuDanger, action: function() { root.deleteTagLocal(tag) } },
+            { text: "Delete Tag from Remote (Origin)", icon: Style.icons.trash, color: Style.colors.contextMenuDanger, action: function() { root.deleteTagRemote(tag) } }
         ]
     }
 
     content: ColumnLayout {
         anchors.fill: parent
+        anchors.leftMargin: Style.dp(10)
+        anchors.rightMargin: Style.dp(10)
         spacing: 6
 
         GuideHoverTrigger {
@@ -125,16 +127,13 @@ UtilitiesCard {
             id: internalListView
             Layout.fillWidth: true
             Layout.preferredHeight: Math.min(contentHeight, 220)
-            spacing: 6
             clip: true
             model: root.tagListModel
 
-            delegate: Rectangle {
+            delegate: Item {
                 id: tagDelegate
                 width: internalListView.width
-                height: Style.dp(35)
-                radius: 4
-                color: Style.colors.secondaryBackground
+                height: tagRow.implicitHeight + Style.dp(2)
 
                 MouseArea {
                     id: rightClickArea
@@ -150,6 +149,7 @@ UtilitiesCard {
                 }
 
                 RowLayout {
+                    id: tagRow
                     anchors.fill: parent
                     anchors.leftMargin: 8
                     anchors.rightMargin: 6
@@ -160,7 +160,8 @@ UtilitiesCard {
                         text: Style.icons.tag || "#"
                         font.family: Style.fontTypes.font6Pro
                         font.pixelSize: Style.appFont.mediumPt
-                        color: modelData.isAnnotated ? Style.colors.accent : Style.colors.secondaryText
+                        color: modelData.isAnnotated ? Style.colors.utilitiesRowIconAccent
+                                                     : Style.colors.utilitiesRowIcon
                         Layout.alignment: Qt.AlignVCenter
                     }
 
@@ -169,7 +170,7 @@ UtilitiesCard {
                         font.family: Style.fontTypes.inter
                         font.pixelSize: Style.appFont.smallPt
                         font.bold: true
-                        color: Style.colors.foreground
+                        color: Style.colors.utilitiesRowText
 
                         Layout.fillWidth: true
                     }
@@ -179,7 +180,7 @@ UtilitiesCard {
                         text: modelData.commitId.substring(0, 7)
                         font.family: Style.fontTypes.inter
                         font.pixelSize: Style.appFont.captionPt
-                        color: Style.colors.mutedText
+                        color: Style.colors.utilitiesRowMetaText
 
                         elide: Text.ElideRight
                     }
@@ -187,7 +188,7 @@ UtilitiesCard {
                     // 3. Delete Action (Fixed Position)
                     ActionIconButton {
                         iconText: Style.icons.trash
-                        textColor: Style.colors.modifiediedFile
+                        textColor: Style.colors.utilitiesActionIconWarning
                         tooltip: "Delete Tag (Local Only)"
                         Layout.preferredWidth: 24
                         Layout.preferredHeight: 24
@@ -198,7 +199,7 @@ UtilitiesCard {
 
                     ActionIconButton {
                         iconText: Style.icons.trash
-                        textColor: Style.colors.deletededFile
+                        textColor: Style.colors.utilitiesActionIconDanger
                         tooltip: "Delete Tag from Remote (Origin)"
                         Layout.preferredWidth: 24
                         Layout.preferredHeight: 24
@@ -215,30 +216,19 @@ UtilitiesCard {
             Label {
                 anchors.centerIn: parent
                 text: "No tags available"
-                color: Style.colors.secondaryText
+                color: Style.colors.utilitiesEmptyStateText
                 visible: internalListView.count === 0
                 font.pixelSize: Style.appFont.smallPt
             }
         }
 
         // Add Tag Button
-        IconButton {
+        DashedButton {
             id: addTagBtn
             Layout.fillWidth: true
-            implicitHeight: Style.dp(25)
+            Layout.topMargin: Style.dp(2)
 
-            display: IconButton.TextBesideIcon
-            icon.name: Style.icons.plus
-            icon.width: Style.appFont.smallPt
-            icon.height: Style.appFont.smallPt
-            icon.color: Style.colors.textButton
-            text: "Add New Tag"
-            font.pixelSize: Style.appFont.mediumPt
-
-            background: Rectangle {
-                radius: Style.dp(4)
-                color: addTagBtn.enabled ? Style.colors.accent : Style.colors.disabledButton
-            }
+            text: "Add Tag"
 
             onClicked: {
                 if (root.addTagPopup) {

--- a/Qml/View/Components/Utilities/UtilityPanel.qml
+++ b/Qml/View/Components/Utilities/UtilityPanel.qml
@@ -1,0 +1,325 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+import GitEase_Style
+import GitEase_Style_Impl
+import GitEase
+
+/*! ***********************************************************************************************
+ * UtilityPanel
+ * ************************************************************************************************/
+Rectangle {
+    id: root
+
+    /* Property Declarations
+     * ****************************************************************************************/
+    property          bool open: true
+    readonly property real borderWidth: 1
+    readonly property real contentWidth: Style.dp(279)
+    readonly property real expandedWidth: contentWidth + borderWidth
+
+    property BranchController        branchController        : null
+    property RemoteController        remoteController        : null
+    property RepositoryController    repositoryController    : null
+    property CommitController        commitController        : null
+    property StatusController        statusController        : null
+    property StashController         stashController         : null
+    property TagController           tagController           : null
+    property RebaseController        rebaseController        : null
+    property ConflictController      conflictController      : null
+    property BundleController        bundleController        : null
+    property ActivityController      activityController      : null
+    property NotificationController  notificationController  : null
+    property GuideController         guideController         : null
+    property UserAuthenticationPopup userAuthenticationPopup : null
+    property UiSessionPopups         uiSessionPopups         : null
+    property var                     pluginController        : null
+    property real                    animatedWidth           : root.open ? expandedWidth : 0
+
+    /* Object Properties
+     * ****************************************************************************************/
+    visible: animatedWidth > 0
+    clip: true
+    Layout.fillHeight: true
+    Layout.preferredWidth: animatedWidth
+
+    color: Style.colors.utilitiesPanelBackground
+    border.width: 0
+
+    Behavior on animatedWidth {
+        NumberAnimation {
+            duration: 200
+            easing.type: Easing.OutCubic
+        }
+    }
+
+    /* Children
+     * ****************************************************************************************/
+    Rectangle {
+        id: leftBorder
+        anchors.left: parent.left
+        anchors.top: parent.top
+        anchors.bottom: parent.bottom
+        width: root.borderWidth
+        color: Style.colors.utilitiesPanelBorder
+    }
+
+    ColumnLayout {
+        anchors.top: parent.top
+        anchors.bottom: parent.bottom
+        anchors.right: parent.right
+        width: root.contentWidth
+        spacing: 0
+
+        TextField {
+            id: filterField
+            Layout.fillWidth: true
+            Layout.margins: Style.dp(8)
+            Layout.preferredHeight: Style.dp(28)
+            placeholderText: qsTr("Filter...")
+            backgroundColor: Style.colors.utilitiesFilterBackground
+            borderWidth: 1
+            borderColor: Style.colors.utilitiesFilterBorder
+            focusBorderWidth: 1
+            focusBorderColor: Style.colors.utilitiesFilterBorderFocus
+            color: Style.colors.utilitiesFilterText
+            placeholderTextColor: Style.colors.utilitiesFilterPlaceholder
+            font.family: Style.fontTypes.inter
+            font.weight: 400
+            font.pixelSize: Style.appFont.smallPt
+
+            onTextChanged: dockFlow.filterText = text
+        }
+
+        Flickable {
+            id: dockFlick
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+            Layout.leftMargin: Style.dp(1)
+            clip: true
+
+            interactive: !dockFlow.dockHovered
+            flickableDirection: Flickable.VerticalFlick
+            boundsBehavior: Flickable.StopAtBounds
+
+            contentWidth: dockFlow.width
+            contentHeight: dockFlow.implicitHeight
+
+            ScrollBar.vertical: ScrollBar {
+                id: dockScrollBar
+                policy: ScrollBar.AsNeeded
+
+                contentItem: Rectangle {
+                    width:  dockScrollBar.interactive ? Style.dp(4) : Style.dp(2)
+                    height: dockScrollBar.interactive ? Style.dp(4) : Style.dp(2)
+                    radius: Style.dp(2)
+                    opacity: 0
+                    color: dockScrollBar.pressed || dockScrollBar.hovered
+                           ? Style.colors.utilitiesPanelScrollBarHover
+                           : Style.colors.utilitiesPanelScrollBar
+                }
+            }
+
+            Flow {
+                id: dockFlow
+                width: dockFlick.width
+
+                property bool dockHovered: false
+                property string filterText: ""
+
+                function matchesFilter(sectionTitle) {
+                    var needle = dockFlow.filterText.trim().toLowerCase()
+                    if (needle.length === 0)
+                        return true
+                    return sectionTitle.toLowerCase().indexOf(needle) !== -1
+                }
+
+                function scrollBlockingHovered(item) {
+                    return item
+                        && item.visible !== false
+                        && item.hasOwnProperty("pageScrollBlocking")
+                        && item.pageScrollBlocking === true
+                        && item.hasOwnProperty("hovered")
+                        && item.hovered === true
+                }
+
+                function updateDockHovered() {
+                    for (let i = 0; i < children.length; ++i) {
+                        const child = children[i]
+                        if (scrollBlockingHovered(child) || scrollBlockingHovered(child.item)) {
+                            dockFlow.dockHovered = true
+                            return
+                        }
+                    }
+
+                    dockFlow.dockHovered = false
+                }
+
+                function setupPluginDock(item) {
+                    if (!item)
+                        return
+
+                    if (item.hasOwnProperty("pageScrollBlocking")
+                            && item.pageScrollBlocking === true
+                            && item.hoveredChanged)
+                    {
+                        item.hoveredChanged.connect(dockFlow.updateDockHovered)
+                    }
+
+                    updateDockHovered()
+                }
+
+                ImportExportBundleDock {
+                    visible: dockFlow.matchesFilter("Export / Import Project")
+                    branchController: root.branchController
+                    bundleController: root.bundleController
+                    notificationController: root.notificationController
+                    guideController: root.guideController
+                }
+
+                RemoteView {
+                    visible: dockFlow.matchesFilter("Remotes")
+                    remoteController: root.remoteController
+                    repositoryController: root.repositoryController
+                    userAuthenticationPopup: root.userAuthenticationPopup
+                    uiSessionPopups: root.uiSessionPopups
+                    addEditRemotePopup: root.uiSessionPopups ? root.uiSessionPopups.addEditRemotePopup : null
+                    notificationController: root.notificationController
+                    guideController: root.guideController
+
+                    onHoveredChanged: dockFlow.updateDockHovered()
+                }
+
+                BranchManagementView {
+                    id: branchManagementView
+                    visible: dockFlow.matchesFilter("Branch Management")
+                    branchController: root.branchController
+                    addBranchPopup: root.uiSessionPopups ? root.uiSessionPopups.addBranchPopup : null
+                    notificationController: root.notificationController
+                    guideController: root.guideController
+
+                    onHoveredChanged: dockFlow.updateDockHovered()
+                }
+
+                StashManagerDock {
+                    id: stashManagerDock
+                    visible: dockFlow.matchesFilter("Stash Manager")
+                    stashController: root.stashController
+                    commitController: root.commitController
+                    statusController: root.statusController
+                    addStashPopup: root.uiSessionPopups ? root.uiSessionPopups.addStashPopup : null
+                    manageStashPopup: root.uiSessionPopups ? root.uiSessionPopups.manageStashPopup : null
+                    guideController: root.guideController
+
+                    notificationController: root.notificationController
+
+                    onHoveredChanged: dockFlow.updateDockHovered()
+                }
+
+                TagManagementView {
+                    id: tagManagementView
+                    visible: dockFlow.matchesFilter("Tag Management")
+                    tagController: root.tagController
+                    addTagPopup: root.uiSessionPopups ? root.uiSessionPopups.addTagPopup : null
+                    guideController: root.guideController
+                    notificationController: root.notificationController
+
+                    onHoveredChanged: dockFlow.updateDockHovered()
+                }
+
+                RecentActivityDock {
+                    visible: dockFlow.matchesFilter("Recent Activity")
+                    activityController: root.activityController
+                    guideController: root.guideController
+
+                    onHoveredChanged: dockFlow.updateDockHovered()
+                }
+
+                RepositoriesHistoryDock {
+                    visible: dockFlow.matchesFilter("Repositories History")
+                    repositoryController: root.repositoryController
+                    guideController: root.guideController
+
+                    onHoveredChanged: dockFlow.updateDockHovered()
+                }
+
+                RebaseDock {
+                    id: rebaseDock
+                    visible: dockFlow.matchesFilter("Rebase")
+                    branchController        : root.branchController
+                    rebaseController        : root.rebaseController
+                    commitController        : root.commitController
+                    statusController        : root.statusController
+                    notificationController  : root.notificationController
+                    conflictController      : root.conflictController
+                    guideController         : root.guideController
+                }
+
+                // ── Plugin docks ─────────────────────────────────────────────────
+                Repeater {
+                    model: root.pluginController?.pluginManager?.registeredDocks ?? []
+
+                    delegate: Loader {
+                        width:  root.contentWidth
+                        height: 390
+                        visible: dockFlow.matchesFilter(modelData.title ?? "")
+
+                        source: modelData.url
+
+                        onLoaded: {
+                            if (!item)
+                                return
+
+                            if (item.hasOwnProperty("pluginManager"))
+                                item.pluginManager = Qt.binding(function() { return root.pluginController?.pluginManager })
+                            if (item.hasOwnProperty("pluginId"))
+                                item.pluginId = modelData.id
+                            if (item.hasOwnProperty("repositoryController"))
+                                item.repositoryController = Qt.binding(function() { return root.repositoryController })
+                            if (item.hasOwnProperty("branchController"))
+                                item.branchController = Qt.binding(function() { return root.branchController })
+                            if (item.hasOwnProperty("remoteController"))
+                                item.remoteController = Qt.binding(function() { return root.remoteController })
+                            if (item.hasOwnProperty("userAuthenticationPopup"))
+                                item.userAuthenticationPopup = Qt.binding(function() { return root.userAuthenticationPopup })
+                            if (item.hasOwnProperty("uiSessionPopups"))
+                                item.uiSessionPopups = Qt.binding(function() { return root.uiSessionPopups })
+                            if (item.hasOwnProperty("notificationController"))
+                                item.notificationController = Qt.binding(function() { return root.notificationController })
+                            if (item.hasOwnProperty("guideController"))
+                                item.guideController = Qt.binding(function() { return root.guideController })
+                            if (item.hasOwnProperty("commitController"))
+                                item.commitController = Qt.binding(function() { return root.commitController })
+                            if (item.hasOwnProperty("statusController"))
+                                item.statusController = Qt.binding(function() { return root.statusController })
+                            if (item.hasOwnProperty("stashController"))
+                                item.stashController = Qt.binding(function() { return root.stashController })
+                            if (item.hasOwnProperty("tagController"))
+                                item.tagController = Qt.binding(function() { return root.tagController })
+                            if (item.hasOwnProperty("eventBus"))
+                                item.eventBus = Qt.binding(function() { return root.pluginController?.pluginManager })
+
+                            dockFlow.setupPluginDock(item)
+                        }
+
+                        onStatusChanged: {
+                            if (status === Loader.Error)
+                                console.error("[UtilityPanel] Failed to load plugin dock:", source)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /* Functions
+     * ****************************************************************************************/
+    //! Re-reads every dock that caches repository state.
+    function reload() {
+        branchManagementView.update()
+        stashManagerDock.updateStashes()
+        tagManagementView.update()
+        rebaseDock.refreshBranches()
+    }
+}

--- a/Qml/View/Header.qml
+++ b/Qml/View/Header.qml
@@ -22,6 +22,11 @@ Item {
 
     /* Children
      * ****************************************************************************************/
+    Rectangle {
+        anchors.fill: parent
+        color: Style.colors.headerBackground
+    }
+
     MouseArea {
         id: dragArea
         anchors.fill: parent

--- a/Qml/View/MainWindow.qml
+++ b/Qml/View/MainWindow.qml
@@ -151,7 +151,7 @@ Rectangle {
                     right: parent.right
                     top: parent.top
                     bottom: parent.bottom
-                    margins: 4
+                    margins: 0
                 }
                 width: parent.width - navigationRail.collapsedWidth - (anchors.leftMargin + anchors.rightMargin)
                 orientation: Qt.Vertical

--- a/Resources.cmake
+++ b/Resources.cmake
@@ -73,6 +73,7 @@ set(RESOURCES_COMPONENTS
     Qml/View/Components/Base/EmptyStateView.qml                # Items Empty State View
     Qml/View/Components/Base/BusyWaiter.qml                    # Items Busy Wait State View
     Qml/View/Components/Base/UtilitiesCard.qml
+    Qml/View/Components/Base/DashedButton.qml                  # Dashed ghost action button for utilities cards
     Qml/View/Components/Base/ContextMenu.qml
     Qml/View/Components/Base/AccentCard.qml                    # Card with accent peeking out on the left
     Qml/View/Components/Base/DetachablePanel.qml               # Detachable panel wrapper
@@ -136,6 +137,8 @@ set(RESOURCES_COMPONENTS
     Qml/View/Components/Docks/RebaseDock.qml
 
     Qml/View/Components/Docks/RepositoriesHistoryDock.qml       # All Repositories Dock
+
+    Qml/View/Components/Utilities/UtilityPanel.qml              # Filter field + scrolling dock flow
 
     # File list components (commit UI)
     Qml/View/Components/FileLists/UnstagedFileListSection.qml  # Unstaged File Status Section


### PR DESCRIPTION
## Utilities panel: own component, own palette

The right-hand utilities panel lived inline in `GraphViewPage.qml` and coloured
itself from whatever generic token happened to be close (`primaryBackground`,
`secondaryBackground`, `mutedText`, `deletededFile`). This PR pulls the panel out
into its own component and gives every element in it a name in the palette, for
both themes.

### Panel

- New `Qml/View/Components/Utilities/UtilityPanel.qml` — filter field over a
  scrolling flow of `UtilitiesCard` docks (plus plugin-registered docks), with the
  animated collapse. `GraphViewPage.qml` drops ~245 lines and just supplies the
  controllers.
- New `Qml/View/Components/Base/DashedButton.qml` — the dashed ghost action
  (Add branch / Add stash / Start rebase / Clear history), with a danger variant.
- Branch Management now pins the checked-out branch to the first row; the rest keep
  git's order.

### Supporting changes

- `ContextMenu`: optional per-item `color` / `iconColor` for destructive entries.
- `RepositoryListItem`, `IconButton`: overridable color properties, defaults unchanged
  so existing call sites are unaffected.
- `Header`, `GraphViewHeader`, `PluginsPageHeader`: use the header chrome tokens
  (background, hover, border); `GraphViewHeader` gains a "Commit Graph" label and
  divider. `PagesRail` font sizes move to `Style.appFont`. New `globe` icon.

### Testing

verified by review only, so the panel needs a visual pass in both
themes before merge. Worth checking specifically: the card header now paints its own
background instead of being transparent, branch-row selection uses the accent tint
instead of the previous blue wash, and the panel scroll bar handle is re-skinned