### PR TITLE
fix(conflict-popup): prevent window height growing on each open/close

### DIFF
--- a/Qml/View/Popups/ConflictPopup.qml
+++ b/Qml/View/Popups/ConflictPopup.qml
@@ -153,6 +153,7 @@ Window {
     /* Object Properties
      * ****************************************************************************************/
     modality: Qt.ApplicationModal
+    flags: Qt.Window | Qt.FramelessWindowHint
     color: "transparent"
 
     width: 1100


### PR DESCRIPTION
### fix(conflict-popup): prevent window height growing on each open/close
## Problem
`ConflictPopup`'s height increased by a few pixels every time it was opened and closed.

## Root Cause

The popup window was created without `Qt.FramelessWindowHint`, so Qt assumed that a native window frame existed, including:

- Caption/title bar
- Resize borders

## Fix
Declare the window as frameless directly in QML, ensuring that Qt and Windows agree on the window geometry:
```qml
flags: Qt.Window | Qt.FramelessWindowHint
