### PR TITLE
Ge 553 popups to window

### DIFF
--- a/Qml/View/Components/Docks/CommitGraphDock.qml
+++ b/Qml/View/Components/Docks/CommitGraphDock.qml
@@ -512,6 +512,7 @@ DetachablePanel {
 
     CommitPlanPopup {
         id: commitPlanPopup
+        hostItem: root.activeItem
         statusController: root.statusController
         commitController: root.commitController
         rebaseController: root.rebaseController
@@ -523,6 +524,7 @@ DetachablePanel {
 
     CommitFileBrowserPopup {
         id: commitFileBrowserPopup
+        hostItem: root.activeItem
         gitTreeController       : root.gitTreeController
         repositoryController    : root.repositoryController
         notificationController  : root.notificationController
@@ -1072,7 +1074,7 @@ DetachablePanel {
 
     function executeRebase(commitHash) {
 
-        commitPlanPopup.open()
+        commitPlanPopup.show()
 
         rebaseController.startPreviewRebasePlan("", commitHash, "")
     }

--- a/Qml/View/Components/Docks/RebaseDock.qml
+++ b/Qml/View/Components/Docks/RebaseDock.qml
@@ -211,6 +211,7 @@ UtilitiesCard {
 
     CommitPlanPopup {
         id: commitPlanPopup
+        hostItem: root
         statusController: root.statusController
         commitController: root.commitController
         rebaseController: root.rebaseController
@@ -259,7 +260,7 @@ UtilitiesCard {
 
         var branchValue = currentBranchValue(currentIndexBranchCombo)
 
-        commitPlanPopup.open()
+        commitPlanPopup.show()
 
         rebaseController.startPreviewRebasePlan(onto, upstream, branchValue)
     }

--- a/Qml/View/Components/Docks/StashManagerDock.qml
+++ b/Qml/View/Components/Docks/StashManagerDock.qml
@@ -102,15 +102,17 @@ UtilitiesCard {
 
         Connections {
             target: root.addStashPopup
-            function onAboutToHide() {
-                root.updateStashes()
+            function onVisibleChanged() {
+                if (root.addStashPopup && !root.addStashPopup.visible)
+                    root.updateStashes()
             }
         }
 
         Connections {
             target: root.manageStashPopup
-            function onAboutToHide() {
-                root.updateStashes()
+            function onVisibleChanged() {
+                if (root.manageStashPopup && !root.manageStashPopup.visible)
+                    root.updateStashes()
             }
         }
 
@@ -213,20 +215,22 @@ UtilitiesCard {
         if (!root.addStashPopup)
             return
 
+        root.addStashPopup.hostItem = root
         root.addStashPopup.stashController = root.stashController
         root.addStashPopup.statusController = root.statusController
-        root.addStashPopup.open()
+        root.addStashPopup.show()
     }
 
     function openPreview(stashEntry) {
         if (!root.manageStashPopup)
             return
 
+        root.manageStashPopup.hostItem = root
         root.manageStashPopup.stashController = root.stashController
         root.manageStashPopup.statusController = root.statusController
         root.manageStashPopup.commitController = root.commitController
         root.manageStashPopup.stashEntry = stashEntry
-        root.manageStashPopup.open()
+        root.manageStashPopup.show()
     }
 
     function popStash(stashEntry) {

--- a/Qml/View/Components/Rebase/RebasePlanHeader.qml
+++ b/Qml/View/Components/Rebase/RebasePlanHeader.qml
@@ -9,7 +9,7 @@ import GitEase_Style_Impl
  * RebasePlanHeader
  * Title, what is being rebased onto what, and a tally of the plan by action.
  * ************************************************************************************************/
-ColumnLayout {
+Item {
     id: root
 
     /* Property Declarations
@@ -24,6 +24,8 @@ ColumnLayout {
     /*! TODO(GE-xxx): no backend yet. Hidden until an advisor exists -- flip this on to preview it. */
     property bool   adviseEnabled: false
 
+    property WindowController windowController: null
+
     /* Signals
      * ****************************************************************************************/
     signal closeRequested()
@@ -31,141 +33,156 @@ ColumnLayout {
 
     /* Object Properties
      * ****************************************************************************************/
-    spacing: 4
+    implicitHeight: contentLayout.implicitHeight
+    implicitWidth: contentLayout.implicitWidth
 
     /* Children
      * ****************************************************************************************/
-    RowLayout {
-        Layout.fillWidth: true
-        spacing: 10
+    // Drag-to-move header (buttons on top still receive clicks)
+    MouseArea {
+        anchors.fill: parent
+        acceptedButtons: Qt.LeftButton
+        onPressed: root.windowController?.startSystemMove()
+        onDoubleClicked: root.windowController?.toggleMaxRestore()
+    }
 
-        Text {
+    ColumnLayout {
+        id: contentLayout
+        anchors.fill: parent
+        spacing: 4
+
+        RowLayout {
             Layout.fillWidth: true
-            text: "Interactive Rebase Plan"
-            color: Style.colors.foreground
-            font.family: Style.fontTypes.inter
-            font.weight: Font.DemiBold
-            font.pixelSize: Style.appFont.largePt
-            elide: Text.ElideRight
-        }
+            spacing: 10
 
-        ConflictPillButton {
-            visible: root.adviseEnabled
-            text: "Advise"
-            leadingText: Style.icons.star
-            accentColor: Style.colors.conflictAssistAccent
-            tooltip: "Suggest a plan for these commits"
-            onClicked: root.adviseRequested()
-        }
-
-        // A sized target rather than the bare glyph: a 14px icon is a hard thing to hit.
-        Rectangle {
-            id: closeButton
-
-            Layout.alignment: Qt.AlignVCenter
-            Layout.preferredWidth: Style.dp(26)
-            Layout.preferredHeight: Style.dp(26)
-
-            radius: 4
-            color: closeHover.hovered ? Style.colors.cardBackground : "transparent"
-
-            HoverHandler {
-                id: closeHover
-                cursorShape: Qt.PointingHandCursor
+            Text {
+                Layout.fillWidth: true
+                text: "Interactive Rebase Plan"
+                color: Style.colors.foreground
+                font.family: Style.fontTypes.inter
+                font.weight: Font.DemiBold
+                font.pixelSize: Style.appFont.largePt
+                elide: Text.ElideRight
             }
 
-            TapHandler {
-                gesturePolicy: TapHandler.ReleaseWithinBounds
-                onTapped: root.closeRequested()
+            ConflictPillButton {
+                visible: root.adviseEnabled
+                text: "Advise"
+                leadingText: Style.icons.star
+                accentColor: Style.colors.conflictAssistAccent
+                tooltip: "Suggest a plan for these commits"
+                onClicked: root.adviseRequested()
+            }
+
+            // A sized target rather than the bare glyph: a 14px icon is a hard thing to hit.
+            Rectangle {
+                id: closeButton
+
+                Layout.alignment: Qt.AlignVCenter
+                Layout.preferredWidth: Style.dp(26)
+                Layout.preferredHeight: Style.dp(26)
+
+                radius: 4
+                color: closeHover.hovered ? Style.colors.cardBackground : "transparent"
+
+                HoverHandler {
+                    id: closeHover
+                    cursorShape: Qt.PointingHandCursor
+                }
+
+                TapHandler {
+                    gesturePolicy: TapHandler.ReleaseWithinBounds
+                    onTapped: root.closeRequested()
+                }
+
+                Text {
+                    anchors.centerIn: parent
+                    text: Style.icons.close
+                    color: closeHover.hovered ? Style.colors.foreground : Style.colors.mutedText
+                    font.family: Style.fontTypes.font6Pro
+                    font.styleName: "Solid"
+                    font.pixelSize: Style.appFont.mediumPt
+                }
+            }
+        }
+
+        RowLayout {
+            Layout.fillWidth: true
+            spacing: 6
+            visible: root.branch !== "" || root.ontoRef !== ""
+
+            Text {
+                text: "Rebasing"
+                color: Style.colors.mutedText
+                font.family: Style.fontTypes.inter
+                font.pixelSize: Style.appFont.captionPt
             }
 
             Text {
-                anchors.centerIn: parent
-                text: Style.icons.close
-                color: closeHover.hovered ? Style.colors.foreground : Style.colors.mutedText
-                font.family: Style.fontTypes.font6Pro
-                font.styleName: "Solid"
-                font.pixelSize: Style.appFont.mediumPt
+                Layout.maximumWidth: root.width * 0.5
+                text: root.branch
+                color: Style.colors.accent
+                font.family: Style.fontTypes.jetBrainsMono
+                font.pixelSize: Style.appFont.captionPt
+                elide: Text.ElideMiddle
             }
-        }
-    }
 
-    RowLayout {
-        Layout.fillWidth: true
-        spacing: 6
-        visible: root.branch !== "" || root.ontoRef !== ""
+            Text {
+                visible: root.ontoRef !== ""
+                text: "onto"
+                color: Style.colors.mutedText
+                font.family: Style.fontTypes.inter
+                font.pixelSize: Style.appFont.captionPt
+            }
 
-        Text {
-            text: "Rebasing"
-            color: Style.colors.mutedText
-            font.family: Style.fontTypes.inter
-            font.pixelSize: Style.appFont.captionPt
-        }
+            Text {
+                visible: root.ontoRef !== ""
+                text: root.ontoRef
+                color: Style.colors.foreground
+                font.family: Style.fontTypes.jetBrainsMono
+                font.pixelSize: Style.appFont.captionPt
+                elide: Text.ElideRight
+            }
 
-        Text {
-            Layout.maximumWidth: root.width * 0.5
-            text: root.branch
-            color: Style.colors.accent
-            font.family: Style.fontTypes.jetBrainsMono
-            font.pixelSize: Style.appFont.captionPt
-            elide: Text.ElideMiddle
-        }
-
-        Text {
-            visible: root.ontoRef !== ""
-            text: "onto"
-            color: Style.colors.mutedText
-            font.family: Style.fontTypes.inter
-            font.pixelSize: Style.appFont.captionPt
-        }
-
-        Text {
-            visible: root.ontoRef !== ""
-            text: root.ontoRef
-            color: Style.colors.foreground
-            font.family: Style.fontTypes.jetBrainsMono
-            font.pixelSize: Style.appFont.captionPt
-            elide: Text.ElideRight
-        }
-
-        Item {
-            Layout.fillWidth: true
-        }
-    }
-
-    RowLayout {
-        Layout.fillWidth: true
-        Layout.topMargin: 2
-        spacing: 6
-
-        Text {
-            text: root.commitCount === 1 ? "1 commit" : `${root.commitCount} commits`
-            color: Style.colors.mutedText
-            font.family: Style.fontTypes.inter
-            font.pixelSize: Style.appFont.captionPt
-        }
-
-        Text {
-            visible: root.commitCount > 0
-            text: "·"
-            color: Style.colors.mutedText
-            font.pixelSize: Style.appFont.captionPt
-        }
-
-        Repeater {
-            model: RebaseActions.all
-
-            delegate: RebaseActionBadge {
-                required property string modelData
-
-                action: modelData
-                count: root.actionCounts[modelData] ?? 0
-                visible: count > 0
+            Item {
+                Layout.fillWidth: true
             }
         }
 
-        Item {
+        RowLayout {
             Layout.fillWidth: true
+            Layout.topMargin: 2
+            spacing: 6
+
+            Text {
+                text: root.commitCount === 1 ? "1 commit" : `${root.commitCount} commits`
+                color: Style.colors.mutedText
+                font.family: Style.fontTypes.inter
+                font.pixelSize: Style.appFont.captionPt
+            }
+
+            Text {
+                visible: root.commitCount > 0
+                text: "·"
+                color: Style.colors.mutedText
+                font.pixelSize: Style.appFont.captionPt
+            }
+
+            Repeater {
+                model: RebaseActions.all
+
+                delegate: RebaseActionBadge {
+                    required property string modelData
+
+                    action: modelData
+                    count: root.actionCounts[modelData] ?? 0
+                    visible: count > 0
+                }
+            }
+
+            Item {
+                Layout.fillWidth: true
+            }
         }
     }
 }

--- a/Qml/View/Components/Stash/StashPopupHeader.qml
+++ b/Qml/View/Components/Stash/StashPopupHeader.qml
@@ -21,6 +21,8 @@ Item {
     property string stashRef:   ""
     property string metaText:   ""
 
+    property WindowController windowController: null
+
     /* Signals
      * ****************************************************************************************/
     signal closeRequested()
@@ -31,10 +33,18 @@ Item {
 
     /* Children
      * ****************************************************************************************/
+    // Drag-to-move header (buttons on top still receive clicks)
+    MouseArea {
+        anchors.fill: parent
+        acceptedButtons: Qt.LeftButton
+        onPressed: root.windowController?.startSystemMove()
+        onDoubleClicked: root.windowController?.toggleMaxRestore()
+    }
+
     ColumnLayout {
         id: titleColumn
         anchors.left: parent.left
-        anchors.right: closeButton.left
+        anchors.right: minimizeButton.left
         anchors.verticalCenter: parent.verticalCenter
         anchors.rightMargin: 12
         spacing: 3
@@ -71,6 +81,29 @@ Item {
             font.pixelSize: Style.appFont.captionPt
             elide: Text.ElideRight
         }
+    }
+
+    WindowsButton {
+        id: minimizeButton
+
+        anchors.right: closeButton.left
+        anchors.rightMargin: 6
+        anchors.verticalCenter: parent.verticalCenter
+        width: 22
+        height: 22
+
+        Material.accent: Style.colors.windowsMinimize
+
+        content: Rectangle {
+            anchors.centerIn: parent
+            width: 10
+            height: 2
+            radius: 1
+            color: minimizeButton.containsMouse ? Style.colors.primaryBackground
+                                                 : Style.colors.foreground
+        }
+
+        onClicked: root.windowController?.minimize()
     }
 
     WindowsButton {

--- a/Qml/View/Popups/AddStashPopup.qml
+++ b/Qml/View/Popups/AddStashPopup.qml
@@ -11,7 +11,7 @@ import GitEase_Style_Impl
  * AddStashPopup
  * ************************************************************************************************/
 
-IPopup {
+IWindow {
     id: root
 
     /* Property Declarations
@@ -55,13 +55,30 @@ IPopup {
      * ****************************************************************************************/
     width: 800
     height: 650
-    padding: 0
+    minimumWidth: 560
+    minimumHeight: 440
 
-    onOpened: root.loadFiles()
+    Connections {
+        target: root
+
+        function onVisibleChanged() {
+            if (root.visible)
+                root.loadFiles()
+        }
+    }
+
+    /* Shortcuts
+     * ****************************************************************************************/
+    Shortcut {
+        sequence: "Escape"
+        enabled: root.visible
+        onActivated: root.closePopUp()
+    }
 
     /* Children
      * ****************************************************************************************/
-    contentItem: Rectangle {
+    Rectangle {
+        anchors.fill: parent
         color: Style.colors.primaryBackground
         radius: 6
         clip: true
@@ -78,6 +95,8 @@ IPopup {
                 Layout.leftMargin: 16
                 Layout.rightMargin: 16
                 Layout.topMargin: 6
+
+                windowController: root.windowController
 
                 title:    qsTr("Create Stash")
                 metaText: root.headerMeta

--- a/Qml/View/Popups/CommitFileBrowserPopup.qml
+++ b/Qml/View/Popups/CommitFileBrowserPopup.qml
@@ -12,7 +12,7 @@ import GitEase
  * Browse the full repository file tree at a specific commit (read-only),
  * similar to GitHub's "Browse files" on a commit.
  * ************************************************************************************************/
-IPopup {
+IWindow {
     id: root
 
     /* Property Declarations
@@ -64,15 +64,22 @@ IPopup {
 
     /* Object Properties
      * ****************************************************************************************/
-    width: Math.min(880, parent ? parent.width - 24 : 880)
-    height: Math.min(620, parent ? parent.height - 24 : 620)
-    modal: true
-    closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutside
-
-    onClosed: clear()
+    width: 920
+    height: 660
+    minimumWidth: 640
+    minimumHeight: 480
 
     /* Signals and Connections
      * ****************************************************************************************/
+    Connections {
+        target: root
+
+        function onVisibleChanged() {
+            if (!root.visible)
+                root.clear()
+        }
+    }
+
     Connections {
         target: repositoryController
 
@@ -80,6 +87,14 @@ IPopup {
             root.clear()
             root.closeRequested()
         }
+    }
+
+    /* Shortcuts
+     * ****************************************************************************************/
+    Shortcut {
+        sequence: "Escape"
+        enabled: root.visible
+        onActivated: root.close()
     }
 
     /* Children
@@ -117,7 +132,8 @@ IPopup {
         }
     }
 
-    contentItem: Rectangle {
+    Rectangle {
+        anchors.fill: parent
         color: Style.colors.primaryBackground
         radius: 8
         clip: true
@@ -134,6 +150,14 @@ IPopup {
                 Layout.fillWidth: true
                 Layout.preferredHeight: 36
                 color: Style.colors.secondaryBackground
+
+                // Drag-to-move header (buttons on top still receive clicks)
+                MouseArea {
+                    anchors.fill: parent
+                    acceptedButtons: Qt.LeftButton
+                    onPressed: root.windowController?.startSystemMove()
+                    onDoubleClicked: root.windowController?.toggleMaxRestore()
+                }
 
                 // bottom border
                 Rectangle {
@@ -191,35 +215,35 @@ IPopup {
                             font.pixelSize: Style.appFont.defaultPt
                         }
 
-                        // Close button
-                        ToolButton {
+                        WindowsButton {
                             id: closeButton
-                            Layout.preferredWidth: 22
-                            Layout.preferredHeight: 22
-                            hoverEnabled: true
-
-                            contentItem: Text {
-                                anchors.centerIn: parent
-                                text: Style.icons.close
-                                font.family: Style.fontTypes.font6ProSolid
-                                font.pixelSize: Style.appFont.smallPt
-                                color: parent.hovered ? Style.colors.foreground : Style.colors.mutedText
-                            }
-
-                            background: Rectangle {
-                                radius: 5
-                                color: parent.hovered ? Style.colors.hoverTitle : "transparent"
-                            }
-
                             onClicked: {
                                 root.close()
                                 root.closeRequested()
                             }
+                            Material.accent: Style.colors.windowsClose
+                            content: Item {
+                                anchors.centerIn: parent
+                                width: 10
+                                height: 10
 
-                            MouseArea {
-                                anchors.fill: parent
-                                acceptedButtons: Qt.NoButton
-                                cursorShape: Qt.PointingHandCursor
+                                Rectangle {
+                                    width: 12
+                                    height: 2
+                                    radius: 1
+                                    color: closeButton.containsMouse ? Style.colors.primaryBackground : Style.colors.foreground
+                                    anchors.centerIn: parent
+                                    rotation: 45
+                                }
+
+                                Rectangle {
+                                    width: 12
+                                    height: 2
+                                    radius: 1
+                                    color: closeButton.containsMouse ? Style.colors.primaryBackground : Style.colors.foreground
+                                    anchors.centerIn: parent
+                                    rotation: -45
+                                }
                             }
                         }
                     }
@@ -768,7 +792,7 @@ IPopup {
             root.notificationController.error("Failed to load file tree for commit " + root.commitShortSha,
                                                   "Commit File Browser", 5000)
 
-        root.open()
+        root.show()
     }
 
     // Load the files changed in this commit and mark their ancestor folders

--- a/Qml/View/Popups/CommitPlanPopup.qml
+++ b/Qml/View/Popups/CommitPlanPopup.qml
@@ -11,7 +11,7 @@ import GitEase_Style_Impl
  * Shows a previewable commits todo list with commit file changes and diff view.
  * ************************************************************************************************/
 
-IPopup {
+IWindow {
     id: root
 
     QtObject {
@@ -105,17 +105,22 @@ IPopup {
 
     /* Object Properties
      * ****************************************************************************************/
-    width   : Math.min(1180 , parent ? parent.width - 80    : 1180)
-    height  : Math.min(760  , parent ? parent.height - 80   : 760)
+    width   : 1180
+    height  : 760
+    minimumWidth: 720
+    minimumHeight: 560
 
-    modal           : true
-    closePolicy     : Popup.NoAutoClose
+    Connections {
+        target: root
 
-    onAboutToShow: root.ownsRebase = true
-
-    onClosed: {
-        root.ownsRebase = false
-        resetPopupState()
+        function onVisibleChanged() {
+            if (root.visible)
+                root.ownsRebase = true
+            else {
+                root.ownsRebase = false
+                root.resetPopupState()
+            }
+        }
     }
 
     /* Shortcuts
@@ -168,9 +173,16 @@ IPopup {
         onActivated: root.setAction(root.selectedIndex, RebaseActions.drop)
     }
 
+    Shortcut {
+        sequence: "Escape"
+        enabled: root.visible
+        onActivated: root.cancelPlan()
+    }
+
     /* Children
      * ****************************************************************************************/
-    contentItem: Rectangle {
+    Rectangle {
+        anchors.fill: parent
         color: Style.colors.primaryBackground
         radius: 12
         clip: true
@@ -239,6 +251,8 @@ IPopup {
                 Layout.rightMargin: root.contentInset
                 Layout.topMargin: Style.dp(14)
                 Layout.bottomMargin: Style.dp(12)
+
+                windowController: root.windowController
 
                 branch: root.planData.branch || ""
                 ontoRef: root.planData.onto || root.planData.upstream || ""
@@ -378,7 +392,7 @@ IPopup {
     ConflictPopup {
         id : rebaseConflictPopup
 
-        hostItem: root.hostOverlay
+        hostItem: root.hostItem
         currentOperation: ConflictPopup.OperationType.Rebase
         ontoRef: root.planData.onto || root.planData.upstream || ""
         rebaseController: root.rebaseController

--- a/Qml/View/Popups/IWindow.qml
+++ b/Qml/View/Popups/IWindow.qml
@@ -1,0 +1,65 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Window
+
+import GitEase
+import GitEase_Style
+import GitEase_Style_Impl
+
+/*! ***********************************************************************************************
+ * IWindow
+ * Base component for top-level windows that behave like the app's popups: a frameless window that
+ * opens centered over its host (or the screen), carries its own WindowController so a header can
+ * drag-move / minimize / maximize it. Resize borders come free from WindowController's native helper.
+ * ************************************************************************************************/
+Window {
+    id: root
+
+    /* Property Declarations
+     * ****************************************************************************************/
+    property          Item              hostItem:               null
+    readonly property var               hostWindow:             root.hostItem ? root.hostItem.Window.window : null
+    readonly property WindowController  windowController:       windowController
+    property          bool              _minimumSizeApplied:    false
+
+    /* Object Properties
+     * ****************************************************************************************/
+    modality: Qt.ApplicationModal
+    color: "transparent"
+    flags: Qt.Window | Qt.FramelessWindowHint
+
+    onHostWindowChanged: {
+        if (root.hostWindow && !root.visible)
+            root.transientParent = root.hostWindow
+    }
+
+    onVisibleChanged: {
+        if (!root.visible)
+            return
+
+        if (!root._minimumSizeApplied) {
+            root._minimumSizeApplied = true
+            root.windowController.setMinimumSize(root.minimumWidth, root.minimumHeight)
+        }
+
+        root.windowController.refreshBorderless()
+
+        Qt.callLater(function() {
+            let host = root.hostWindow
+            if (host) {
+                root.x = host.x + Math.round((host.width  - root.width)  / 2)
+                root.y = host.y + Math.round((host.height - root.height) / 2)
+            } else {
+                root.x = Math.round((Screen.width  - root.width)  / 2)
+                root.y = Math.round((Screen.height - root.height) / 2)
+            }
+        })
+    }
+
+    /* Children
+     * ****************************************************************************************/
+    WindowController {
+        id: windowController
+        window: root
+    }
+}

--- a/Qml/View/Popups/IWindow.qml
+++ b/Qml/View/Popups/IWindow.qml
@@ -20,6 +20,7 @@ Window {
     property          Item              hostItem:               null
     readonly property var               hostWindow:             root.hostItem ? root.hostItem.Window.window : null
     readonly property WindowController  windowController:       windowController
+    property          int               animationDuration:      150
     property          bool              _minimumSizeApplied:    false
 
     /* Object Properties
@@ -27,6 +28,15 @@ Window {
     modality: Qt.ApplicationModal
     color: "transparent"
     flags: Qt.Window | Qt.FramelessWindowHint
+
+    // Fade-in on show
+    opacity: 0
+    Behavior on opacity {
+        NumberAnimation {
+            duration: root.animationDuration
+            easing.type: Easing.OutCubic
+        }
+    }
 
     onHostWindowChanged: {
         if (root.hostWindow && !root.visible)
@@ -44,6 +54,9 @@ Window {
 
         root.windowController.refreshBorderless()
 
+        // Fade-in animation
+        root.opacity = 1
+
         Qt.callLater(function() {
             let host = root.hostWindow
             if (host) {
@@ -54,6 +67,17 @@ Window {
                 root.y = Math.round((Screen.height - root.height) / 2)
             }
         })
+    }
+
+    onClosing: (close) => {
+        if (close.accepted && root.opacity > 0) {
+            close.accepted = false
+            root.opacity = 0
+
+            Qt.callLater(function() {
+                root.close()
+            }, root.animationDuration)
+        }
     }
 
     /* Children

--- a/Qml/View/Popups/ManageStashPopup.qml
+++ b/Qml/View/Popups/ManageStashPopup.qml
@@ -11,7 +11,7 @@ import GitEase_Style_Impl
  * ManageStashPopup
  * ************************************************************************************************/
 
-IPopup {
+IWindow {
     id: root
 
     /* Property Declarations
@@ -91,7 +91,8 @@ IPopup {
      * ****************************************************************************************/
     width: 800
     height: 650
-    padding: 0
+    minimumWidth: 560
+    minimumHeight: 440
 
     onStashEntryChanged: {
         if (!root.stashEntry || !root.statusController) {
@@ -116,9 +117,18 @@ IPopup {
         }
     }
 
+    /* Shortcuts
+     * ****************************************************************************************/
+    Shortcut {
+        sequence: "Escape"
+        enabled: root.visible
+        onActivated: root.close()
+    }
+
     /* Children
      * ****************************************************************************************/
-    contentItem: Rectangle {
+    Rectangle {
+        anchors.fill: parent
         color: Style.colors.primaryBackground
         radius: 6
         clip: true
@@ -135,6 +145,8 @@ IPopup {
                 Layout.leftMargin: 16
                 Layout.rightMargin: 16
                 Layout.topMargin: 6
+
+                windowController: root.windowController
 
                 title:    root.headerTitle
                 stashRef: root.stashRef

--- a/Resources.cmake
+++ b/Resources.cmake
@@ -244,6 +244,7 @@ set(RESOURCES_POPUPS
     Qml/View/Popups/ItemSelectorPopup.qml           # Select Item popup
     Qml/View/Popups/SettingsPopup.qml
     Qml/View/Popups/IPopup.qml
+    Qml/View/Popups/IWindow.qml
     Qml/View/Popups/AddEditRemotePopup.qml
     Qml/View/Popups/AddBranchPopup.qml
     Qml/View/Popups/CheckoutBranchSelectorPopup.qml  # Branch picker for double-click checkout

--- a/Src/Utilities/windowsManager/borderlesswindowhelper.cpp
+++ b/Src/Utilities/windowsManager/borderlesswindowhelper.cpp
@@ -171,6 +171,25 @@ void BorderlessWindowHelper::setMinimumSize(const QSize &newSize)
     m_minimumSize = newSize;
 }
 
+void BorderlessWindowHelper::refreshBorderless()
+{
+#ifdef Q_OS_WIN
+    if (!m_window)
+        return;
+
+    HWND hwnd = reinterpret_cast<HWND>(m_window->winId());
+    if (!hwnd)
+        return;
+
+    if (hwnd != m_hwnd)
+        m_hwnd = hwnd;
+
+    applyBorderlessNow();
+
+    ::EnableWindow(m_hwnd, TRUE);
+#endif
+}
+
 #ifdef Q_OS_WIN
 bool BorderlessWindowHelper::minimizePreservingState()
 {
@@ -252,6 +271,13 @@ bool BorderlessWindowHelper::nativeEventFilter(const QByteArray& eventType, void
     case WM_SHOWWINDOW:
     {
         if (msg->wParam) { // becoming visible
+            HWND currentHwnd = m_window ? reinterpret_cast<HWND>(m_window->winId()) : nullptr;
+            if (currentHwnd && currentHwnd != m_hwnd)
+                m_hwnd = currentHwnd;
+
+            if (reinterpret_cast<HWND>(msg->hwnd) != m_hwnd)
+                return false; // not our window
+
             // Reassert styles and framecalc
             ensureWindowStyles();
             ::SetWindowPos(m_hwnd, nullptr, 0,0,0,0,

--- a/Src/Utilities/windowsManager/borderlesswindowhelper.h
+++ b/Src/Utilities/windowsManager/borderlesswindowhelper.h
@@ -24,6 +24,8 @@ public:
     QSize minimumSize() const;
     void setMinimumSize(const QSize &newSize);
 
+    void refreshBorderless();
+
     bool minimizePreservingState();
 
 private:

--- a/Src/Utilities/windowsManager/windowcontroller.hpp
+++ b/Src/Utilities/windowsManager/windowcontroller.hpp
@@ -81,6 +81,13 @@ public:
             m_helper->setMinimumSize(QSize(w,h));
     }
 
+    // Re-assert the native frameless/resizable state after the window is (re)shown;
+    // Windows can recreate the platform window across a show/hide cycle.
+    Q_INVOKABLE void refreshBorderless() {
+        if (m_helper)
+            m_helper->refreshBorderless();
+    }
+
 signals:
     void titleBarHeightChanged();
     void windowChanged();


### PR DESCRIPTION
## Summary

Converts four app popups — `AddStashPopup`, `ManageStashPopup`, `CommitPlanPopup` and
`CommitFileBrowserPopup` — from in-window `Popup` overlays into real, top-level, frameless
**windows** that can be moved (by dragging their header) and resized (native borders),
following the pattern already established by `ConflictPopup`.

A new shared base component, **`IWindow`**, was introduced to keep the Popup-style API
(`open()`/`close()`) callers already use, so the dock call sites stay unchanged in spirit.
It also fixes a Windows-only bug where these windows only worked **the first time** they were
opened: after closing and reopening, they appeared but could no longer be moved or resized.

---

## The "only works the first time" bug

**Symptom (Windows):** each converted window works on its first open; after closing and
reopening it, it appears but can no longer be moved or resized.

**Root cause:** the windows are translucent (`color: "transparent"`) and rely on
`BorderlessWindowHelper` for frameless look, native resize borders (`WM_NCHITTEST`) and
`startSystemMove()` drag. That helper captured the native window handle (`m_hwnd`) once at
construction. On Windows, Qt can **recreate the platform window** across a hide/show cycle,
leaving that captured handle stale, so hit-testing and style re-assertion stopped targeting
the live window. Additionally, the base window shadowed Qt's built-in `Window.minimumWidth` /
`minimumHeight` and lacked the `Qt.FramelessWindowHint` flag that translucent windows require
(per Qt docs, without it translucency "may not be enabled consistently on all platforms").

**Fix (three layers):**
1. `IWindow` sets `flags: Qt.Window | Qt.FramelessWindowHint` so Qt itself manages the
   frameless/translucent state on every show, and uses Qt's built-in min-size properties.
2. `BorderlessWindowHelper::refreshBorderless()` re-syncs the handle from the live window,
   re-applies the frameless/resizable styles + DWM margins, and re-enables the window
   (Windows modality bookkeeping can otherwise leave a re-shown window disabled, blocking
   all drag/resize input).
3. `IWindow` calls `windowController.refreshBorderless()` on every show, and `WM_SHOWWINDOW`
   re-binds the handle so later messages (hit-test, min/max info) target the right window.

---

## Testing

- [ ] Open `AddStashPopup`, drag by header, resize by edges, close, reopen -> still draggable/resizable.
- [ ] Same cycle for `ManageStashPopup`, `CommitPlanPopup`, `CommitFileBrowserPopup`.
- [ ] Windows still open centered over their host dock.
- [ ] Escape / close button still close the windows.
- [ ] `ConflictPopup` (existing window) unaffected.
- [ ] Build and run on Windows (native borderless behavior).