### PR TITLE
Ge 581 canvas issue recent repo hover interaction #581

### DIFF
--- a/Qml/View/Components/Docks/CommitGraphDock.qml
+++ b/Qml/View/Components/Docks/CommitGraphDock.qml
@@ -59,6 +59,9 @@ DetachablePanel {
     property var selectedCommit         : null
     property int lastSelectedIndex      : -1
 
+    property int hoveredIndex           : -1
+    property string hoverSource         : ""   // "canvas" | "list" | "" - who last set hoveredIndex
+
     property string navigationRule  : "Author Email"
     property string filterText      : ""
     property string filterStartDate : ""
@@ -281,6 +284,16 @@ DetachablePanel {
                             graphColumnWidth: root.commitsColGraphWidth
                             branchTagColumnWidth: root.commitsColBranchTagWidth
                             allCommitsHash: root.allCommitsHash
+                            hoveredIndex: root.hoveredIndex
+                            onHoverIndexChanged: function(index) {
+                                if (index >= 0) {
+                                    root.hoverSource = "canvas"
+                                    root.hoveredIndex = index
+                                } else if (root.hoverSource === "canvas") {
+                                    root.hoveredIndex = -1
+                                    root.hoverSource = ""
+                                }
+                            }
                             onInfiniteScroll: root.loadMoreCommits()
                         }
                     }
@@ -328,6 +341,7 @@ DetachablePanel {
                         isHead      : modelData ? modelData.hash === root.headHash  : false
                         isStash     : modelData ? modelData.isStash === true        : false
                         parentRoot  : root.activeItem
+                        hoveredIndex: root.hoveredIndex
 
                         onItemClicked: function(button, modifiers, idx, mouseX, mouseY) {
                             root.handleItemClick(modelData, button, modifiers, idx, mouseX, mouseY)
@@ -339,6 +353,18 @@ DetachablePanel {
 
                         onResetHeadOne: {
                             root.executeResetHead("HEAD~1", ResetController.ResetMode.Mixed)
+                        }
+
+                        onHoverEntered: function(_index) {
+                            root.hoverSource = "list"
+                            root.hoveredIndex = _index
+                        }
+
+                        onHoverExited: function(_index) {
+                            if (root.hoverSource === "list" && root.hoveredIndex === _index) {
+                                root.hoveredIndex = -1
+                                root.hoverSource = ""
+                            }
                         }
                     }
                 }

--- a/Qml/View/Components/Docks/CommitGraphDock.qml
+++ b/Qml/View/Components/Docks/CommitGraphDock.qml
@@ -294,6 +294,13 @@ DetachablePanel {
                                     root.hoverSource = ""
                                 }
                             }
+                            onCommitRightClicked: function(index, mouseX, mouseY) {
+                                var data = root.commits[index]
+                                if (!data)
+                                    return
+                                var pos = graphCanvas.mapToItem(root.activeItem, mouseX, mouseY)
+                                root.handleItemClick(data, Qt.RightButton, 0, index, pos.x, pos.y)
+                            }
                             onInfiniteScroll: root.loadMoreCommits()
                         }
                     }

