### PR TITLE
532 reload committing page when returning to the tab

### DIFF
--- a/Qml/Pages/CommittingPage.qml
+++ b/Qml/Pages/CommittingPage.qml
@@ -694,4 +694,8 @@ Page {
             root.notificationController.error("Failed to save changes to the file", "Save Error", 5000)
         }
     }
+
+    function onPageActivated() {
+        changesFileLists.updateStatus()
+    }
 }

--- a/Qml/View/MainWindow.qml
+++ b/Qml/View/MainWindow.qml
@@ -67,9 +67,16 @@ Rectangle {
 
         let current = pageSwipeView.currentItem
         if (current?.onPageChange) {
-            current.onPageChange(accepted => { if (accepted) pageSwipeView.setCurrentIndex(targetIndex) })
+            current.onPageChange(accepted => {
+                if (!accepted)
+                    return
+
+                pageSwipeView.setCurrentIndex(targetIndex)
+                pages[targetIndex]?.onPageActivated?.()
+            })
         } else {
             pageSwipeView.setCurrentIndex(targetIndex)
+            pages[targetIndex]?.onPageActivated?.()
         }
     }
 


### PR DESCRIPTION
## Summary

Fix the Committing Page not refreshing its staged/unstaged file lists when the user returns to the tab after Git state changes elsewhere in the app.  
Closes #532.

## Problem

The Committing Page only refreshed its file lists when the application regained focus (e.g., Alt+Tab) or when the repository changed.  
If the user performed a Git operation elsewhere in the app (like applying or popping a stash from the Graph View) and then navigated back to the Committing Page, the file lists still showed the old state.

## Root Cause

The Committing Page had no reliable hook for internal page activation.  
`SwipeView` keeps pages alive, so `onVisibleChanged` was not consistent.  
The page only refreshed on:

- `Qt.application.stateChanged`
- `repositoryController.currentRepoChanged`
- some explicit operations inside the page

There was no refresh when switching back to the page from another tab.

## Solution

1. **CommittingPage.qml**  
   Added a new function:

   ```qml
   function onPageActivated() {
       changesFileLists.updateStatus()
   }
   ```

   This keeps the refresh responsibility inside the page.

2. **MainWindow.qml**  
   Modified `switchToPageById()` so that after a successful page switch, it calls `onPageActivated()` on the target page:

   ```qml
   pageSwipeView.setCurrentIndex(targetIndex)
   pages[targetIndex]?.onPageActivated?.()
   ```

   This happens both when `onPageChange` is present (after acceptance) and when it is not.


## How to Test

1. Open a repository and go to **Graph View**.
2. Open the **Stash Manager** from Graph View and apply or pop a stash.
3. Navigate to the **Committing Page**.
4. The staged/unstaged lists should immediately reflect the new Git state.
5. Repeat with a pop operation.
6. Switch away and back to Committing Page – lists should refresh each time.
7. Verify that the unsaved‑changes dialog still blocks the page switch when necessary.
8. Verify that file selection and diff behavior remain functional.

## Acceptance Criteria

- Apply a stash from Graph View → Committing Page lists update immediately. ✅
- Pop a stash from Graph View → Committing Page lists update immediately. ✅
- No Alt+Tab required. ✅
- No cross‑page refresh signal required. ✅
- Switching away and back reloads Git status. ✅
- Existing file selection/diff behavior remains functional. ✅