### PR TITLE
531 fix fetch pull push in committing page

### DIFF
--- a/Qml/Pages/CommittingPage.qml
+++ b/Qml/Pages/CommittingPage.qml
@@ -64,6 +64,10 @@ Page {
         notificationController: root.notificationController
         remoteController: root.remoteController
         guideController: root.guideController
+
+        onPullRequested: root.pullAndUpdate()
+        onPushRequested: function(force) { root.pushAndUpdate(force) }
+        onFetchRequested: root.fetch()
     }
 
     onStatusControllerChanged: {

--- a/Qml/View/Components/Pages/CommittingPage/CommittingPageHeader.qml
+++ b/Qml/View/Components/Pages/CommittingPage/CommittingPageHeader.qml
@@ -29,6 +29,9 @@ RowLayout {
 
     /* Signals
      * ****************************************************************************************/
+    signal pullRequested()
+    signal pushRequested(bool force)
+    signal fetchRequested()
 
     /* Children
      * ****************************************************************************************/
@@ -130,7 +133,7 @@ RowLayout {
             border.color: Style.colors.chipBorder
         }
 
-        onClicked: root.pullAndUpdate()
+        onClicked: headerRow.pullRequested()
 
         MouseArea {
             acceptedButtons: Qt.NoButton
@@ -187,7 +190,7 @@ RowLayout {
         }
 
         onClicked: {
-            root.pushAndUpdate()
+            headerRow.pushRequested(false)
         }
 
         MouseArea {
@@ -239,7 +242,7 @@ RowLayout {
             border.color: Style.colors.chipBorder
         }
 
-        onClicked: root.fetch()
+        onClicked: headerRow.fetchRequested()
 
         MouseArea {
             acceptedButtons: Qt.NoButton
@@ -296,7 +299,7 @@ RowLayout {
         }
 
         onClicked: {
-            root.pushAndUpdate(true)
+            headerRow.pushRequested(true)
         }
 
         MouseArea {


### PR DESCRIPTION
## What this PR does

Fixes #531 – the **Pull**, **Push**, **Force Push** and **Fetch** buttons in the Committing Page header.

Before this PR the buttons did nothing.  
Now each button starts the correct remote operation and the file list is refreshed after completion.

## Root Cause

`CommittingPageHeader` called page functions directly on its own `root`:

```qml
onClicked: root.pullAndUpdate()
```

`root` inside the header refers to the header `RowLayout`, not the page.  
The functions `pullAndUpdate()`, `pushAndUpdate()`, etc. exist only on the **CommittingPage**, so the calls silently failed.

## Solution

**1. Refactor the header to emit signals**

Added three signals to `CommittingPageHeader`:

```qml
signal pullRequested()
signal pushRequested(bool force)
signal fetchRequested()
```

Buttons now emit these signals:

- Pull: `headerRow.pullRequested()`
- Push: `headerRow.pushRequested(false)`
- Force Push: `headerRow.pushRequested(true)`
- Fetch: `headerRow.fetchRequested()`

**2. Connect signals in `CommittingPage`**

The `headerContent` instantiation now wires the signals to the page’s remote-operation methods:

```qml
headerContent: CommittingPageHeader {
    // ...
    onPullRequested:  root.pullAndUpdate()
    onPushRequested:  function(force) { root.pushAndUpdate(force) }
    onFetchRequested: root.fetch()
}
```

`pullAndUpdate()`, `pushAndUpdate()` and `fetch()` delegate to the shared `RemoteOperationsSession`, which is now available after the fix in #530.

**3. Refresh file list after operation**

The `pullAndUpdate()` function already called `changesFileLists.updateStatus()` after the pull, so the file list reflects the latest Git state automatically.

## Files changed

| File | What changed |
|------|--------------|
| `Qml/View/Components/Pages/CommittingPage/CommittingPageHeader.qml` | Replaced direct function calls with signal emissions. |
| `Qml/Pages/CommittingPage.qml` | Connected header signals to page’s remote-operation methods. |

No changes to the remote-operation session or other files were necessary (the session was already provided by `UiSession`).