### PR TITLE
530 fix fetch pull push in graph view

### DIFF
--- a/Qml/UiCore/UiSession.qml
+++ b/Qml/UiCore/UiSession.qml
@@ -182,5 +182,14 @@ QtObject {
     // Injected by MainWindow after the SwipeView is ready; forwarded into PluginController
     // so page plugins can add themselves to the navigation rail.
     property var pageController: null
+
+    property RemoteOperationsSession remoteOperationsSession: RemoteOperationsSession {
+        remoteController:        root.remoteController
+        repositoryController:    root.repositoryController
+        branchController:        root.branchController
+        notificationController:  root.notificationController
+        userAuthenticationPopup: root.popups?.userAuthenticationPopup
+        fetchSummaryPopup:       root.popups?.fetchSummaryPopup
+    }
 }
 


### PR DESCRIPTION
## What this PR does

Fixes #530 – the **Fetch**, **Pull**, **Push** and **Force Push** buttons in the Graph View header.

## Root Cause

`GraphViewPage` expected a `RemoteOperationsSession` but `UiSession` never created one.

`MainWindow` already passed it:

```qml
remoteOperationsSession: root.uiSession?.remoteOperationsSession
```

but `UiSession.qml` had **no** `remoteOperationsSession` property, so the page always received `null`.  
All remote-action calls (`root.remoteOperationsSession?.fetch()`, etc.) were silently skipped by the optional chaining.

## Solution

**1. Create the shared session in `UiSession`**

Added a `remoteOperationsSession` property that owns a single `RemoteOperationsSession` instance, wired with all required controllers and popups:

```qml
property RemoteOperationsSession remoteOperationsSession: RemoteOperationsSession {
    remoteController:        root.remoteController
    repositoryController:    root.repositoryController
    branchController:        root.branchController
    notificationController:  root.notificationController
    userAuthenticationPopup: root.popups?.userAuthenticationPopup
    fetchSummaryPopup:       root.popups?.fetchSummaryPopup
}
```

**2. Graph View already communicates correctly via signals**

`GraphViewHeader` emits `pullRequested()`, `pushRequested(force)`, `fetchRequested()`.  
`GraphViewPage` connects those signals to its own `pullAndUpdate()`, `pushAndUpdate()`, `fetch()` methods, which delegate to the session.

**3. Reload the graph after operation**

After a remote operation completes (Pull, Push, Fetch), the graph is reloaded so the user immediately sees new commits or remote-tracking changes.

## Files changed

| File | What changed |
|------|--------------|
| `Qml/UiCore/UiSession.qml` | Added `RemoteOperationsSession` property. |
| `Qml/Pages/GraphViewPage.qml` | No functional change (already correct); depends on the session now existing. |

The header (`GraphViewHeader.qml`) and `MainWindow.qml` were already correctly wired – no changes required.