--- a/Qml/View/Components/GraphView/CommitGraphCanvas.qml
+++ b/Qml/View/Components/GraphView/CommitGraphCanvas.qml
@@ -39,6 +39,7 @@ Item {
      * ****************************************************************************************/
     signal infiniteScroll()
     signal hoverIndexChanged(int index)
+    signal commitRightClicked(int index, real mouseX, real mouseY)
 
     /* Children
      * ****************************************************************************************/
@@ -73,24 +74,11 @@ Item {
             id: hoverArea
             anchors.fill: flick.contentItem
             hoverEnabled: true
-            acceptedButtons: Qt.NoButton
+            acceptedButtons: Qt.RightButton
             z: 1000
 
             onPositionChanged: (mouse) => {
-                var newHoveredIndex = -1;
-                for (var i = 0; i < root.commits.length; i++) {
-                    var commit = root.commits[i];
-                    var pos = root.commitPositions[commit.hash];
-                    if (pos) {
-                        var rowTop = pos.y;
-                        var rowBottom = pos.y + root.commitItemHeight + root.commitItemSpacing * 2;
-                        if (mouse.y >= rowTop && mouse.y < rowBottom) {
-                            newHoveredIndex = i;
-                            break;
-                        }
-                    }
-                }
-
+                var newHoveredIndex = rowIndexAt(mouse.y);
                 if (newHoveredIndex !== root.hoveredIndex)
                     root.hoverIndexChanged(newHoveredIndex);
             }
@@ -98,6 +86,16 @@ Item {
             onExited: {
                 if (root.hoveredIndex !== -1)
                     root.hoverIndexChanged(-1);
+            }
+
+            onClicked: (mouse) => {
+                if (mouse.button !== Qt.RightButton)
+                    return;
+                var idx = rowIndexAt(mouse.y);
+                if (idx < 0)
+                    return;
+                var pos = hoverArea.mapToItem(root, mouse.x, mouse.y);
+                root.commitRightClicked(idx, pos.x, pos.y);
             }
         }
 
@@ -505,6 +503,20 @@ Item {
         if (commitObj && commitObj.isUncommitted) return "#888888"
         if (!commitObj || !commitObj.colorKey) return GraphUtils.getCategoryColor("main")
         return GraphUtils.getCategoryColor(commitObj.colorKey)
+    }
+
+    function rowIndexAt(y) {
+        for (var i = 0; i < root.commits.length; i++) {
+            var commit = root.commits[i];
+            var pos = root.commitPositions[commit.hash];
+            if (pos) {
+                var rowTop = pos.y;
+                var rowBottom = pos.y + root.commitItemHeight + root.commitItemSpacing * 2;
+                if (y >= rowTop && y < rowBottom)
+                    return i;
+            }
+        }
+        return -1;
     }
 
     function requestPaint() {

--- a/Qml/View/Components/GraphView/CommitGraphCanvas.qml
+++ b/Qml/View/Components/GraphView/CommitGraphCanvas.qml
@@ -33,9 +33,12 @@ Item {
     property real   branchTagColumnWidth: 80
     property var    allCommitsHash      : ({})
 
+    property int    hoveredIndex        : -1
+
     /* Signals
      * ****************************************************************************************/
     signal infiniteScroll()
+    signal hoverIndexChanged(int index)
 
     /* Children
      * ****************************************************************************************/
@@ -66,6 +69,38 @@ Item {
             }
         }
 
+        MouseArea {
+            id: hoverArea
+            anchors.fill: flick.contentItem
+            hoverEnabled: true
+            acceptedButtons: Qt.NoButton
+            z: 1000
+
+            onPositionChanged: (mouse) => {
+                var newHoveredIndex = -1;
+                for (var i = 0; i < root.commits.length; i++) {
+                    var commit = root.commits[i];
+                    var pos = root.commitPositions[commit.hash];
+                    if (pos) {
+                        var rowTop = pos.y;
+                        var rowBottom = pos.y + root.commitItemHeight + root.commitItemSpacing * 2;
+                        if (mouse.y >= rowTop && mouse.y < rowBottom) {
+                            newHoveredIndex = i;
+                            break;
+                        }
+                    }
+                }
+
+                if (newHoveredIndex !== root.hoveredIndex)
+                    root.hoverIndexChanged(newHoveredIndex);
+            }
+
+            onExited: {
+                if (root.hoveredIndex !== -1)
+                    root.hoverIndexChanged(-1);
+            }
+        }
+
         // ---------- Canvas (draws the entire DAG) ----------
         Canvas {
             id: graphCanvas
@@ -83,6 +118,7 @@ Item {
                 target: root
                 function onCommitsChanged() { graphCanvas.requestPaint() }
                 function onSelectedHashesChanged() { graphCanvas.requestPaint() }
+                function onHoveredIndexChanged() { graphCanvas.requestPaint() }
             }
 
             onPaint: {
@@ -402,14 +438,23 @@ Item {
 
                     var isSelected = isCommitSelected(commit3.hash);
                     var isHead = commit3.hash === root.headHash;
+                    var isHovered = (root.hoveredIndex >= 0 && k === root.hoveredIndex);
+                    let isUncommitted = commit3.isUncommitted;
 
                     if (isSelected) {
                         ctx.fillStyle = "#6088B2DF";
-                        ctx.fillRect(0, pos3.y, graphCanvas.width, root.commitItemHeight + root.commitItemSpacing*2);
+                    } else if (isUncommitted && isHovered) {
+                        ctx.fillStyle = Qt.rgba(Style.colors.accent.r, Style.colors.accent.g, Style.colors.accent.b, 0.35);
+                    } else if (isHovered) {
+                        ctx.fillStyle = Qt.rgba(Style.colors.accent.r, Style.colors.accent.g, Style.colors.accent.b, 0.15);
+                    } else if (isUncommitted) {
+                        ctx.fillStyle = Qt.rgba(Style.colors.accent.r, Style.colors.accent.g, Style.colors.accent.b, 0.22);
                     } else if (isHead) {
                         ctx.fillStyle = "#40FFA500";
-                        ctx.fillRect(0, pos3.y, graphCanvas.width, root.commitItemHeight + root.commitItemSpacing*2);
                     }
+
+                    if (isUncommitted || isSelected || isHovered || isHead)
+                        ctx.fillRect(0, pos3.y, graphCanvas.width, root.commitItemHeight + root.commitItemSpacing*2);
 
                     ctx.save();
                     ctx.strokeStyle = isSelected ? GraphUtils.darkenColor(branchColor3, 0.2) : GraphUtils.lightenColor(branchColor3, 0.3);

--- a/Qml/View/Components/GraphView/CommitListDelegate.qml
+++ b/Qml/View/Components/GraphView/CommitListDelegate.qml
@@ -29,7 +29,9 @@ Rectangle {
     property bool   isHead          : false
     property bool   isStash         : false
 
-    property bool   isHovered       : mouseArea.containsMouse
+    property int    hoveredIndex    : -1
+
+    property bool   isHovered       : mouseArea.containsMouse || (hoveredIndex >= 0 && index === hoveredIndex)
 
     property Item   parentRoot      : null
 
@@ -38,13 +40,13 @@ Rectangle {
     signal itemClicked(int mouseButton, int mouseModifiers, int _index, real mouseX, real mouseY)
     signal itemDoubleClicked(int mouseButton, int mouseModifiers, var _index)
     signal resetHeadOne()
+    signal hoverEntered(int _index)
+    signal hoverExited(int _index)
 
     /* Object Properties
      * ****************************************************************************************/
     width   : ListView.view ? ListView.view.width : parent.width
     height  : 24 + 4*2
-
-    radius  : (isSelected || isHovered) ? 4 : 0
 
     color: {
         if (!commitData)
@@ -54,12 +56,12 @@ Rectangle {
             return "#6088B2DF";
 
         if (commitData.isUncommitted) {
-            return isHovered ? Qt.darker(Style.colors.hoverTitle, 1.03)
-                             : (Style.colors.secondaryBackground || Style.colors.primaryBackground);
+            return isHovered ? Qt.rgba(Style.colors.accent.r, Style.colors.accent.g, Style.colors.accent.b, 0.35)
+                             : Qt.rgba(Style.colors.accent.r, Style.colors.accent.g, Style.colors.accent.b, 0.22);
         }
 
         if (isHovered)
-            return Style.colors.hoverTitle;
+            return Qt.rgba(Style.colors.accent.r, Style.colors.accent.g, Style.colors.accent.b, 0.15);
 
         if (isHead)
             return "#40FFA500";
@@ -74,6 +76,9 @@ Rectangle {
         anchors.fill: parent
         hoverEnabled: true
         acceptedButtons: Qt.LeftButton | Qt.RightButton
+
+        onEntered: commitItem.hoverEntered(index)
+        onExited: commitItem.hoverExited(index)
 
         onClicked: (mouse) => {
             var pos = parentRoot ? commitItem.mapToItem(parentRoot, mouse.x, mouse.y) : Qt.point(mouse.x, mouse.y)

--- a/Qml/View/Components/Repository/RecentRepositoryRow.qml
+++ b/Qml/View/Components/Repository/RecentRepositoryRow.qml
@@ -32,20 +32,16 @@ Rectangle {
      * ****************************************************************************************/
     implicitHeight: 50
     radius: 8
-    color: root.selected
-           ? Qt.rgba(Style.colors.accent.r, Style.colors.accent.g, Style.colors.accent.b, 0.12)
-           : (rowMouse.containsMouse
-              ? Qt.rgba(Style.colors.foreground.r, Style.colors.foreground.g, Style.colors.foreground.b, 0.04)
-              : Style.colors.secondaryBackground)
+    color: {
+        var accent = Style.colors.accent
+        if (root.selected)
+            return Qt.rgba(accent.r, accent.g, accent.b, rowMouse.containsMouse ? 0.25 : 0.12)
+        if (rowMouse.containsMouse)
+            return Qt.rgba(accent.r, accent.g, accent.b, 0.15)
+        return Style.colors.secondaryBackground
+    }
     border.width: root.selected ? 1 : 0
     border.color: Style.colors.accent
-
-    Behavior on color {
-        ColorAnimation
-        {
-            duration: 120
-        }
-    }
 
     /* Children
      * ****************************************************************************************/


### PR DESCRIPTION
## Summary

Makes the commit **graph canvas** and the **commit list** behave as one hover-aware view: hovering a row in either view highlights the matching row in the other with the same color, right-clicking a commit in the graph opens the exact same context menu as the list, and the recent-repository rows in the Open Repository UI get a correct, accent-tinted hover state.

---

## Bidirectional hover sync (canvas ⇄ list)

**Problem:** hovering a row in the commit list (or in the graph canvas) had no effect on the other view, so the two halves of the commit panel never agreed on which row was hovered.

**Solution — a single source of truth in `CommitGraphDock`:**

- The dock owns `hoveredIndex` (and `hoverSource`, which records whether the canvas or the list last set it) and feeds the same value into both views:
  - `CommitGraphCanvas.hoveredIndex` → the canvas repaints the matching row.
  - Each `CommitListDelegate.hoveredIndex` → the delegate highlights when `index === hoveredIndex`.
- **List → canvas:** the delegate emits `hoverEntered(index)` / `hoverExited(index)`; the dock updates `hoveredIndex`, and the canvas repaints via `onHoveredIndexChanged`.
- **Canvas → list:** a transparent, hover-only `MouseArea` covers the graph content and hit-tests the cursor position against `commitPositions` (via a shared `rowIndexAt(y)` helper). Instead of writing to its bound `hoveredIndex` (which would destroy the binding and never reach the dock), the canvas emits `hoverIndexChanged(index)` upward; the dock is the only writer.
- **Boundary handling:** `hoverSource` ensures a stale exit event from one view can only clear a hover that the *same* view set — so gliding the cursor from the canvas into the list (or back) never lets a late `-1` clobber the newly entered row. Leaving the panel entirely clears the highlight.
---

## Right-click context menu on the graph canvas

**Problem:** the commit list opened the full commit context menu on right-click, but right-clicking a row drawn on the canvas did nothing.

**Solution:** right-clicks on the canvas MouseArea now hit-test the row and emit `commitRightClicked(index, x, y)` (coordinates mapped to the canvas root). The dock maps that position into `activeItem` and funnels it through the existing `handleItemClick(data, Qt.RightButton, …)` path, so the canvas gets — for free — the exact behavior of the list: single-selection when the commit wasn't selected, the full `MenuBuilder` context menu (checkout, cherry-pick, rebase, new branch/tag, push, plugin items, …), and the same no-op on the uncommitted row.

`acceptedButtons: Qt.RightButton` matches the established context-menu idiom used by `BranchesList`, `StashCard`, `RemoteView`, and `TagManagementView`.

---

## Recent-repository row hover fix

**Problem:** hovering a `RecentRepositoryRow` in the Open Repository popup looked wrong and behaved oddly:

1. The hover fill was `foreground` at **4% alpha** — nearly transparent. Because the resting fill is *opaque* gray, the moment the row was hovered the gray disappeared and the translucent fill revealed the white page behind it, making the row **lighten/blend into the background** instead of highlighting (and it was nearly invisible in dark theme).
2. The `selected` branch was checked first, so a selected row gave **no hover feedback at all**.
3. A 120 ms `ColorAnimation` interpolated between the opaque resting gray and the translucent accent fill — animating RGB *and* alpha together produced a visible **"pale, then full"** flash on every hover (the row's alpha dropped, showing the page behind it, before the blue tint saturated).

---

## Testing checklist

- [x] Hover a row in the commit list → the same row highlights in the graph canvas; move the cursor across into the canvas and confirm the highlight follows smoothly (no jump/blink at the boundary).
- [x] Hover a row in the canvas → the matching list row highlights; gliding back into the list keeps the highlight continuous.
- [x] Move the cursor fully out of the commit panel → the highlight clears.
- [x] Right-click several commits in the graph → the menu matches the list's context menu (checkout, cherry-pick, rebase, copy hash, plugin items); right-clicking the uncommitted row is a no-op like the list.
- [x] Drag-scroll / wheel-scroll still works over the graph area.
- [x] In the Open Repository popup (Recents tab), hovering a row now shows an immediate blue tint, not a pale flash; a selected row still responds to hover.